### PR TITLE
[Feature] 팀 변경 이벤트 처리

### DIFF
--- a/backend/src/battles/dto/battleTeamVote.dto.ts
+++ b/backend/src/battles/dto/battleTeamVote.dto.ts
@@ -1,0 +1,13 @@
+import { IsIn, IsNotEmpty, IsString } from 'class-validator'
+import { BATTLE_TEAM } from '../const/battles.const'
+import type { BattleTeam } from '../types/battles.types'
+
+export class BattleTeamVoteDto {
+  @IsString()
+  @IsNotEmpty()
+  battleId!: string
+
+  @IsString()
+  @IsIn([BATTLE_TEAM.A, BATTLE_TEAM.B, BATTLE_TEAM.NONE])
+  team!: BattleTeam
+}

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -17,6 +17,8 @@ import { AttackRequestDto, DefenseRequestDto, AttackVoteRequestDto, DefenseVoteR
 import { BattlePhaseResponseDto, BattleRoundResponseDto, BattleTurnResponseDto } from '../dto/battleTurnResponse.dto'
 import { BattleChatDto } from '../dto/battleChat.dto'
 import { BATTLE_CHAT_SCOPE } from '../const/battles.const'
+import { BattleTeamVoteDto } from '../dto/battleTeamVote.dto'
+import type { BattleTeam } from '../types/battles.types'
 
 @WebSocketGateway()
 export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect, OnModuleInit {
@@ -171,6 +173,15 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
     this.battlesService.on('battle:round:update', (payload: BattleRoundResponseDto) => this.roundUpdate(payload))
 
+    this.battlesService.on(
+      'battle:team:update',
+      (payload: {
+        battleId: string
+        changes: Array<{ clientId: string; from: BattleTeam; to: BattleTeam }>
+        counts: { teamA: number; teamB: number; none: number }
+      }) => this.teamUpdate(payload),
+    )
+
     // this.battlesService.on('battle:ended', payload => {
     //   const { battleId } = payload
     //   this.server.to(`battle:${battleId}`).emit('battle:ended', payload)
@@ -193,5 +204,38 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
         client.emit('battle:chat:error', { message: error.message })
       }
     }
+  }
+
+  @SubscribeMessage('battle:teamVote')
+  handleTeamVote(@MessageBody() dto: BattleTeamVoteDto, @ConnectedSocket() client: Socket) {
+    try {
+      this.battlesService.voteTeam(dto, client.id)
+    } catch (error) {
+      if (error instanceof Error) {
+        client.emit('battle:teamVote:error', { message: error.message })
+      }
+    }
+  }
+
+  private teamUpdate(payload: {
+    battleId: string
+    changes: Array<{ clientId: string; from: BattleTeam; to: BattleTeam }>
+    counts: { teamA: number; teamB: number; none: number }
+  }) {
+    const battleRoomId = this.battlesService.getBattleRoomId(payload.battleId)
+
+    for (const change of payload.changes) {
+      const socket = this.server.sockets.sockets.get(change.clientId)
+      if (!socket) continue
+
+      const fromRoom = this.battlesService.getBattleRoomId(payload.battleId, change.from)
+      const toRoom = this.battlesService.getBattleRoomId(payload.battleId, change.to)
+
+      void socket.leave(fromRoom)
+      void socket.join(toRoom)
+      socket.emit('battle:team:update', { battleId: payload.battleId, team: change.to })
+    }
+
+    this.server.to(battleRoomId).emit('battle:team:update', payload)
   }
 }

--- a/backend/src/battles/service/battles.service.spec.ts
+++ b/backend/src/battles/service/battles.service.spec.ts
@@ -347,6 +347,53 @@ describe('BattlesService', () => {
     })
   })
 
+  describe('voteTeam / TEAM_SWITCH 적용', () => {
+    beforeEach(() => {
+      const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
+      service.setBattlesForTest([battle])
+      service['initBattleState']('battle-1')
+
+      service.joinBattle(
+        {
+          battleId: 'battle-1',
+          team: BATTLE_TEAM.A,
+          userId: 'user-1',
+        },
+        'client-1',
+      )
+    })
+
+    it('TEAM_SWITCH가 아니면 팀 변경 투표가 거부된다', () => {
+      expect(() =>
+        service.voteTeam(
+          {
+            battleId: 'battle-1',
+            team: BATTLE_TEAM.B,
+          },
+          'client-1',
+        ),
+      ).toThrow(BadRequestException)
+    })
+
+    it('TEAM_SWITCH 종료 시 투표가 반영되어 팀이 변경된다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.TEAM_SWITCH.name
+
+      service.voteTeam(
+        {
+          battleId: 'battle-1',
+          team: BATTLE_TEAM.B,
+        },
+        'client-1',
+      )
+
+      service['updatePhase']('battle-1')
+
+      expect(state.teamA.users).not.toContain('client-1')
+      expect(state.teamB.users).toContain('client-1')
+    })
+  })
+
   describe('getOpenBattles', () => {
     it('PUBLIC 이면서 OPEN 상태인 배틀만 반환한다', () => {
       const battles: Battle[] = [

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -7,6 +7,7 @@ import { mockBattleResults } from '../mock/battleResults.mock'
 import { TimelineItem, Mvp } from '../types/battleResult.types'
 import { ActiveBattleState, Battle, BattlePhase, BattleTeam, BattleDiscussion, BattleDefense, BattlePlayTime } from '../types/battles.types'
 import { BattleChatDto } from '../dto/battleChat.dto'
+import type { BattleTeamVoteDto } from '../dto/battleTeamVote.dto'
 import { BattleResponseDto } from '../dto/battleResponse.dto'
 import { BattleResultResponseDto } from '../dto/battleResult.dto'
 import { BattleJoinRequestDto } from '../dto/battleJoinRequest.dto'
@@ -231,6 +232,8 @@ export class BattlesService extends EventEmitter {
         attacks: [],
         defenses: [],
       },
+      participants: new Map(),
+      teamVotes: new Map(),
       phase: BATTLE_PHASE.OPINION_SHARE.name,
       round: 1,
       turn: null,
@@ -294,10 +297,32 @@ export class BattlesService extends EventEmitter {
 
     if (!battleState) throw new NotFoundException('해당 배틀은 현재 진행 중이지 않습니다.')
 
-    const { teamA, teamB } = battleState
+    battleState.participants.set(clientId, team as BattleTeam)
+    this.rebuildTeamUsers(battleState)
+  }
 
-    const myTeam = team === BATTLE_TEAM.A ? teamA : teamB
-    myTeam.users.push(clientId)
+  private rebuildTeamUsers(state: ActiveBattleState) {
+    state.teamA.users = []
+    state.teamB.users = []
+
+    for (const [clientId, team] of state.participants.entries()) {
+      if (team === BATTLE_TEAM.A) state.teamA.users.push(clientId)
+      if (team === BATTLE_TEAM.B) state.teamB.users.push(clientId)
+    }
+  }
+
+  voteTeam(dto: BattleTeamVoteDto, clientId: string) {
+    const state = this.getBattleState(dto.battleId)
+
+    if (state.phase !== BATTLE_PHASE.TEAM_SWITCH.name) {
+      throw new BadRequestException('팀 변경 투표는 TEAM_SWITCH 페이즈에서만 가능합니다.')
+    }
+
+    if (!state.participants.has(clientId)) {
+      throw new BadRequestException('배틀 참가자만 팀 변경 투표를 할 수 있습니다.')
+    }
+
+    state.teamVotes.set(clientId, dto.team)
   }
 
   private updatePhase(battleId: string): void {
@@ -373,12 +398,41 @@ export class BattlesService extends EventEmitter {
         return this.updateTurn(state)
 
       case BATTLE_PHASE.TEAM_SWITCH.name: {
+        this.applyTeamVotes(state)
         const isNextRound = this.updateRound(state)
         return isNextRound ? BATTLE_PHASE.OPINION_SHARE : null
       }
 
       default:
         return null
+    }
+  }
+
+  private applyTeamVotes(state: ActiveBattleState) {
+    const changes: Array<{ clientId: string; from: BattleTeam; to: BattleTeam }> = []
+
+    for (const [clientId, desiredTeam] of state.teamVotes.entries()) {
+      const currentTeam = state.participants.get(clientId)
+      if (!currentTeam) continue
+      if (currentTeam === desiredTeam) continue
+
+      state.participants.set(clientId, desiredTeam)
+      changes.push({ clientId, from: currentTeam, to: desiredTeam })
+    }
+
+    state.teamVotes.clear()
+    this.rebuildTeamUsers(state)
+
+    if (changes.length) {
+      this.emit('battle:team:update', {
+        battleId: state.battleId,
+        changes,
+        counts: {
+          teamA: state.teamA.users.length,
+          teamB: state.teamB.users.length,
+          none: [...state.participants.values()].filter(t => t === BATTLE_TEAM.NONE).length,
+        },
+      })
     }
   }
 

--- a/backend/src/battles/types/battles.types.ts
+++ b/backend/src/battles/types/battles.types.ts
@@ -85,6 +85,9 @@ export interface ActiveBattleState {
   teamA: BattleTeamData
   teamB: BattleTeamData
 
+  participants: Map<string, BattleTeam>
+  teamVotes: Map<string, BattleTeam>
+
   round: number
   phase: BattlePhaseName
   turn: {


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->
Closes #19 

## ✅ 작업 내용

  - battle:teamVote DTO 추가
  -  투표/참가자 상태 저장 자료구조 추가:
      - participants: Map<clientId, team>
      - teamVotes: Map<clientId, desiredTeam>
  - voteTeam(dto, clientId) :
      - 서버에서 phase === TEAM_SWITCH 체크
      - 참가자 여부 체크 후 teamVotes에 저장
  - TEAM_SWITCH 종료 시점에(updatePhase가 TEAM_SWITCH를 처리할 때) applyTeamVotes가 투표 반영:
      - 반영 후 battle:team:update 이벤트를 emit(변경 목록 + 팀 카운트)
  - Gateway:
      - @SubscribeMessage('battle:teamVote') 추가
      - 서비스 이벤트 battle:team:update 구독 후 소켓 room 이동(leave/join) + 클라에 battle:team:update emit
  - 단위 테스트 추가

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
