### PR TITLE
[Feature] 배틀 채팅 UI 구현 

### DIFF
--- a/frontend/src/assets/icon/world.svg
+++ b/frontend/src/assets/icon/world.svg
@@ -1,0 +1,12 @@
+<svg width="17" height="17" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.548896" clip-path="url(#clip0_196_1031)">
+<path d="M8.39391 15.3901C12.2574 15.3901 15.3894 12.2581 15.3894 8.39465C15.3894 4.53115 12.2574 1.39917 8.39391 1.39917C4.53042 1.39917 1.39844 4.53115 1.39844 8.39465C1.39844 12.2581 4.53042 15.3901 8.39391 15.3901Z" stroke="white" stroke-width="1.3991" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.39389 1.39917C6.59762 3.28526 5.5957 5.79005 5.5957 8.39465C5.5957 10.9992 6.59762 13.504 8.39389 15.3901C10.1902 13.504 11.1921 10.9992 11.1921 8.39465C11.1921 5.79005 10.1902 3.28526 8.39389 1.39917Z" stroke="white" stroke-width="1.3991" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1.39844 8.39453H15.3894" stroke="white" stroke-width="1.3991" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_196_1031">
+<rect width="16.7891" height="16.7891" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,3 +19,22 @@ body {
 #root {
   min-height: 100vh;
 }
+
+/* Custom scrollbar styles */
+.scrollbar-thin::-webkit-scrollbar {
+  width: 6px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-track {
+  background: #2D2D3F;
+  border-radius: 5px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  background: #FF6900;
+  border-radius: 5px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb:hover {
+  background: #FF8533;
+}

--- a/frontend/src/pages/battlePage/components/chatting/ChatInput.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatInput.tsx
@@ -1,15 +1,39 @@
 import SendIcon from '@/assets/icon/send.svg?react';
+import { useState } from 'react';
 
-export default function ChatInput() {
+interface ChatInputProps {
+  onSend: (message: string) => void;
+}
+
+export default function ChatInput({ onSend }: ChatInputProps) {
+  const [inputValue, setInputValue] = useState('');
+
+  const handleSend = () => {
+    if (inputValue) {
+      onSend(inputValue);
+      // @Todo : 소켓으로 메세지 전송 이벤트 로직 필요.
+      setInputValue('');
+    }
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSend();
+    }
+  };
+
   return (
     <div className="p-4 border-t border-[#2D2D3F]">
       <div className="flex gap-2">
         <input
           type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyPress={handleKeyPress}
           placeholder="메시지를 입력하세요..."
           className="flex-1 bg-[#2D2D3F] border border-[#3D3D4F] rounded-md px-3 py-2.5 text-[13px] text-white placeholder-[#666] focus:outline-none focus:border-[#FF6900]"
         />
-        <button className="p-2.5 rounded-md bg-[#3D3D4F] hover:bg-[#4D4D5F] transition-colors">
+        <button onClick={handleSend} className="p-2.5 rounded-md bg-[#3D3D4F] hover:bg-[#4D4D5F] transition-colors">
           <SendIcon />
         </button>
       </div>

--- a/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
@@ -6,6 +6,7 @@ interface ChatMessageProps {
   content: string;
   timestamp: string;
   showTeamBadge?: boolean;
+  type?: 'normal' | 'objection' | 'rebuttal';
 }
 
 const TEAM_NICKNAME_COLORS = {
@@ -42,7 +43,7 @@ export default function ChatMessage({ user, team, content, timestamp, showTeamBa
         <span className="text-[11px] text-[#666]">{getTimeAgo(timestamp)}</span>
       </div>
       <div className={`flex items-center gap-2 ${isYou ? 'flex-row-reverse' : ''}`}>
-        <div className={`${isYou ? 'bg-[#6B3410]' : 'bg-[#2D2D3F]'} rounded-lg px-3 py-2 max-w-[280px]`}>
+        <div className={`${isYou ? 'bg-[#6B3410]' : 'bg-[#2D2D3F]'}  rounded-lg px-3 py-2 max-w-[280px]`}>
           <p className="text-[13px] text-white">{content}</p>
         </div>
       </div>

--- a/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
@@ -2,7 +2,7 @@ import { getTimeAgo } from '@/utils/getTimeAgo';
 
 interface ChatMessageProps {
   user: string;
-  team: 'A' | 'B' | 'none';
+  team: 'A' | 'B' | 'NONE';
   content: string;
   timestamp: string;
   showTeamBadge?: boolean;
@@ -12,19 +12,19 @@ interface ChatMessageProps {
 const TEAM_NICKNAME_COLORS = {
   A: 'text-[#51A2FF]',
   B: 'text-[#FF5A5F]',
-  none: 'text-[#99A1AF]'
+  NONE: 'text-[#99A1AF]'
 };
 
 const TEAM_BADGE_COLORS = {
   A: 'bg-[#51A2FF]',
   B: 'bg-[#FF5A5F]',
-  none: 'bg-[#99A1AF]'
+  NONE: 'bg-[#99A1AF]'
 };
 
 const TEAM_LABELS = {
   A: 'A팀',
   B: 'B팀',
-  none: '중립'
+  NONE: '중립'
 };
 
 export default function ChatMessage({ user, team, content, timestamp, showTeamBadge = false }: ChatMessageProps) {

--- a/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
@@ -5,6 +5,7 @@ interface ChatMessageProps {
   team: 'A' | 'B' | 'none';
   content: string;
   timestamp: string;
+  showTeamBadge?: boolean;
 }
 
 const TEAM_NICKNAME_COLORS = {
@@ -13,7 +14,19 @@ const TEAM_NICKNAME_COLORS = {
   none: 'text-[#99A1AF]'
 };
 
-export default function ChatMessage({ user, team, content, timestamp }: ChatMessageProps) {
+const TEAM_BADGE_COLORS = {
+  A: 'bg-[#51A2FF]',
+  B: 'bg-[#FF5A5F]',
+  none: 'bg-[#99A1AF]'
+};
+
+const TEAM_LABELS = {
+  A: 'A팀',
+  B: 'B팀',
+  none: '중립'
+};
+
+export default function ChatMessage({ user, team, content, timestamp, showTeamBadge = false }: ChatMessageProps) {
   const nickNameColor = TEAM_NICKNAME_COLORS[team];
   const isYou = user === 'You';
 
@@ -21,6 +34,11 @@ export default function ChatMessage({ user, team, content, timestamp }: ChatMess
     <div className={`flex ${isYou ? 'flex-col items-end' : 'flex-col items-start'} mb-3`}>
       <div className="flex items-center gap-2 mb-1">
         <span className={`text-[13px] font-medium ${nickNameColor}`}>{user}</span>
+        {showTeamBadge && (
+          <span className={`px-1.5 py-0.5 ${TEAM_BADGE_COLORS[team]} rounded text-[10px] font-medium text-white`}>
+            {TEAM_LABELS[team]}
+          </span>
+        )}
         <span className="text-[11px] text-[#666]">{getTimeAgo(timestamp)}</span>
       </div>
       <div className={`flex items-center gap-2 ${isYou ? 'flex-row-reverse' : ''}`}>

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -3,7 +3,7 @@ import ChatMessage from './ChatMessage';
 import PeoplesIcons from '@/assets/icon/peoples.svg?react';
 import MessageIcon from '@/assets/icon/message.svg?react';
 
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
 interface Message {
   id: number;
@@ -52,6 +52,13 @@ interface ChatSectionProps {
 
 export default function ChatSection({ aTeamMemebers, onSendMessage }: ChatSectionProps) {
   const [message, setMessage] = useState<Message[]>(MOCK_MESSAGES);
+  const chatContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (chatContainerRef.current) {
+      chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight;
+    }
+  }, [message]);
 
   const handleSendMessage = (content: string) => {
     const newMessage: Message = {
@@ -61,10 +68,8 @@ export default function ChatSection({ aTeamMemebers, onSendMessage }: ChatSectio
       content,
       timestamp: new Date().toISOString().replace('T', ' ').substring(0, 19)
     };
-    // 낙관적 업데이트: 로컬 상태에 즉시 추가
     setMessage((prev) => [...prev, newMessage]);
 
-    // 부모 컴포넌트로 메시지 전송 (서버 전송용)
     if (onSendMessage) {
       onSendMessage(content);
     }
@@ -88,7 +93,7 @@ export default function ChatSection({ aTeamMemebers, onSendMessage }: ChatSectio
         </span>
       </div>
 
-      <div className=" h-[422px] px-4 py-2">
+      <div ref={chatContainerRef} className=" h-[422px] px-4 py-2 overflow-y-auto">
         {message.map((message) => (
           <ChatMessage
             key={message.id}

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -10,7 +10,7 @@ import { useState, useRef, useEffect, useMemo } from 'react';
 interface Message {
   id: number;
   user: string;
-  team: 'A' | 'B' | 'none';
+  team: 'A' | 'B' | 'NONE';
   content: string;
   timestamp: string;
   type?: 'normal' | 'objection' | 'rebuttal';
@@ -71,7 +71,7 @@ const MOCK_ALL_MESSAGES: Message[] = [
   {
     id: 3,
     user: 'Observer',
-    team: 'none',
+    team: 'NONE',
     content: '둘 다 장단점이 있네요',
     timestamp: '2025-12-16 21:31:30',
     type: 'normal'
@@ -81,13 +81,13 @@ const MOCK_ALL_MESSAGES: Message[] = [
 interface ChatSectionProps {
   aTeamMemebers: number;
   onSendMessage?: (content: string) => void;
-  team: 'A' | 'B' | 'none';
+  team: 'A' | 'B' | 'NONE';
 }
 
 export default function ChatSection({ aTeamMemebers, onSendMessage, team }: ChatSectionProps) {
   const [teamMessages, setTeamMessages] = useState<Message[]>(MOCK_TEAM_MESSAGES);
   const [allMessages, setAllMessages] = useState<Message[]>(MOCK_ALL_MESSAGES);
-  const [activeTab, setActiveTab] = useState<'team' | 'all'>(team === 'none' ? 'all' : 'team');
+  const [activeTab, setActiveTab] = useState<'team' | 'all'>(team === 'NONE' ? 'all' : 'team');
   const chatContainerRef = useRef<HTMLDivElement>(null);
 
   const currentMessages = useMemo(() => {

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -81,13 +81,13 @@ const MOCK_ALL_MESSAGES: Message[] = [
 interface ChatSectionProps {
   aTeamMemebers: number;
   onSendMessage?: (content: string) => void;
-  team: 'A' | 'B';
+  team: 'A' | 'B' | 'none';
 }
 
 export default function ChatSection({ aTeamMemebers, onSendMessage, team }: ChatSectionProps) {
   const [teamMessages, setTeamMessages] = useState<Message[]>(MOCK_TEAM_MESSAGES);
   const [allMessages, setAllMessages] = useState<Message[]>(MOCK_ALL_MESSAGES);
-  const [activeTab, setActiveTab] = useState<'team' | 'all'>('team');
+  const [activeTab, setActiveTab] = useState<'team' | 'all'>(team === 'none' ? 'all' : 'team');
   const chatContainerRef = useRef<HTMLDivElement>(null);
 
   const currentMessages = useMemo(() => {

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -93,7 +93,7 @@ export default function ChatSection({ aTeamMemebers, onSendMessage }: ChatSectio
         </span>
       </div>
 
-      <div ref={chatContainerRef} className=" h-[422px] px-4 py-2 overflow-y-auto">
+      <div ref={chatContainerRef} className="h-[422px] px-4 py-2 overflow-y-auto scrollbar-thin">
         {message.map((message) => (
           <ChatMessage
             key={message.id}

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -3,6 +3,8 @@ import ChatMessage from './ChatMessage';
 import PeoplesIcons from '@/assets/icon/peoples.svg?react';
 import MessageIcon from '@/assets/icon/message.svg?react';
 
+import { useState } from 'react';
+
 interface Message {
   id: number;
   user: string;
@@ -45,9 +47,33 @@ const MOCK_MESSAGES: Message[] = [
 
 interface ChatSectionProps {
   aTeamMemebers: number;
+  onSendMessage?: (content: string) => void;
 }
 
-export default function ChatSection({ aTeamMemebers }: ChatSectionProps) {
+export default function ChatSection({ aTeamMemebers, onSendMessage }: ChatSectionProps) {
+  const [message, setMessage] = useState<Message[]>(MOCK_MESSAGES);
+
+  const handleSendMessage = (content: string) => {
+    const newMessage: Message = {
+      id: message.length + 1,
+      user: 'You',
+      team: 'A',
+      content,
+      timestamp: new Date().toISOString().replace('T', ' ').substring(0, 19)
+    };
+    // 낙관적 업데이트: 로컬 상태에 즉시 추가
+    setMessage((prev) => [...prev, newMessage]);
+
+    // 부모 컴포넌트로 메시지 전송 (서버 전송용)
+    if (onSendMessage) {
+      onSendMessage(content);
+    }
+  };
+
+  /*Todo 채팅 소켓 구동 이벤트로직 필요.
+    setMessage()
+  */
+
   return (
     <section className="w-[500px] flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden">
       <div className="flex items-center justify-between px-4 py-3 border-b border-[#2D2D3F]">
@@ -63,7 +89,7 @@ export default function ChatSection({ aTeamMemebers }: ChatSectionProps) {
       </div>
 
       <div className=" h-[422px] px-4 py-2">
-        {MOCK_MESSAGES.map((message) => (
+        {message.map((message) => (
           <ChatMessage
             key={message.id}
             user={message.user}
@@ -73,7 +99,7 @@ export default function ChatSection({ aTeamMemebers }: ChatSectionProps) {
           />
         ))}
       </div>
-      <ChatInput />
+      <ChatInput onSend={handleSendMessage} />
     </section>
   );
 }

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -4,7 +4,7 @@ import ChatTabs from './ChatTabs';
 import PeoplesIcons from '@/assets/icon/peoples.svg?react';
 import MessageIcon from '@/assets/icon/message.svg?react';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 
 interface Message {
   id: number;
@@ -15,7 +15,7 @@ interface Message {
   isObjection?: boolean;
 }
 
-const MOCK_MESSAGES: Message[] = [
+const MOCK_TEAM_MESSAGES: Message[] = [
   {
     id: 1,
     user: 'CodeMaster',
@@ -46,6 +46,30 @@ const MOCK_MESSAGES: Message[] = [
   }
 ];
 
+const MOCK_ALL_MESSAGES: Message[] = [
+  {
+    id: 1,
+    user: 'PlayerB',
+    team: 'B',
+    content: 'B팀도 나쁘지 않은데요?',
+    timestamp: '2025-12-16 21:30:30'
+  },
+  {
+    id: 2,
+    user: 'CodeMaster',
+    team: 'A',
+    content: 'A팀이 더 나은 것 같습니다',
+    timestamp: '2025-12-16 21:31:00'
+  },
+  {
+    id: 3,
+    user: 'Observer',
+    team: 'none',
+    content: '둘 다 장단점이 있네요',
+    timestamp: '2025-12-16 21:31:30'
+  }
+];
+
 interface ChatSectionProps {
   aTeamMemebers: number;
   onSendMessage?: (content: string) => void;
@@ -53,25 +77,35 @@ interface ChatSectionProps {
 }
 
 export default function ChatSection({ aTeamMemebers, onSendMessage, team }: ChatSectionProps) {
-  const [message, setMessage] = useState<Message[]>(MOCK_MESSAGES);
+  const [teamMessages, setTeamMessages] = useState<Message[]>(MOCK_TEAM_MESSAGES);
+  const [allMessages, setAllMessages] = useState<Message[]>(MOCK_ALL_MESSAGES);
   const [activeTab, setActiveTab] = useState<'team' | 'all'>('team');
   const chatContainerRef = useRef<HTMLDivElement>(null);
+
+  const currentMessages = useMemo(() => {
+    return activeTab === 'team' ? teamMessages : allMessages;
+  }, [activeTab, teamMessages, allMessages]);
 
   useEffect(() => {
     if (chatContainerRef.current) {
       chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight;
     }
-  }, [message]);
+  }, [currentMessages]);
 
   const handleSendMessage = (content: string) => {
     const newMessage: Message = {
-      id: message.length + 1,
+      id: currentMessages.length + 1,
       user: 'You',
-      team: 'A',
+      team: team,
       content,
       timestamp: new Date().toISOString().replace('T', ' ').substring(0, 19)
     };
-    setMessage((prev) => [...prev, newMessage]);
+
+    if (activeTab === 'team') {
+      setTeamMessages((prev) => [...prev, newMessage]);
+    } else {
+      setAllMessages((prev) => [...prev, newMessage]);
+    }
 
     if (onSendMessage) {
       onSendMessage(content);
@@ -79,7 +113,7 @@ export default function ChatSection({ aTeamMemebers, onSendMessage, team }: Chat
   };
 
   /*Todo 채팅 소켓 구동 이벤트로직 필요.
-    setMessage()
+    setTeamMessages() / setAllMessages()
   */
 
   return (
@@ -100,13 +134,14 @@ export default function ChatSection({ aTeamMemebers, onSendMessage, team }: Chat
       </div>
 
       <div ref={chatContainerRef} className="h-[422px] px-4 py-2 overflow-y-auto scrollbar-thin">
-        {message.map((message) => (
+        {currentMessages.map((message) => (
           <ChatMessage
             key={message.id}
             user={message.user}
             team={message.team}
             content={message.content}
             timestamp={message.timestamp}
+            showTeamBadge={activeTab === 'all'}
           />
         ))}
       </div>

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -1,5 +1,6 @@
 import ChatInput from './ChatInput';
 import ChatMessage from './ChatMessage';
+import ObjectionMessage from './ObjectionMessage';
 import ChatTabs from './ChatTabs';
 import PeoplesIcons from '@/assets/icon/peoples.svg?react';
 import MessageIcon from '@/assets/icon/message.svg?react';
@@ -12,7 +13,7 @@ interface Message {
   team: 'A' | 'B' | 'none';
   content: string;
   timestamp: string;
-  isObjection?: boolean;
+  type?: 'normal' | 'objection' | 'rebuttal';
 }
 
 const MOCK_TEAM_MESSAGES: Message[] = [
@@ -21,28 +22,32 @@ const MOCK_TEAM_MESSAGES: Message[] = [
     user: 'CodeMaster',
     team: 'A',
     content: '구현스가 Set을 사용해서 더 간결하네요',
-    timestamp: '2025-12-16 21:30:00'
+    timestamp: '2025-12-16 21:30:00',
+    type: 'normal'
   },
   {
     id: 2,
     user: 'JSLover',
     team: 'A',
     content: 'Set 사용이 훨씬 직관적인 것 같은데요',
-    timestamp: '2025-12-16 21:31:00'
+    timestamp: '2025-12-16 21:31:00',
+    type: 'normal'
   },
   {
     id: 3,
     user: 'You',
     team: 'A',
     content: '코드가 구려요',
-    timestamp: '2025-12-16 21:32:00'
+    timestamp: '2025-12-16 21:32:00',
+    type: 'objection'
   },
   {
     id: 4,
     user: 'You',
     team: 'A',
     content: '별론데요',
-    timestamp: '2025-12-16 21:32:30'
+    timestamp: '2025-12-16 21:32:30',
+    type: 'normal'
   }
 ];
 
@@ -52,21 +57,24 @@ const MOCK_ALL_MESSAGES: Message[] = [
     user: 'PlayerB',
     team: 'B',
     content: 'B팀도 나쁘지 않은데요?',
-    timestamp: '2025-12-16 21:30:30'
+    timestamp: '2025-12-16 21:30:30',
+    type: 'objection'
   },
   {
     id: 2,
     user: 'CodeMaster',
     team: 'A',
     content: 'A팀이 더 나은 것 같습니다',
-    timestamp: '2025-12-16 21:31:00'
+    timestamp: '2025-12-16 21:31:00',
+    type: 'rebuttal'
   },
   {
     id: 3,
     user: 'Observer',
     team: 'none',
     content: '둘 다 장단점이 있네요',
-    timestamp: '2025-12-16 21:31:30'
+    timestamp: '2025-12-16 21:31:30',
+    type: 'normal'
   }
 ];
 
@@ -98,7 +106,8 @@ export default function ChatSection({ aTeamMemebers, onSendMessage, team }: Chat
       user: 'You',
       team: team,
       content,
-      timestamp: new Date().toISOString().replace('T', ' ').substring(0, 19)
+      timestamp: new Date().toISOString().replace('T', ' ').substring(0, 19),
+      type: 'normal'
     };
 
     if (activeTab === 'team') {
@@ -134,16 +143,26 @@ export default function ChatSection({ aTeamMemebers, onSendMessage, team }: Chat
       </div>
 
       <div ref={chatContainerRef} className="h-[422px] px-4 py-2 overflow-y-auto scrollbar-thin">
-        {currentMessages.map((message) => (
-          <ChatMessage
-            key={message.id}
-            user={message.user}
-            team={message.team}
-            content={message.content}
-            timestamp={message.timestamp}
-            showTeamBadge={activeTab === 'all'}
-          />
-        ))}
+        {currentMessages.map((message) =>
+          message.type === 'objection' || message.type === 'rebuttal' ? (
+            <ObjectionMessage
+              key={message.id}
+              team={message.team}
+              content={message.content}
+              timestamp={message.timestamp}
+              type={message.type}
+            />
+          ) : (
+            <ChatMessage
+              key={message.id}
+              user={message.user}
+              team={message.team}
+              content={message.content}
+              timestamp={message.timestamp}
+              showTeamBadge={activeTab === 'all'}
+            />
+          )
+        )}
       </div>
       <ChatInput onSend={handleSendMessage} />
     </section>

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -1,5 +1,6 @@
 import ChatInput from './ChatInput';
 import ChatMessage from './ChatMessage';
+import ChatTabs from './ChatTabs';
 import PeoplesIcons from '@/assets/icon/peoples.svg?react';
 import MessageIcon from '@/assets/icon/message.svg?react';
 
@@ -48,10 +49,12 @@ const MOCK_MESSAGES: Message[] = [
 interface ChatSectionProps {
   aTeamMemebers: number;
   onSendMessage?: (content: string) => void;
+  team: 'A' | 'B';
 }
 
-export default function ChatSection({ aTeamMemebers, onSendMessage }: ChatSectionProps) {
+export default function ChatSection({ aTeamMemebers, onSendMessage, team }: ChatSectionProps) {
   const [message, setMessage] = useState<Message[]>(MOCK_MESSAGES);
+  const [activeTab, setActiveTab] = useState<'team' | 'all'>('team');
   const chatContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -81,16 +84,19 @@ export default function ChatSection({ aTeamMemebers, onSendMessage }: ChatSectio
 
   return (
     <section className="w-[500px] flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-[#2D2D3F]">
-        <div className="flex items-center gap-2">
-          <MessageIcon />
-          <h3 className="text-[14px] font-medium text-white">A팀 라운지</h3>
-          <span className="px-2 py-0.5 bg-[#51A2FF] rounded text-[11px] font-medium text-white">A팀</span>
+      <div className="px-4 pt-3 pb-2 border-b border-[#2D2D3F]">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <MessageIcon />
+            <h3 className="text-[14px] font-medium text-white">라운지</h3>
+          </div>
+          <span className="text-[12px] text-[#99A1AF] flex items-center gap-1">
+            <PeoplesIcons />
+            {aTeamMemebers}
+          </span>
         </div>
-        <span className="text-[12px] text-[#99A1AF] flex items-center gap-1">
-          <PeoplesIcons />
-          {aTeamMemebers}
-        </span>
+
+        <ChatTabs activeTab={activeTab} onTabChange={setActiveTab} team={team} />
       </div>
 
       <div ref={chatContainerRef} className="h-[422px] px-4 py-2 overflow-y-auto scrollbar-thin">

--- a/frontend/src/pages/battlePage/components/chatting/ChatTabs.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatTabs.tsx
@@ -4,11 +4,22 @@ import WordIcon from '@/assets/icon/world.svg?react';
 interface ChatTabsProps {
   activeTab: 'team' | 'all';
   onTabChange: (tab: 'team' | 'all') => void;
-  team: 'A' | 'B';
+  team: 'A' | 'B' | 'none';
 }
 
 export default function ChatTabs({ activeTab, onTabChange, team }: ChatTabsProps) {
-  const teamColor = team === 'A' ? 'bg-blue-600' : 'bg-red-600';
+  const teamColor = team === 'A' ? 'bg-blue-600' : team === 'B' ? 'bg-red-600' : 'bg-gray-600';
+
+  if (team === 'none') {
+    return (
+      <div className="flex-1 py-3 w-full text-[13px] font-medium rounded-t-lg bg-[#FF6900] text-white">
+        <span className="flex items-center justify-center gap-1">
+          <WordIcon className="w-[20px] h-[20px]" />
+          <span className="">전체 라운지</span>
+        </span>
+      </div>
+    );
+  }
 
   return (
     <div className="flex gap-0 bg-[#2D2D3F] rounded-lg p-1">

--- a/frontend/src/pages/battlePage/components/chatting/ChatTabs.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatTabs.tsx
@@ -1,0 +1,39 @@
+import PeopleIcon from '@/assets/icon/peoples.svg?react';
+import WordIcon from '@/assets/icon/world.svg?react';
+
+interface ChatTabsProps {
+  activeTab: 'team' | 'all';
+  onTabChange: (tab: 'team' | 'all') => void;
+  team: 'A' | 'B';
+}
+
+export default function ChatTabs({ activeTab, onTabChange, team }: ChatTabsProps) {
+  const teamColor = team === 'A' ? 'bg-blue-600' : 'bg-red-600';
+
+  return (
+    <div className="flex gap-0 bg-[#2D2D3F] rounded-lg p-1">
+      <button
+        onClick={() => onTabChange('team')}
+        className={`flex-1 py-3 px-3 text-[13px] font-medium rounded-md transition-colors ${
+          activeTab === 'team' ? `${teamColor} text-white` : 'bg-transparent text-[#99A1AF] hover:text-white'
+        }`}
+      >
+        <span className="flex items-center justify-center gap-1">
+          <PeopleIcon className="w-[20px] h-[20px]" />
+          <span className="">팀 라운지</span>
+        </span>
+      </button>
+      <button
+        onClick={() => onTabChange('all')}
+        className={`flex-1 py-3 px-3 text-[13px] font-medium rounded-md transition-colors ${
+          activeTab === 'all' ? 'bg-[#FF6900] text-white' : 'bg-transparent text-[#99A1AF] hover:text-white'
+        }`}
+      >
+        <span className="flex items-center justify-center gap-1">
+          <WordIcon className="w-[20px] h-[20px]" />
+          <span className="">전체 라운지</span>
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/battlePage/components/chatting/ChatTabs.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatTabs.tsx
@@ -4,13 +4,13 @@ import WordIcon from '@/assets/icon/world.svg?react';
 interface ChatTabsProps {
   activeTab: 'team' | 'all';
   onTabChange: (tab: 'team' | 'all') => void;
-  team: 'A' | 'B' | 'none';
+  team: 'A' | 'B' | 'NONE';
 }
 
 export default function ChatTabs({ activeTab, onTabChange, team }: ChatTabsProps) {
   const teamColor = team === 'A' ? 'bg-blue-600' : team === 'B' ? 'bg-red-600' : 'bg-gray-600';
 
-  if (team === 'none') {
+  if (team === 'NONE') {
     return (
       <div className="flex-1 py-3 w-full text-[13px] font-medium rounded-t-lg bg-[#FF6900] text-white">
         <span className="flex items-center justify-center gap-1">

--- a/frontend/src/pages/battlePage/components/chatting/ObjectionMessage.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ObjectionMessage.tsx
@@ -1,0 +1,35 @@
+import { getTimeAgo } from '@/utils/getTimeAgo';
+import BattleIcon from '@/assets/icon/battle.svg?react';
+import ShieldIcon from '@/assets/icon/shield.svg?react';
+
+interface ObjectionMessageProps {
+  team: 'A' | 'B' | 'none';
+  content: string;
+  timestamp: string;
+  type: 'objection' | 'rebuttal';
+}
+
+export default function ObjectionMessage({ team, content, timestamp, type }: ObjectionMessageProps) {
+  return (
+    <div className={`flex justify-end mb-3 w-full shadow-lg `}>
+      <div
+        className={`flex flex-col items-end  rounded-lg px-3 min-w-[300px] max-w-[350px] ${type === 'objection' ? 'bg-red-700' : 'bg-blue-700'} `}
+      >
+        <div className="w-full flex justify-between items-center gap-2 mb-1 text-[15px] mt-1">
+          <div className="flex gap-2">
+            {type === 'objection' ? (
+              <BattleIcon className="w-[24px] h-[24px]" />
+            ) : (
+              <ShieldIcon className="w-[26px] h-[26px]" />
+            )}
+            <span className="font-semibold">
+              {team}팀 {type === 'objection' ? '이의제기' : '반박'}
+            </span>
+          </div>
+          <span className="text-[11px] text-slate-100">{getTimeAgo(timestamp)}</span>
+        </div>
+        <p className="text-[20px] font-bold text-slate-200 mb-3 ml-12 text-start w-full">{content}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/battlePage/components/chatting/ObjectionMessage.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ObjectionMessage.tsx
@@ -3,7 +3,7 @@ import BattleIcon from '@/assets/icon/battle.svg?react';
 import ShieldIcon from '@/assets/icon/shield.svg?react';
 
 interface ObjectionMessageProps {
-  team: 'A' | 'B' | 'none';
+  team: 'A' | 'B' | 'NONE';
   content: string;
   timestamp: string;
   type: 'objection' | 'rebuttal';

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -49,7 +49,7 @@ export default function BattlePage() {
             codeB={battleInfo.bCode}
           />
           <aside className="flex flex-col gap-4">
-            <ChatSection aTeamMemebers={102} team="A" />
+            <ChatSection aTeamMemebers={102} team="none" />
             <section>이의제의 input</section>
             <section>투표</section>
           </aside>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -49,7 +49,7 @@ export default function BattlePage() {
             codeB={battleInfo.bCode}
           />
           <aside className="flex flex-col gap-4">
-            <ChatSection aTeamMemebers={102} />
+            <ChatSection aTeamMemebers={102} team="A" />
             <section>이의제의 input</section>
             <section>투표</section>
           </aside>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -49,7 +49,7 @@ export default function BattlePage() {
             codeB={battleInfo.bCode}
           />
           <aside className="flex flex-col gap-4">
-            <ChatSection aTeamMemebers={102} team="none" />
+            <ChatSection aTeamMemebers={102} team={selectedTeam} />
             <section>이의제의 input</section>
             <section>투표</section>
           </aside>


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #21

## ✅ 작업 내용
### 1. 채팅 메시지 전송 기능 구현
- 채팅 입력 후 전송 기능 구현 (현재 낙관적 업데이트 적용 O / 소켓 통신은 미구현 상태) 
- 전송된 메시지를 라운지별로 상태 관리 (팀 라운지/전체 라운지 분리)
- 전체 라운지에서 A팀/B팀 사용자 구분을 위한 뱃지 표시 적용
- 새 메시지 추가 시 자동으로 스크롤 맨 하단으로 내려주는 기능 구현

### 2. 라운지 채팅 탭 기능
- 팀 라운지 / 전체 라운지 탭 전환 UI 구현 및  탭별 메시지 독립 관리 (팀 라운지와 전체 라운지 메시지 분리)
- 중립 사용자는 전체 라운지만 표시하도록 구현
- 팀 사용자는 중립 라운지와 자신이 속한 라운지 모두 접근 가능 하도록 UI 분기 처리 적용

### 3. 이의제기 & 반박 메시지
- 이의제기와 반박 메시지를 일반 채팅과 구분하여 표시 하도록 적용했습니다.
- 이의제기는 빨간색, 반박은 파란색 배경을 적용했으며, 전용 아이콘(battle/shield) 각각 추가했습니다. 

### 4. 채팅 UI 개선
- 커스텀 스크롤바 디자인 적용

<br />

## 구현 내용 
### 중립 진영 사용자 경우 - 전체 라운지만 보이는 로직 적용한 부분 
<img width="336" height="404" alt="image" src="https://github.com/user-attachments/assets/54d42250-a672-4d63-b168-0ceb8194611d" />

### 특정 팀으로 참여한 경우 - 전체 라운지 / 팀 라운지 탭 보이는 로직 적용한 부분 
<img width="338" height="405" alt="image" src="https://github.com/user-attachments/assets/e1835ae5-9476-4bf6-be2d-8937e80963d4" />

### 스크롤바 디자인 적용한 부분 
<img width="348" height="407" alt="image" src="https://github.com/user-attachments/assets/871d0975-26f4-4536-a2b7-77335143e9c2" />


## 📸 참고 사항
- 채팅 소켓 통신 기능은 아직 미구현 상태으로 MOCK 데이터만 적용 되어있습니다.
- `ChatSection` 컴포넌트에서 `setTeamMessages()` / `setAllMessages()` 소켓 이벤트 로직 추가 필요
- 이의제기, 반박 채팅 메세지 경우 디자인 변경이 느껴졌으나... 현재 프로토타입 완성이 우선임으로 해당 사항은 일단 스킵했습니다. 

<br />
