### PR TITLE
[Feature] 배틀 종료 이벤트 발행 및 데이터 제거

### DIFF
--- a/backend/src/battles/dto/battleClosedResponse.dto.ts
+++ b/backend/src/battles/dto/battleClosedResponse.dto.ts
@@ -1,0 +1,16 @@
+export class BattleClosedResponseDto {
+  battleId: string
+
+  static fromEntity(payload: BattleClosedResponseDto): BattleClosedResponseDto {
+    const res = new BattleClosedResponseDto()
+    const { battleId } = payload
+
+    res.battleId = battleId
+
+    return res
+  }
+
+  static of(payload: BattleClosedResponseDto): BattleClosedResponseDto {
+    return BattleClosedResponseDto.fromEntity(payload)
+  }
+}

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -17,6 +17,7 @@ import { AttackRequestDto, DefenseRequestDto, AttackVoteRequestDto, DefenseVoteR
 import { BattlePhaseResponseDto, BattleRoundResponseDto, BattleTurnResponseDto } from '../dto/battleTurnResponse.dto'
 import { BattleChatDto } from '../dto/battleChat.dto'
 import { BATTLE_CHAT_SCOPE } from '../const/battles.const'
+import { BattleClosedResponseDto } from '../dto/battleClosedResponse.dto'
 
 @WebSocketGateway()
 export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect, OnModuleInit {
@@ -164,6 +165,19 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     this.server.to(battleRoomId).emit('battle:round:update', payload)
   }
 
+  closeBattle(payload: BattleClosedResponseDto) {
+    const { battleId } = payload
+    const battleRoomId = this.battlesService.getBattleRoomId(battleId)
+    const battleARoomId = this.battlesService.getBattleRoomId(battleId, 'A')
+    const battleBRoomId = this.battlesService.getBattleRoomId(battleId, 'B')
+
+    this.server.to(battleRoomId).emit('battle:closed', payload)
+
+    const rooms = [battleRoomId, battleARoomId, battleBRoomId]
+
+    rooms.forEach(room => this.server.in(room).disconnectSockets(true))
+  }
+
   private bindBattleEvents() {
     this.battlesService.on('battle:phase:update', (payload: BattlePhaseResponseDto) => this.phaseUpdate(payload))
 
@@ -171,10 +185,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
     this.battlesService.on('battle:round:update', (payload: BattleRoundResponseDto) => this.roundUpdate(payload))
 
-    // this.battlesService.on('battle:ended', payload => {
-    //   const { battleId } = payload
-    //   this.server.to(`battle:${battleId}`).emit('battle:ended', payload)
-    // })
+    this.battlesService.on('battle:closed', (payload: BattleClosedResponseDto) => this.closeBattle(payload))
   }
 
   @SubscribeMessage('battle:chat')

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -24,6 +24,7 @@ import {
   BATTLE_DISCUSSION_TYPE,
 } from '../const/battles.const'
 import { BattlePhaseResponseDto, BattleRoundResponseDto, BattleTurnResponseDto } from '../dto/battleTurnResponse.dto'
+import { BattleClosedResponseDto } from '../dto/battleClosedResponse.dto'
 
 @Injectable()
 export class BattlesService extends EventEmitter {
@@ -302,6 +303,8 @@ export class BattlesService extends EventEmitter {
 
   private updatePhase(battleId: string): void {
     const state = this.getBattleState(battleId)
+    if (!state) return
+
     const battle = this.battles.find(battle => battle.id === battleId)
     if (battle?.status === BATTLE_STATUS.CLOSED) return
 
@@ -448,12 +451,16 @@ export class BattlesService extends EventEmitter {
   }
 
   private finishBattle(battle: Battle) {
-    //TODO 배틀 종료 처리
     const battleTimer = this.battleTimers.get(battle.id)
     clearTimeout(battleTimer)
     this.battleTimers.delete(battle.id)
+
     battle.status = BATTLE_STATUS.CLOSED
+
     this.activeBattles.delete(battle.id)
+    this.battles = this.battles.filter(b => b.id !== battle.id)
+
+    this.emit('battle:closed', BattleClosedResponseDto.of({ battleId: battle.id }))
   }
 
   private isPublicAndOpen(battle: Battle): boolean {
@@ -575,6 +582,7 @@ export class BattlesService extends EventEmitter {
     if (battle?.status === BATTLE_STATUS.CLOSED) return
 
     const state = this.getBattleState(battleId)
+    if (!state) return
 
     const prevTimer = this.battleTimers.get(battleId)
     if (prevTimer) clearTimeout(prevTimer)


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #62 

## ✅ 작업 내용

- 소켓 연결 해제
- 배틀 타이머 제거
- 실시간 배틀 제거
- 배틀 데이터 제거
- 배틀 종료 이벤트 발행

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항
<img width="1327" height="581" alt="스크린샷 2025-12-18 오후 4 05 56" src="https://github.com/user-attachments/assets/732f6b6f-a6d4-49b7-89da-643d522b9df0" />

<img width="1055" height="215" alt="스크린샷 2025-12-18 오후 4 06 06" src="https://github.com/user-attachments/assets/9e200fce-589f-45d7-bd9d-c3282cce714c" />

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->

1. API 명세서에 `battle:closed`에 대한 이벤트 Response에 여러 데이터를 전달되는 걸로 명시되어 있었는데,
배틀을 모두 제거하고 배틀 결과를 Mock 데이터만 보여줄 예정이니, `battleId`만 응답하는 것으로 구현하였습니다.

2. `dev`에서 작업을 시작한 것이 아닌, 기존 타이머 작업했던 브랜치에 이어서 작업을 하느라 Conflict가 많이 발생할 것 같습니다 🥹

3. 현재 턴 관리가 머지되지 않아, 턴관리 커밋까지 보이는데 `[feat: Battle Close DTO 작성]` 부터 확인해주시면 감사드립니다 :)
