### PR TITLE
[Feature] 서버로부터 이벤트를 받아 채팅을 보여준다

### DIFF
--- a/backend/src/battles/dto/battleChat.dto.ts
+++ b/backend/src/battles/dto/battleChat.dto.ts
@@ -12,9 +12,9 @@ export class BattleChatDto {
   scope!: typeof BATTLE_CHAT_SCOPE.ALL | typeof BATTLE_CHAT_SCOPE.TEAM
 
   @IsString()
-  @IsIn([BATTLE_TEAM.A, BATTLE_TEAM.B])
+  @IsIn([BATTLE_TEAM.A, BATTLE_TEAM.B, 'NONE'])
   @IsNotEmpty()
-  team?: BattleTeam
+  team: BattleTeam
 
   @IsString()
   @MinLength(1)

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -213,7 +213,8 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
           ? this.battlesService.getBattleRoomId(battleChatDto.battleId)
           : this.battlesService.getBattleRoomId(battleChatDto.battleId, battleChatDto.team)
 
-      this.server.to(roomId).emit('battle:chatUpdate', saved)
+      // this.server.to(roomId).emit('battle:chatUpdate', saved)
+      this.server.to(roomId).except(client.id).emit('battle:chatUpdate', saved)
     } catch (error) {
       if (error instanceof Error) {
         client.emit('battle:chat:error', { message: error.message })

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -270,6 +270,7 @@ export class BattlesService extends EventEmitter {
 
     const chat = {
       messageId: this.generateId(),
+      team,
       sender: senderId,
       text: text.trim(),
       createdAt: new Date(),
@@ -289,7 +290,7 @@ export class BattlesService extends EventEmitter {
     const target = team === BATTLE_TEAM.A ? battleState.teamA : battleState.teamB
     target.chats.push(chat)
 
-    return { battleId, scope, team, ...chat }
+    return { battleId, scope, ...chat }
   }
 
   private addParticipant(battleId: string, clientId: string, team: string): void {

--- a/backend/src/battles/types/battles.types.ts
+++ b/backend/src/battles/types/battles.types.ts
@@ -50,6 +50,7 @@ export interface Battle {
 }
 export interface BattleChat {
   messageId: string
+  team: BattleTeam
   sender: string
   text: string
   createdAt: Date

--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -1,7 +1,12 @@
 // BattleChat 타입
 export interface BattleChat {
-  authorId: string;
-  content: string;
+  battleId: string;
+  scope: 'TEAM' | 'ALL';
+  messageId: string;
+  sender: string;
+  team: Team;
+  text: string;
+  createdAt: Date;
 }
 
 export interface BattleInfo {

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -6,9 +6,11 @@ import PeoplesIcons from '@/assets/icon/peoples.svg?react';
 import MessageIcon from '@/assets/icon/message.svg?react';
 
 import { useState, useRef, useEffect, useMemo } from 'react';
+import { Socket } from 'socket.io-client';
+import type { BattleChat } from '@/commons/types/battle';
 
 interface Message {
-  id: number;
+  id: string;
   user: string;
   team: 'A' | 'B' | 'NONE';
   content: string;
@@ -18,7 +20,7 @@ interface Message {
 
 const MOCK_TEAM_MESSAGES: Message[] = [
   {
-    id: 1,
+    id: '1',
     user: 'CodeMaster',
     team: 'A',
     content: '구현스가 Set을 사용해서 더 간결하네요',
@@ -26,7 +28,7 @@ const MOCK_TEAM_MESSAGES: Message[] = [
     type: 'normal'
   },
   {
-    id: 2,
+    id: '2',
     user: 'JSLover',
     team: 'A',
     content: 'Set 사용이 훨씬 직관적인 것 같은데요',
@@ -34,7 +36,7 @@ const MOCK_TEAM_MESSAGES: Message[] = [
     type: 'normal'
   },
   {
-    id: 3,
+    id: '3',
     user: 'You',
     team: 'A',
     content: '코드가 구려요',
@@ -42,7 +44,7 @@ const MOCK_TEAM_MESSAGES: Message[] = [
     type: 'objection'
   },
   {
-    id: 4,
+    id: '4',
     user: 'You',
     team: 'A',
     content: '별론데요',
@@ -53,7 +55,7 @@ const MOCK_TEAM_MESSAGES: Message[] = [
 
 const MOCK_ALL_MESSAGES: Message[] = [
   {
-    id: 1,
+    id: '1',
     user: 'PlayerB',
     team: 'B',
     content: 'B팀도 나쁘지 않은데요?',
@@ -61,7 +63,7 @@ const MOCK_ALL_MESSAGES: Message[] = [
     type: 'objection'
   },
   {
-    id: 2,
+    id: '2',
     user: 'CodeMaster',
     team: 'A',
     content: 'A팀이 더 나은 것 같습니다',
@@ -69,7 +71,7 @@ const MOCK_ALL_MESSAGES: Message[] = [
     type: 'rebuttal'
   },
   {
-    id: 3,
+    id: '3',
     user: 'Observer',
     team: 'NONE',
     content: '둘 다 장단점이 있네요',
@@ -79,12 +81,24 @@ const MOCK_ALL_MESSAGES: Message[] = [
 ];
 
 interface ChatSectionProps {
+  socket: Socket | null;
+  battleId?: string;
+  chats: BattleChat[];
+  allChats: BattleChat[];
   aTeamMemebers: number;
   onSendMessage?: (content: string) => void;
   team: 'A' | 'B' | 'NONE';
 }
 
-export default function ChatSection({ aTeamMemebers, onSendMessage, team }: ChatSectionProps) {
+export default function ChatSection({
+  socket,
+  aTeamMemebers,
+  onSendMessage,
+  team,
+  battleId,
+  chats,
+  allChats
+}: ChatSectionProps) {
   const [teamMessages, setTeamMessages] = useState<Message[]>(MOCK_TEAM_MESSAGES);
   const [allMessages, setAllMessages] = useState<Message[]>(MOCK_ALL_MESSAGES);
   const [activeTab, setActiveTab] = useState<'team' | 'all'>(team === 'NONE' ? 'all' : 'team');
@@ -95,14 +109,81 @@ export default function ChatSection({ aTeamMemebers, onSendMessage, team }: Chat
   }, [activeTab, teamMessages, allMessages]);
 
   useEffect(() => {
+    const newChats =
+      chats?.map(
+        (chat: BattleChat): Message => ({
+          id: chat.messageId,
+          user: chat.sender,
+          team: chat.team,
+          content: chat.text,
+          timestamp: new Date(chat.createdAt).toISOString().replace('T', ' ').substring(0, 19),
+          type: 'normal'
+        })
+      ) ?? [];
+
+    const newAllchats =
+      allChats?.map(
+        (chat: BattleChat): Message => ({
+          id: chat.messageId,
+          user: chat.sender,
+          team: chat.team,
+          content: chat.text,
+          timestamp: new Date(chat.createdAt).toISOString().replace('T', ' ').substring(0, 19),
+          type: 'normal'
+        })
+      ) ?? [];
+
+    setTeamMessages((prev) => [...prev, ...newChats]);
+    setAllMessages((prev) => [...prev, ...newAllchats]);
+  }, [chats, allChats]);
+
+  useEffect(() => {
     if (chatContainerRef.current) {
       chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight;
     }
   }, [currentMessages]);
 
+  useEffect(() => {
+    const handleChatUpdate = (message: BattleChat) => {
+      const newMessage: Message = {
+        id: message.messageId,
+        user: message.sender,
+        team: message.team,
+        content: message.text,
+        timestamp: new Date(message.createdAt).toISOString().replace('T', ' ').substring(0, 19),
+        type: 'normal'
+      };
+
+      if (message.scope === 'TEAM') {
+        setTeamMessages((prev) => [...prev, newMessage]);
+      } else {
+        setAllMessages((prev) => [...prev, newMessage]);
+      }
+
+      if (onSendMessage) {
+        onSendMessage(newMessage.content);
+      }
+    };
+    socket?.on('battle:chatUpdate', handleChatUpdate);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [socket]);
+
   const handleSendMessage = (content: string) => {
+    if (!socket) return;
+
+    const scope = activeTab === 'team' ? 'TEAM' : 'ALL';
+
+    const chatMessage = {
+      battleId,
+      scope,
+      team,
+      text: content.trim()
+    };
+
+    socket.emit('battle:chat', chatMessage);
+
     const newMessage: Message = {
-      id: currentMessages.length + 1,
+      id: currentMessages.length + 1 + '',
       user: 'You',
       team: team,
       content,
@@ -115,7 +196,6 @@ export default function ChatSection({ aTeamMemebers, onSendMessage, team }: Chat
     } else {
       setAllMessages((prev) => [...prev, newMessage]);
     }
-
     if (onSendMessage) {
       onSendMessage(content);
     }

--- a/frontend/src/pages/battlePage/components/modals/TeamChangeModal.tsx
+++ b/frontend/src/pages/battlePage/components/modals/TeamChangeModal.tsx
@@ -5,7 +5,7 @@ import TimerIcon from '@/assets/icon/timer.svg?react';
 interface TeamChangeModalProps {
   aTeamCounts: number;
   bTeamCounts: number;
-  currentTeam : 'A' | 'B' | 'NONE'; 
+  currentTeam: 'A' | 'B' | 'NONE';
   remainingTime: number;
   noneTeamCounts: number;
   handleTeamChange: (team: 'A' | 'B' | 'NONE') => void;

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -29,7 +29,7 @@ export default function BattlePage() {
   } = useModal(false);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { socket, currentStage, battleProgress, isConnected } = useBattleSocket({
+  const { socket, currentStage, battleProgress, isConnected, battleData } = useBattleSocket({
     battleId: id || '1',
     userId: 'abc',
     team: selectedTeam
@@ -79,8 +79,8 @@ export default function BattlePage() {
   };
 
   //@Todo 초기 이의제기/반론 목록 로드 소켓 로직 추가 필요
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleTeamChange = (team: 'A' | 'B' | 'NONE') => {
-    console.log(team);
     // @ Todo 팀 변경 로직 추가 필요
     closeTeamChangeModal();
   };
@@ -111,7 +111,14 @@ export default function BattlePage() {
             <TimelineSection />
           </div>
           <aside className="flex flex-col gap-4 w-[590px]">
-            <ChatSection aTeamMemebers={102} team={selectedTeam} />
+            <ChatSection
+              aTeamMemebers={102}
+              team={selectedTeam}
+              socket={socket}
+              battleId={id}
+              chats={battleData?.chats || []}
+              allChats={battleData?.allChats || []}
+            />
             <ObjectionInput
               onSubmit={handleObjectionSubmit}
               phase={battleProgress?.phase}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #59 

## ✅ 작업 내용

1. 채팅 작성 시, 서버로 이벤트 호출 + 자기 자신 채팅 추가("YOU")
2. 채팅 수신 시, Scope에 따라 전체/진영 채팅방에 추가 
    - 해당 과정에서 FE, BE  데이터 구조 변경
3. 배틀 참여 시, 수신된 해당 배틀 채팅 내용 추가

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

1. 같은 팀 진영 2명 + 중립 1명
![chat](https://github.com/user-attachments/assets/d2abc330-056e-497e-b66c-633608946aa7)

3. 새로 참여할 경우
![joinchat](https://github.com/user-attachments/assets/9b7caac3-91b4-4b95-8592-5c2f60dc3843)

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
