### PR TITLE
[Feature] 이의제기/반론 투표함 UI 구현

### DIFF
--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -126,7 +126,7 @@ export default function ChatSection({ aTeamMemebers, onSendMessage, team }: Chat
   */
 
   return (
-    <section className="w-[500px] flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden">
+    <section className="w-full flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden">
       <div className="px-4 pt-3 pb-2 border-b border-[#2D2D3F]">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">

--- a/frontend/src/pages/battlePage/components/codeview/CodeSection.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/CodeSection.tsx
@@ -14,7 +14,7 @@ export default function CodeSection({ onViewChange, currentView, codeA, codeB, l
   const [currentTab, setCurrentTab] = useState<'A' | 'B'>('A');
 
   return (
-    <section className="w-[1194px] flex-1 flex flex-col bg-[#1E1E2F]  rounded-lg overflow-hidden">
+    <section className="w-[1194px] h-fit flex-1 flex flex-col bg-[#1E1E2F]  rounded-lg overflow-hidden">
       <CodeHeader
         onViewChange={onViewChange}
         currentView={currentView}

--- a/frontend/src/pages/battlePage/components/codeview/CodeViewer.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/CodeViewer.tsx
@@ -29,7 +29,7 @@ export default function CodeViewer({ team, language, code }: CodeViewerProps) {
         <span className="text-[14px] text-white">{language}</span>
         <span className={`text-[16px] font-bold ${styles.text}`}>구현 {team}</span>
       </div>
-      <div className="p-4 min-h-[380px]">
+      <div className="p-4 min-h-[460px]">
         <pre className="text-[13px] text-[#E0E0E0] font-mono leading-relaxed">
           {lines.map((line, index) => (
             <div key={index} className="flex">

--- a/frontend/src/pages/battlePage/components/objection/ObjectionInput.tsx
+++ b/frontend/src/pages/battlePage/components/objection/ObjectionInput.tsx
@@ -1,13 +1,20 @@
 import BattleIcon from '@/assets/icon/battle.svg?react';
+import ShieldIcon from '@/assets/icon/shield.svg?react';
 import { useState } from 'react';
 
 interface ObjectionInputProps {
   disabled?: boolean;
   onSubmit?: (content: string) => void;
+  phase: 'objection' | 'rebuttal';
 }
 
-export default function ObjectionInput({ disabled = false, onSubmit }: ObjectionInputProps) {
+export default function ObjectionInput({ disabled = false, onSubmit, phase }: ObjectionInputProps) {
   const [inputValue, setInputValue] = useState('');
+
+  const isObjection = phase === 'objection';
+  const placeholderText = isObjection ? '상대 진영에 이의제기...' : '상대 진영에 반론...';
+  const buttonText = isObjection ? '이의제기' : '반론';
+  const Icon = isObjection ? BattleIcon : ShieldIcon;
 
   const handleSubmit = () => {
     if (inputValue.trim() && !disabled) {
@@ -30,16 +37,16 @@ export default function ObjectionInput({ disabled = false, onSubmit }: Objection
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           onKeyPress={handleKeyPress}
-          placeholder="상대 진영에 이의제기..."
+          placeholder={placeholderText}
           autoFocus
           className="w-full bg-[#2D2D3F] border border-[#FF5A5F] rounded-md px-4 py-3 text-[13px] text-white placeholder-[#666] focus:outline-none focus:border-[#FF5A5F]"
         />
         <button
           onClick={handleSubmit}
-          className="w-[140px] px-3 py-2 bg-[#4A5568] text-[13px] text-white rounded-md hover:bg-[#5A6578] transition-colors flex items-center gap-1"
+          className="w-[140px] py-2 bg-[#4A5568] text-[15px] text-white rounded-md hover:bg-[#5A6578] transition-colors flex items-center justify-center gap-1"
         >
-          <BattleIcon className="w-[24px] h-[24px]" />
-          이의제기
+          <Icon className="w-[22px] h-[22px]" />
+          {buttonText}
         </button>
       </div>
     </section>

--- a/frontend/src/pages/battlePage/components/objection/ObjectionInput.tsx
+++ b/frontend/src/pages/battlePage/components/objection/ObjectionInput.tsx
@@ -3,13 +3,15 @@ import { useState } from 'react';
 
 interface ObjectionInputProps {
   disabled?: boolean;
+  onSubmit?: (content: string) => void;
 }
 
-export default function ObjectionInput({ disabled = false }: ObjectionInputProps) {
+export default function ObjectionInput({ disabled = false, onSubmit }: ObjectionInputProps) {
   const [inputValue, setInputValue] = useState('');
 
   const handleSubmit = () => {
     if (inputValue.trim() && !disabled) {
+      onSubmit?.(inputValue);
       setInputValue('');
     }
   };

--- a/frontend/src/pages/battlePage/components/objection/ObjectionInput.tsx
+++ b/frontend/src/pages/battlePage/components/objection/ObjectionInput.tsx
@@ -23,7 +23,7 @@ export default function ObjectionInput({ disabled = false, onSubmit }: Objection
   };
 
   return (
-    <section className="w-[500px] bg-[#1E1E2F] rounded-lg overflow-hidden">
+    <section className="w-full bg-[#1E1E2F] rounded-lg overflow-hidden">
       <div className="p-4 flex gap-1">
         <input
           type="text"

--- a/frontend/src/pages/battlePage/components/objection/ObjectionInput.tsx
+++ b/frontend/src/pages/battlePage/components/objection/ObjectionInput.tsx
@@ -1,0 +1,45 @@
+import BattleIcon from '@/assets/icon/battle.svg?react';
+import { useState } from 'react';
+
+interface ObjectionInputProps {
+  disabled?: boolean;
+}
+
+export default function ObjectionInput({ disabled = false }: ObjectionInputProps) {
+  const [inputValue, setInputValue] = useState('');
+
+  const handleSubmit = () => {
+    if (inputValue.trim() && !disabled) {
+      setInputValue('');
+    }
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSubmit();
+    }
+  };
+
+  return (
+    <section className="w-[500px] bg-[#1E1E2F] rounded-lg overflow-hidden">
+      <div className="p-4 flex gap-1">
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyPress={handleKeyPress}
+          placeholder="상대 진영에 이의제기..."
+          autoFocus
+          className="w-full bg-[#2D2D3F] border border-[#FF5A5F] rounded-md px-4 py-3 text-[13px] text-white placeholder-[#666] focus:outline-none focus:border-[#FF5A5F]"
+        />
+        <button
+          onClick={handleSubmit}
+          className="w-[140px] px-3 py-2 bg-[#4A5568] text-[13px] text-white rounded-md hover:bg-[#5A6578] transition-colors flex items-center gap-1"
+        >
+          <BattleIcon className="w-[24px] h-[24px]" />
+          이의제기
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/battlePage/components/objection/ObjectionVote.tsx
+++ b/frontend/src/pages/battlePage/components/objection/ObjectionVote.tsx
@@ -14,11 +14,19 @@ interface Objection {
 interface ObjectionVoteProps {
   objections: Objection[];
   onVote: (objectionId: number) => void;
+  phase: 'objection' | 'rebuttal';
 }
 
 export { type Objection };
 
-export default function ObjectionVote({ objections, onVote }: ObjectionVoteProps) {
+export default function ObjectionVote({ objections, onVote, phase }: ObjectionVoteProps) {
+  const isObjection = phase === 'objection';
+  const headerText = isObjection ? '제출된 이의제기 목록' : '제출된 반론 목록';
+  const infoText = isObjection
+    ? '이의제기가 실시간으로 추가되며, 바로 투표 가능합니다!'
+    : '반론이 실시간으로 추가되며, 바로 투표 가능합니다!';
+  const summaryText = isObjection ? '이의제기' : '반론';
+
   if (objections.length === 0) {
     return null;
   }
@@ -28,12 +36,12 @@ export default function ObjectionVote({ objections, onVote }: ObjectionVoteProps
       <div className="bg-gradient-to-r from-[#59168B] to-[#1C398E] p-4">
         <div className="flex items-center gap-2 mb-2">
           <ScaleIcon className="w-[20px] h-[20px]" />
-          <h3 className="text-[14px] font-medium text-white">제출된 이의제기 목록</h3>
+          <h3 className="text-[14px] font-medium text-white">{headerText}</h3>
         </div>
 
         <div className="text-[11px] text-white flex items-center gap-1">
           <span className="inline-block w-1 h-1 rounded-full bg-white"></span>
-          이의제기가 실시간으로 추가되며, 바로 투표 가능합니다!
+          {infoText}
         </div>
       </div>
 
@@ -55,7 +63,9 @@ export default function ObjectionVote({ objections, onVote }: ObjectionVoteProps
       </div>
       <div className="py-4 bg-gradient-to-r from-[#1C398E] to-[#59168B] border-t border-[#2D2D3F] flex items-center justify-center gap-2 text-[13px]">
         <span className="text-[#FFB800]">⚡</span>
-        <span className="text-white font-medium">총 {objections.length}개의 이의제기</span>
+        <span className="text-white font-medium">
+          총 {objections.length}개의 {summaryText}
+        </span>
         <span className="text-[#99A1AF]">/ 투표 완료</span>
       </div>
     </section>

--- a/frontend/src/pages/battlePage/components/objection/ObjectionVote.tsx
+++ b/frontend/src/pages/battlePage/components/objection/ObjectionVote.tsx
@@ -1,0 +1,59 @@
+import ScaleIcon from '@/assets/icon/scale.svg?react';
+import ObjectionVoteItem from './ObjectionVoteItem';
+
+interface Objection {
+  id: number;
+  user: string;
+  team: 'A' | 'B';
+  content: string;
+  votes: number;
+  totalVotes: number;
+  hasVoted: boolean;
+}
+
+interface ObjectionVoteProps {
+  objections: Objection[];
+  onVote: (objectionId: number) => void;
+}
+
+export { type Objection };
+
+export default function ObjectionVote({ objections, onVote }: ObjectionVoteProps) {
+  return (
+    <section className="w-[500px] bg-[#1E1E2F] rounded-lg overflow-hidden">
+      <div className="bg-gradient-to-r from-[#59168B] to-[#1C398E] p-4">
+        <div className="flex items-center gap-2 mb-2">
+          <ScaleIcon className="w-[20px] h-[20px]" />
+          <h3 className="text-[14px] font-medium text-white">제출된 이의제기 목록</h3>
+        </div>
+
+        <div className="text-[11px] text-white flex items-center gap-1">
+          <span className="inline-block w-1 h-1 rounded-full bg-white"></span>
+          이의제기가 실시간으로 추가되며, 바로 투표 가능합니다!
+        </div>
+      </div>
+
+      <div className="p-4 bg-gradient-to-r from-[#1E1E2F] to-[#59168B]">
+        <div className="space-y-3 ">
+          {objections.map((objection) => (
+            <ObjectionVoteItem
+              key={objection.id}
+              user={objection.user}
+              team={objection.team}
+              content={objection.content}
+              votes={objection.votes}
+              totalVotes={objection.totalVotes}
+              hasVoted={objection.hasVoted}
+              onVote={() => onVote(objection.id)}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="py-4 bg-gradient-to-r from-[#1C398E] to-[#59168B] border-t border-[#2D2D3F] flex items-center justify-center gap-2 text-[13px]">
+        <span className="text-[#FFB800]">⚡</span>
+        <span className="text-white font-medium">총 {objections.length}개의 이의제기</span>
+        <span className="text-[#99A1AF]">/ 투표 완료</span>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/battlePage/components/objection/ObjectionVote.tsx
+++ b/frontend/src/pages/battlePage/components/objection/ObjectionVote.tsx
@@ -20,7 +20,7 @@ export { type Objection };
 
 export default function ObjectionVote({ objections, onVote }: ObjectionVoteProps) {
   return (
-    <section className="w-[500px] bg-[#1E1E2F] rounded-lg overflow-hidden">
+    <section className="w-full bg-[#1E1E2F] rounded-lg overflow-hidden">
       <div className="bg-gradient-to-r from-[#59168B] to-[#1C398E] p-4">
         <div className="flex items-center gap-2 mb-2">
           <ScaleIcon className="w-[20px] h-[20px]" />

--- a/frontend/src/pages/battlePage/components/objection/ObjectionVote.tsx
+++ b/frontend/src/pages/battlePage/components/objection/ObjectionVote.tsx
@@ -19,6 +19,10 @@ interface ObjectionVoteProps {
 export { type Objection };
 
 export default function ObjectionVote({ objections, onVote }: ObjectionVoteProps) {
+  if (objections.length === 0) {
+    return null;
+  }
+
   return (
     <section className="w-full bg-[#1E1E2F] rounded-lg overflow-hidden">
       <div className="bg-gradient-to-r from-[#59168B] to-[#1C398E] p-4">

--- a/frontend/src/pages/battlePage/components/objection/ObjectionVoteItem.tsx
+++ b/frontend/src/pages/battlePage/components/objection/ObjectionVoteItem.tsx
@@ -1,0 +1,60 @@
+interface ObjectionVoteItemProps {
+  user: string;
+  team: 'A' | 'B';
+  content: string;
+  votes: number;
+  totalVotes: number;
+  hasVoted: boolean;
+  onVote: () => void;
+}
+
+export default function ObjectionVoteItem({
+  user,
+  team,
+  content,
+  votes,
+  totalVotes,
+  hasVoted,
+  onVote
+}: ObjectionVoteItemProps) {
+  const getVotePercentage = (votes: number, total: number) => {
+    if (total === 0) return 0;
+    return Math.round((votes / total) * 100);
+  };
+
+  return (
+    <button
+      onClick={hasVoted ? undefined : onVote}
+      disabled={hasVoted}
+      className={`w-full p-3 rounded-lg border text-left transition-all ${
+        hasVoted ? 'bg-[#1E3A2E] border-[#2ECC71]' : 'bg-[#2D2D3F] border-[#3D3D4F] hover:border-[#4D4D5F]'
+      } ${!hasVoted ? 'cursor-pointer' : 'cursor-default'}`}
+    >
+      <div className="flex items-start justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <span className={`text-[13px] font-medium ${team === 'A' ? 'text-[#51A2FF]' : 'text-[#FF5A5F]'}`}>
+            {user}
+          </span>
+          {hasVoted && <span className="text-[10px] px-1.5 py-0.5 bg-[#2ECC71] text-white rounded">✓ 투표완료</span>}
+        </div>
+        <div className="flex items-center gap-1">
+          <span className={`text-[18px] font-bold ${hasVoted ? 'text-[#2ECC71]' : 'text-white'}`}>{votes}</span>
+          <span className="text-[11px] text-[#99A1AF]">표</span>
+        </div>
+      </div>
+
+      <p className="text-[13px] text-white mb-3">{content}</p>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <div className="flex-1 h-2 bg-[#1E1E2F] rounded-full overflow-hidden">
+            <div
+              className={`h-full transition-all duration-300 ${hasVoted ? 'bg-[#2ECC71]' : 'bg-[#4A5568]'}`}
+              style={{ width: `${getVotePercentage(votes, totalVotes)}%` }}
+            />
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/frontend/src/pages/battlePage/components/timeline/TimelineSection.tsx
+++ b/frontend/src/pages/battlePage/components/timeline/TimelineSection.tsx
@@ -34,7 +34,7 @@ const MOCK_TIMELINE: TimelineItem[] = [
 
 export default function TimelineSection() {
   return (
-    <section className="w-[1284px] mb-8">
+    <section className="w-[1194px] mt-4">
       <div className="bg-[#1E1E2F] rounded-lg p-6">
         <div className="flex items-center gap-2 mb-2">
           <BattleIcon className="text-[#AD46FF]" />

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -68,6 +68,8 @@ export default function BattlePage() {
     userId: 'abc',
     team: selectedTeam
   });
+  //@Todo 턴 변경 정보 이벤트 구독 소켓 로직 추가 필요
+  //@Todo 초기 이의제기/반론 목록 로드 소켓 로직 추가 필요
 
   return (
     <div className="text-white flex flex-col items-center">

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -13,12 +13,16 @@ type LocationState = {
   selectedTeam?: 'A' | 'B' | 'NONE';
 };
 
+type TurnPhase = 'objection' | 'rebuttal';
+
 export default function BattlePage() {
   const { id } = useParams<{ id: string }>();
   const { state } = useLocation();
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const [objections, setObjections] = useState<Objection[]>([]);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [currentPhase, setCurrentPhase] = useState<TurnPhase>('rebuttal');
 
   const getTotalVotes = () => {
     return objections.reduce((sum, obj) => sum + obj.votes, 0);
@@ -69,9 +73,9 @@ export default function BattlePage() {
     <div className="text-white flex flex-col items-center">
       <div className="w-[1800px]">
         <BattleHeader
-          title={battleInfo.title}
-          description={battleInfo.description}
-          status="A팀 의견 공유 중"
+          title="배열에서 중복 제거하기"
+          description="배열에서 중복된 요소를 제거하는 최적의 방법은?"
+          status={currentPhase === 'objection' ? 'A팀 이의 제기 중' : 'B팀 반론 중'}
           timer="0:02"
           teamACounts={1}
           teamBCounts={1}
@@ -91,9 +95,9 @@ export default function BattlePage() {
             <TimelineSection />
           </div>
           <aside className="flex flex-col gap-4 w-[590px]">
-            <ChatSection aTeamMemebers={102} team={selectedTeam} />
-            <ObjectionInput onSubmit={handleObjectionSubmit} />
-            <ObjectionVote objections={objections} onVote={handleVote} />
+            <ChatSection aTeamMemebers={102}  team={selectedTeam}/>
+            <ObjectionInput onSubmit={handleObjectionSubmit} phase={currentPhase} />
+            <ObjectionVote objections={objections} onVote={handleVote} phase={currentPhase} />
           </aside>
         </div>
       </main>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -4,6 +4,7 @@ import type { BattleInfo } from '@/commons/types/battle';
 import BattleHeader from './components/header/BattleHeader';
 import CodeSection from './components/codeview/CodeSection';
 import ChatSection from './components/chatting/ChatSection';
+import ObjectionInput from './components/objection/ObjectionInput';
 import TimelineSection from './components/timeline/TimelineSection';
 import { useBattleSocket } from './hooks/useBattleSocket';
 
@@ -50,7 +51,7 @@ export default function BattlePage() {
           />
           <aside className="flex flex-col gap-4">
             <ChatSection aTeamMemebers={102} team={selectedTeam} />
-            <section>이의제의 input</section>
+            <ObjectionInput />
             <section>투표</section>
           </aside>
         </div>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -5,6 +5,7 @@ import BattleHeader from './components/header/BattleHeader';
 import CodeSection from './components/codeview/CodeSection';
 import ChatSection from './components/chatting/ChatSection';
 import ObjectionInput from './components/objection/ObjectionInput';
+import ObjectionVote, { type Objection } from './components/objection/ObjectionVote';
 import TimelineSection from './components/timeline/TimelineSection';
 import { useBattleSocket } from './hooks/useBattleSocket';
 
@@ -17,6 +18,36 @@ export default function BattlePage() {
   const { state } = useLocation();
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
+  const [objections, setObjections] = useState<Objection[]>([]);
+
+  const handleVote = (objectionId: number) => {
+    setObjections((prev) =>
+      prev.map((obj) => {
+        if (obj.id === objectionId) {
+          return { ...obj, hasVoted: true, votes: obj.votes + 1 };
+        } else if (obj.hasVoted) {
+          return { ...obj, hasVoted: false, votes: obj.votes - 1 };
+        }
+        return obj;
+      })
+    );
+    // @ Todo 소켓으로 투표 정보 전송 로직 추가 필요
+  };
+
+  const handleObjectionSubmit = (content: string) => {
+    const newObjection: Objection = {
+      id: Date.now(),
+      user: 'You',
+      team: 'A', // @ Todo 실제 팀 정보로 대체 필요
+      content,
+      votes: 0,
+      totalVotes: objections.length + 1,
+      hasVoted: false
+    };
+
+    setObjections((prev) => [...prev, newObjection]);
+    // @ Todo 소켓으로 이의제기 정보 전송 로직 추가 필요
+  };
 
   const { selectedTeam = 'NONE' } = (state || {}) as LocationState;
 
@@ -51,8 +82,8 @@ export default function BattlePage() {
           />
           <aside className="flex flex-col gap-4">
             <ChatSection aTeamMemebers={102} team={selectedTeam} />
-            <ObjectionInput />
-            <section>투표</section>
+            <ObjectionInput onSubmit={handleObjectionSubmit} />
+            <ObjectionVote objections={objections} onVote={handleVote} />
           </aside>
         </div>
         <TimelineSection />

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -20,17 +20,24 @@ export default function BattlePage() {
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const [objections, setObjections] = useState<Objection[]>([]);
 
+  const getTotalVotes = () => {
+    return objections.reduce((sum, obj) => sum + obj.votes, 0);
+  };
+
   const handleVote = (objectionId: number) => {
-    setObjections((prev) =>
-      prev.map((obj) => {
+    setObjections((prev) => {
+      const updated = prev.map((obj) => {
         if (obj.id === objectionId) {
           return { ...obj, hasVoted: true, votes: obj.votes + 1 };
         } else if (obj.hasVoted) {
           return { ...obj, hasVoted: false, votes: obj.votes - 1 };
         }
         return obj;
-      })
-    );
+      });
+
+      const totalVotes = updated.reduce((sum, obj) => sum + obj.votes, 0);
+      return updated.map((obj) => ({ ...obj, totalVotes }));
+    });
     // @ Todo 소켓으로 투표 정보 전송 로직 추가 필요
   };
 
@@ -41,7 +48,7 @@ export default function BattlePage() {
       team: 'A', // @ Todo 실제 팀 정보로 대체 필요
       content,
       votes: 0,
-      totalVotes: objections.length + 1,
+      totalVotes: getTotalVotes(),
       hasVoted: false
     };
 

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -72,21 +72,23 @@ export default function BattlePage() {
         />
       </div>
       <main className="w-[1800px]">
-        <div className="flex gap-4 py-4">
-          <CodeSection
+        <div className="flex gap-2 py-4">
+          <div className="flex-1">
+             <CodeSection
             onViewChange={setViewMode}
             currentView={viewMode}
             language="javascript"
             codeA={battleInfo.aCode}
             codeB={battleInfo.bCode}
           />
-          <aside className="flex flex-col gap-4">
+            <TimelineSection />
+          </div>
+          <aside className="flex flex-col gap-4 w-[590px]">
             <ChatSection aTeamMemebers={102} team={selectedTeam} />
             <ObjectionInput onSubmit={handleObjectionSubmit} />
             <ObjectionVote objections={objections} onVote={handleVote} />
           </aside>
         </div>
-        <TimelineSection />
       </main>
     </div>
   );


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #23

## ✅ 작업 내용

### 💡개선 사항

#### 1. 이의제기/반론 입력 UI 구현
-  이의제기 및 반론 제출 입력 컴포넌트 구현
- 턴 상태(`phase`)에 따라 placeholder와 버튼 텍스트 동적 변경 (이의제기 턴 / 반론 턴)
- Enter 키로도 입력 제출 이벤트 적용할 수 있도록 구현
- 전송시 낙관적 업데이트로 투표 안건 리스트 컴포넌트에 추가되는 로직 추가 
- (현재 소켓 통신 관련된 이벤트 로직은 미구현)

#### 2. 이의제기/반론 투표 시스템 기능 및 UI 구현
- 제출된 이의제기/반론 목록 표시 하는 컴포넌트 구현 
- 개별 투표 항목에 따른 득표수 및 득표율 프로그레스 바 표시 기능 구현
- 한 번만 투표 가능하며, 다른 항목 선택 시 자동 변경 되는 기능 구현 (중복 투표 x)
- 투표 항목이 없을 때는 컴포넌트 숨김 처리 로직 적용 

#### 3. 턴 개념 임시 추가 
- 배틀 페이지 상단에서 이의제기 / 반론 턴 값을 관리하는 임시 상태 구현 
 -> 용도 : 이의제기 / 반론 때마다 동적 UI 표시하기 위한 용도

#### 4. 배틀 페이지 레이아웃 개선
- 사이드바 너비 조정 (500px → 590px)
- TimelineSection을 CodeSection 하단으로 이동

<br />

### 구현 내용
#### 반론 턴의 경우 
<img width="425" height="795" alt="image" src="https://github.com/user-attachments/assets/6fff4bad-d5bf-45a6-98cd-25f1455e0a82" />
#### 이의제기 턴의 경우 
<img width="408" height="865" alt="image" src="https://github.com/user-attachments/assets/00549bd4-25a2-41b5-8d9c-929e6a2bc515" />



## 📸 참고 사항
- **소켓 통신 미구현**
  - 투표 정보 전송 로직 추가 필요
  - 이의제기/반론 제출 정보 전송 로직 추가 필요
  - 턴 변경 정보 이벤트 구독 소켓 로직 추가 필요
  - 초기 이의제기/반론 목록 로드 소켓 로직 추가 필요
<br />
