### PR TITLE
[Feature] 배틀 타임라인 컴포넌트 UI 구현

### DIFF
--- a/frontend/src/assets/icon/downArrow.svg
+++ b/frontend/src/assets/icon/downArrow.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.99219 3.33008V12.6543" stroke="white" stroke-width="1.33203" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.6543 7.99219L7.99219 12.6543L3.33008 7.99219" stroke="white" stroke-width="1.33203" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/pages/battlePage/components/timeline/TimelineCard.tsx
+++ b/frontend/src/pages/battlePage/components/timeline/TimelineCard.tsx
@@ -1,4 +1,6 @@
 import LikeIcon from '@/assets/icon/like.svg?react';
+import BattleIcon from '@/assets/icon/battle.svg?react';
+import ShieldIcon from '@/assets/icon/shield.svg?react';
 
 interface TimelineCardProps {
   user: string;
@@ -12,11 +14,15 @@ interface TimelineCardProps {
 const TYPE_COLORS = {
   이의제기: {
     bg: 'bg-[#82181A]/20',
-    border: 'border-[#FB2C36]'
+    margin: 'ml-0',
+    border: 'border-[#FB2C36]',
+    icon: 'text-[#05DF72]'
   },
   반박: {
     bg: 'bg-[#0D542B]/20',
-    border: 'border-[#00C950]'
+    margin: 'ml-16',
+    border: 'border-[#00C950]',
+    icon: 'text-[#FF6467]'
   }
 };
 
@@ -36,24 +42,30 @@ export default function TimelineCard({ user, team, type, content, voteCount }: T
   const teamColors = TEAM_COLORS[team];
 
   return (
-    <div className={`w-[1143px] ${typeColors.bg} ${typeColors.border} border-[2px] rounded-lg p-4 shadow-xl`}>
+    <div
+      className={`w-[85%] ${typeColors.bg} ${typeColors.border} ${typeColors.margin} border-2 rounded-lg p-4 shadow-xl`}
+    >
       <div className="flex items-start justify-between mb-3">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
           <div
-            className={`w-[36px] h-[24px] ${teamColors.badge} rounded-sm flex items-center justify-center text-white font-bold text-[12px]`}
+            className={`w-[36px] h-[20px] ${teamColors.badge} rounded-sm flex items-center justify-center text-white font-bold text-[12px]`}
           >
             {team}팀
           </div>
-          <span className={`text-[15px] font-bold ${teamColors.text}`}>{user}</span>
+          <span className={`text-[18px] font-bold ${teamColors.text}`}>{user}</span>
+          {type === '이의제기' ? (
+            <BattleIcon className={`w-[20px] h-[20px] ${typeColors.icon}`} />
+          ) : (
+            <ShieldIcon className={`w-[20px] h-[20px] ${typeColors.icon}`} />
+          )}
+          <span className={`text-[14px] font-medium ${typeColors.icon}`}>{type}</span>
         </div>
-
-        <div className="flex items-center gap-2 text-white rounded-md px-2 py-1 bg-[#2D2D3F]">
+        <div className="flex items-center gap-2 rounded-md px-2 py-1 bg-[#2D2D3F]">
           <LikeIcon className="w-[20px] h-[20px]" />
           <span className="text-[13px] text-white font-medium">{voteCount}</span>
         </div>
       </div>
-
-      <p className="text-[16px] text-start text-white pl-[12px]">{content}</p>
+      <p className="text-[16px] text-white pl-[12px] text-left">{content}</p>
     </div>
   );
 }

--- a/frontend/src/pages/battlePage/components/timeline/TimelineCard.tsx
+++ b/frontend/src/pages/battlePage/components/timeline/TimelineCard.tsx
@@ -9,34 +9,42 @@ interface TimelineCardProps {
   voteCount: number;
 }
 
+const TYPE_COLORS = {
+  이의제기: {
+    bg: 'bg-[#82181A]/20',
+    border: 'border-[#FB2C36]'
+  },
+  반박: {
+    bg: 'bg-[#0D542B]/20',
+    border: 'border-[#00C950]'
+  }
+};
+
 const TEAM_COLORS = {
   A: {
-    bg: 'bg-[#1E3A5F]',
-    border: 'border-[#2B7FFF]',
     badge: 'bg-[#2B7FFF]',
     text: 'text-[#51A2FF]'
   },
   B: {
-    bg: 'bg-[#3D1F2B]',
-    border: 'border-[#FB2C36]',
     badge: 'bg-[#FB2C36]',
     text: 'text-[#FF5A5F]'
   }
 };
 
-export default function TimelineCard({ user, team, content, voteCount }: TimelineCardProps) {
-  const colors = TEAM_COLORS[team];
+export default function TimelineCard({ user, team, type, content, voteCount }: TimelineCardProps) {
+  const typeColors = TYPE_COLORS[type];
+  const teamColors = TEAM_COLORS[team];
 
   return (
-    <div className={`w-[1143px] ${colors.bg} ${colors.border} border-l-4 rounded-lg p-4`}>
+    <div className={`w-[1143px] ${typeColors.bg} ${typeColors.border} border-[2px] rounded-lg p-4 shadow-xl`}>
       <div className="flex items-start justify-between mb-3">
         <div className="flex items-center gap-3">
           <div
-            className={`w-[36px] h-[24px] ${colors.badge} rounded-sm flex items-center justify-center text-white font-bold text-[12px]`}
+            className={`w-[36px] h-[24px] ${teamColors.badge} rounded-sm flex items-center justify-center text-white font-bold text-[12px]`}
           >
             {team}팀
           </div>
-          <span className={`text-[15px] font-bold ${colors.text}`}>{user}</span>
+          <span className={`text-[15px] font-bold ${teamColors.text}`}>{user}</span>
         </div>
 
         <div className="flex items-center gap-2 text-white rounded-md px-2 py-1 bg-[#2D2D3F]">

--- a/frontend/src/pages/battlePage/components/timeline/TimelineCard.tsx
+++ b/frontend/src/pages/battlePage/components/timeline/TimelineCard.tsx
@@ -48,7 +48,7 @@ export default function TimelineCard({ user, team, type, content, voteCount }: T
       <div className="flex items-start justify-between mb-3">
         <div className="flex items-center gap-2">
           <div
-            className={`w-[36px] h-[20px] ${teamColors.badge} rounded-sm flex items-center justify-center text-white font-bold text-[12px]`}
+            className={`w-[36px] h-[20px] ${teamColors.badge} rounded-sm flex items-center justify-center text-white font-bold text-[12px] mb-2`}
           >
             {team}팀
           </div>

--- a/frontend/src/pages/battlePage/components/timeline/TimelineSection.tsx
+++ b/frontend/src/pages/battlePage/components/timeline/TimelineSection.tsx
@@ -1,4 +1,5 @@
 import BattleIcon from '@/assets/icon/battle.svg?react';
+import DownArrowIcon from '@/assets/icon/downArrow.svg?react';
 import TimelineCard from './TimelineCard';
 
 interface TimelineItem {
@@ -34,7 +35,7 @@ const MOCK_TIMELINE: TimelineItem[] = [
 
 export default function TimelineSection() {
   return (
-    <section className="w-[1194px] mt-4">
+    <section className="w-[1193px] mt-2">
       <div className="bg-[#1E1E2F] rounded-lg p-6">
         <div className="flex items-center gap-2 mb-2">
           <BattleIcon className="text-[#AD46FF]" />
@@ -44,10 +45,13 @@ export default function TimelineSection() {
           각 진영의 주장과 반박을 시간순으로 확인하고 투표하세요
         </h3>
         <div className="space-y-4">
-          {MOCK_TIMELINE.map((item, index) => (
+          {MOCK_TIMELINE.map((item) => (
             <div key={item.id} className="relative">
-              {index < MOCK_TIMELINE.length - 1 && (
-                <div className="absolute left-[15px] top-[60px] w-[2px] h-[calc(100%+16px)] bg-[#2D2D3F]" />
+              {item.type === '반박' && (
+                <div className="flex gap-2 items-center my-4 ml-17">
+                  <DownArrowIcon className="w-[32px] h-[32px] bg-[#59168B] fill-[#C27AFF] rounded-full px-1 py-1" />
+                  <p className="text-[14px] text-[#C27AFF]">반박</p>
+                </div>
               )}
               <TimelineCard
                 user={item.user}

--- a/frontend/src/pages/battlePage/components/timeline/TimelineSection.tsx
+++ b/frontend/src/pages/battlePage/components/timeline/TimelineSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import BattleIcon from '@/assets/icon/battle.svg?react';
 import DownArrowIcon from '@/assets/icon/downArrow.svg?react';
 import TimelineCard from './TimelineCard';
@@ -30,10 +31,28 @@ const MOCK_TIMELINE: TimelineItem[] = [
     content: '구현 B의 반복문 사용이 더 명확하고 이해하기 쉽습니다.',
     timestamp: '2024-12-16 21:30:00',
     voteCount: 15
+  },
+  {
+    id: 3,
+    user: 'Alice',
+    team: 'A',
+    type: '이의제기',
+    content: '구현 A의 Set 사용이 더 효율적입니다. O(1) 시간 복잡도로 중복을 제거합니다.',
+    timestamp: '2024-12-16 21:30:00',
+    voteCount: 15
   }
 ];
 
 export default function TimelineSection() {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [timeline, setTimeline] = useState<TimelineItem[]>(MOCK_TIMELINE);
+
+  /*
+  useEffect(() => {
+    // @Todos : 소켓으로 타임 라인 데이터 구독 로직 추가 필요
+  }, []);
+  */
+
   return (
     <section className="w-[1193px] mt-2">
       <div className="bg-[#1E1E2F] rounded-lg p-6">
@@ -45,7 +64,7 @@ export default function TimelineSection() {
           각 진영의 주장과 반박을 시간순으로 확인하고 투표하세요
         </h3>
         <div className="space-y-4">
-          {MOCK_TIMELINE.map((item) => (
+          {timeline.map((item) => (
             <div key={item.id} className="relative">
               {item.type === '반박' && (
                 <div className="flex gap-2 items-center my-4 ml-17">


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #25 

## ✅ 작업 내용

### 배틀 타임라인 컴포넌트 UI 구현
#### 1. 타임라인 카드 구현
- **이의제기 카드**: 빨간색 계열 배경 
- **반박 카드**: 초록색 계열 배경 


#### 2. 반박 표시 UI 추가
- 반박 흐름의 시각화를 돕기 위한 반박 카드 상단에 화살표 아이콘과 `반박` 텍스트 표시
- 반박 카드는 들여쓰기로 계층 구조 표현 했습니다. 

<br />

### 구현 내용
<img width="816" height="376" alt="image" src="https://github.com/user-attachments/assets/60465466-9b59-4f0a-95a2-7eeed0a44b8d" />


## 📸 참고 사항
- 타임라인 데이터는 현재 Mock 데이터로 동작하며, 추후 소켓 연동이 필요합니다. (필요한 위치는 주석(//@Todo)으로 표기 해놨습니다.
- 카드들에 사용중인 디자인의 경우 프로토타입 개발이 끝난 이후에 디자인 개선이 필요하다는 의견이 있었어서 기획서에 적혀있는것 외로 추가적으로 디자인을 상세히 꾸미지는 않았습니다.  

<br />
