### PR TITLE
[Feature] 배틀페이지에서 타이머 기능을 적용한다

### DIFF
--- a/frontend/src/pages/battlePage/components/modals/TeamChangeModal.tsx
+++ b/frontend/src/pages/battlePage/components/modals/TeamChangeModal.tsx
@@ -5,8 +5,8 @@ import TimerIcon from '@/assets/icon/timer.svg?react';
 interface TeamChangeModalProps {
   aTeamCounts: number;
   bTeamCounts: number;
-  currentTeam : 'A' | 'B' | 'NONE'; 
-  remainingTime: number;
+  currentTeam: 'A' | 'B' | 'NONE';
+  remainingTime: string;
   noneTeamCounts: number;
   handleTeamChange: (team: 'A' | 'B' | 'NONE') => void;
   onClose: () => void;
@@ -40,7 +40,7 @@ export default function TeamChangeModal({
         <p className="text-[#99A1AF] text-[16px]">어느 팀을 지지하시나요?</p>
         <div className="text-[#FF8904] text-[24px] font-bold my-2 flex items-center">
           <TimerIcon className="w-[24px] h-[24px] mr-2" />
-          <span>0:{remainingTime}</span>
+          <span>{remainingTime}</span>
         </div>
         <div className="flex gap-4">
           <button

--- a/frontend/src/pages/battlePage/hooks/useBattleTimer.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTimer.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react';
+
+interface UseBattleTimerProps {
+  expiredAt?: number;
+}
+
+export function useBattleTimer({ expiredAt }: UseBattleTimerProps) {
+  const [remainingTime, setRemainingTime] = useState<number>(0);
+
+  useEffect(() => {
+    if (!expiredAt) return;
+
+    const updateRemainingTime = () => {
+      const now = Date.now();
+      const remaining = Math.max(0, expiredAt - now);
+      setRemainingTime(Math.floor(remaining / 1000));
+    };
+
+    updateRemainingTime();
+    const interval = setInterval(updateRemainingTime, 1000);
+
+    return () => clearInterval(interval);
+  }, [expiredAt]);
+
+  const formatTime = (seconds: number): string => {
+    const minutes = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${minutes}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  return {
+    remainingTime,
+    formattedTime: formatTime(remainingTime)
+  };
+}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -240,7 +240,7 @@ export default function BattlePage() {
           aTeamCounts={10}
           bTeamCounts={8}
           noneTeamCounts={2}
-          remainingTime={30}
+          remainingTime={formattedTime}
           currentTeam={selectedTeam}
           handleTeamChange={handleTeamChange}
           onClose={closeTeamChangeModal}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -42,9 +42,87 @@ export default function BattlePage() {
     }
   }, [battleProgress?.phase, openTeamChangeModal]);
 
-  const getTotalVotes = () => {
-    return objections.reduce((sum, obj) => sum + obj.votes, 0);
-  };
+  // 투표 결과 업데이트 수신
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleVoteUpdate = (data: { discussionId: string; upvotes: number; votes: string[] }) => {
+      setObjections((prev) => {
+        const updated = prev.map((obj) => {
+          const isTarget = String(obj.id) === data.discussionId;
+          return isTarget ? { ...obj, votes: data.upvotes, hasVoted: data.votes.includes('abc') } : obj;
+        });
+        const totalVotes = updated.reduce((sum, obj) => sum + obj.votes, 0);
+        return updated.map((obj) => ({ ...obj, totalVotes }));
+      });
+    };
+
+    // 다른 사람이 제출한 이의제기/반론 수신
+    const handleNewAttack = (data: {
+      discussionId: string;
+      authorId: string;
+      content: string;
+      upvotes: number;
+      votes: string[];
+    }) => {
+      setObjections((prev) => {
+        const totalVotes = prev.reduce((sum, obj) => sum + obj.votes, 0);
+
+        if (selectedTeam === 'NONE') {
+          return prev;
+        }
+        const newObjection: Objection = {
+          id: data.discussionId as unknown as number,
+          user: data.authorId === 'abc' ? 'You' : `User-${data.authorId.slice(0, 4)}`,
+          team: selectedTeam,
+          content: data.content,
+          votes: data.upvotes,
+          totalVotes,
+          hasVoted: data.votes.includes('abc')
+        };
+
+        return [...prev, newObjection];
+      });
+    };
+
+    const handleNewDefense = (data: {
+      discussionId: string;
+      authorId: string;
+      content: string;
+      upvotes: number;
+      votes: string[];
+    }) => {
+      setObjections((prev) => {
+        if (selectedTeam === 'NONE') {
+          return prev;
+        }
+        const totalVotes = prev.reduce((sum, obj) => sum + obj.votes, 0);
+        const newObjection: Objection = {
+          id: data.discussionId as unknown as number,
+          user: data.authorId === 'abc' ? 'You' : `User-${data.authorId.slice(0, 4)}`,
+          team: selectedTeam,
+          content: data.content,
+          votes: data.upvotes,
+          totalVotes,
+          hasVoted: data.votes.includes('abc')
+        };
+
+        return [...prev, newObjection];
+      });
+    };
+
+    socket.on('Battle:AttackVoteUpdate', handleVoteUpdate);
+    socket.on('Battle:DefenseVoteUpdate', handleVoteUpdate);
+    socket.on('Battle:NewAttack', handleNewAttack);
+    socket.on('Battle:NewDefense', handleNewDefense);
+
+    return () => {
+      socket.off('Battle:AttackVoteUpdate', handleVoteUpdate);
+      socket.off('Battle:DefenseVoteUpdate', handleVoteUpdate);
+      socket.off('Battle:NewAttack', handleNewAttack);
+      socket.off('Battle:NewDefense', handleNewDefense);
+    };
+  }, [socket, selectedTeam]);
 
   const handleVote = (objectionId: number) => {
     if (!socket || selectedTeam === 'NONE') return;
@@ -94,17 +172,8 @@ export default function BattlePage() {
       team: selectedTeam
     });
 
-    const newObjection: Objection = {
-      id: Date.now(),
-      user: 'You',
-      team: selectedTeam,
-      content,
-      votes: 0,
-      totalVotes: getTotalVotes(),
-      hasVoted: false
-    };
-
-    setObjections((prev) => [...prev, newObjection]);
+    // 서버에서 Battle:NewAttack/NewDefense로 받을 예정이므로 여기서는 optimistic update 제거
+    // 중복 추가 방지
   };
 
   //@Todo 초기 이의제기/반론 목록 로드 소켓 로직 추가 필요

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -23,24 +23,50 @@ export default function BattlePage() {
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const [objections, setObjections] = useState<Objection[]>([]);
+  const [remainingTime, setRemainingTime] = useState<number>(0);
   const {
     isOpen: isTeamChangeModalOpen,
     openModal: openTeamChangeModal,
     closeModal: closeTeamChangeModal
   } = useModal(false);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { socket, currentStage, battleProgress, isConnected } = useBattleSocket({
+  const { socket, currentStage, battleProgress } = useBattleSocket({
     battleId: id || '1',
     userId: 'abc',
     team: selectedTeam
   });
 
   useEffect(() => {
+    if (!battleProgress?.expiredAt) return;
+
+    const updateRemainingTime = () => {
+      const now = Date.now();
+      const remaining = Math.max(0, battleProgress.expiredAt - now);
+      setRemainingTime(Math.floor(remaining / 1000));
+    };
+
+    updateRemainingTime();
+    const interval = setInterval(updateRemainingTime, 1000);
+
+    return () => clearInterval(interval);
+  }, [battleProgress?.expiredAt]);
+
+  const formatTime = (seconds: number): string => {
+    const minutes = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${minutes}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  useEffect(() => {
     if (battleProgress?.phase === 'TEAM_SWITCH') {
       openTeamChangeModal();
     }
   }, [battleProgress?.phase, openTeamChangeModal]);
+
+  // 턴 변경 시 투표 리스트 초기화
+  useEffect(() => {
+    setObjections([]);
+  }, [battleProgress?.turn?.status, battleProgress?.phase]);
 
   // 투표 결과 업데이트 수신
   useEffect(() => {
@@ -190,7 +216,7 @@ export default function BattlePage() {
           title="배열에서 중복 제거하기"
           description="배열에서 중복된 요소를 제거하는 최적의 방법은?"
           status={currentStage || 'END'}
-          timer="0:02"
+          timer={formatTime(remainingTime)}
           teamACounts={1}
           teamBCounts={1}
           teamNoneCounts={0}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -8,6 +8,7 @@ import ObjectionInput from './components/objection/ObjectionInput';
 import ObjectionVote, { type Objection } from './components/objection/ObjectionVote';
 import TimelineSection from './components/timeline/TimelineSection';
 import { useBattleSocket } from './hooks/useBattleSocket';
+import { getObjectionConfig, isInputDisabled } from './utils/battlePhase';
 import useModal from '@/commons/hooks/useModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
 
@@ -46,6 +47,21 @@ export default function BattlePage() {
   };
 
   const handleVote = (objectionId: number) => {
+    if (!socket || selectedTeam === 'NONE') return;
+
+    const targetObjection = objections.find((obj) => obj.id === objectionId);
+    if (targetObjection?.hasVoted) return;
+
+    const { isAttacking } = getObjectionConfig(selectedTeam, battleProgress?.phase);
+    const eventName = isAttacking ? 'Battle:AttackVote' : 'Battle:DefenseVote';
+
+    socket.emit(eventName, {
+      battleId: id || '1',
+      discussionId: String(objectionId),
+      userId: 'abc', // TODO: 실제 userId로 교체 필요
+      team: selectedTeam
+    });
+
     setObjections((prev) => {
       const updated = prev.map((obj) => {
         if (obj.id === objectionId) {
@@ -59,11 +75,25 @@ export default function BattlePage() {
       const totalVotes = updated.reduce((sum, obj) => sum + obj.votes, 0);
       return updated.map((obj) => ({ ...obj, totalVotes }));
     });
-    // @ Todo 소켓으로 투표 정보 전송 로직 추가 필요
   };
 
   const handleObjectionSubmit = (content: string) => {
-    if (selectedTeam === 'NONE') return;
+    if (selectedTeam === 'NONE' || !socket) return;
+
+    const { isAttacking } = getObjectionConfig(selectedTeam, battleProgress?.phase);
+    const canSubmit = !isInputDisabled(selectedTeam, battleProgress?.phase, battleProgress?.turn?.status);
+
+    if (!canSubmit) {
+      return;
+    }
+
+    socket.emit(isAttacking ? 'Battle:Attack' : 'Battle:Defense', {
+      battleId: id || '1',
+      authorId: 'abc', // TODO: 실제 userId로 교체 필요
+      content,
+      team: selectedTeam
+    });
+
     const newObjection: Objection = {
       id: Date.now(),
       user: 'You',
@@ -75,7 +105,6 @@ export default function BattlePage() {
     };
 
     setObjections((prev) => [...prev, newObjection]);
-    // @ Todo 소켓으로 이의제기 정보 전송 로직 추가 필요
   };
 
   //@Todo 초기 이의제기/반론 목록 로드 소켓 로직 추가 필요

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -23,6 +23,7 @@ export default function BattlePage() {
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const [objections, setObjections] = useState<Objection[]>([]);
+  const [remainingTime, setRemainingTime] = useState<number>(0);
   const {
     isOpen: isTeamChangeModalOpen,
     openModal: openTeamChangeModal,
@@ -34,6 +35,27 @@ export default function BattlePage() {
     userId: 'abc',
     team: selectedTeam
   });
+
+  useEffect(() => {
+    if (!battleProgress?.expiredAt) return;
+
+    const updateRemainingTime = () => {
+      const now = Date.now();
+      const remaining = Math.max(0, battleProgress.expiredAt - now);
+      setRemainingTime(Math.floor(remaining / 1000));
+    };
+
+    updateRemainingTime();
+    const interval = setInterval(updateRemainingTime, 1000);
+
+    return () => clearInterval(interval);
+  }, [battleProgress?.expiredAt]);
+
+  const formatTime = (seconds: number): string => {
+    const minutes = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${minutes}:${secs.toString().padStart(2, '0')}`;
+  };
 
   useEffect(() => {
     if (battleProgress?.phase === 'TEAM_SWITCH') {
@@ -194,7 +216,7 @@ export default function BattlePage() {
           title="배열에서 중복 제거하기"
           description="배열에서 중복된 요소를 제거하는 최적의 방법은?"
           status={currentStage || 'END'}
-          timer="0:02"
+          timer={formatTime(remainingTime)}
           teamACounts={1}
           teamBCounts={1}
           teamNoneCounts={0}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -8,6 +8,7 @@ import ObjectionInput from './components/objection/ObjectionInput';
 import ObjectionVote, { type Objection } from './components/objection/ObjectionVote';
 import TimelineSection from './components/timeline/TimelineSection';
 import { useBattleSocket } from './hooks/useBattleSocket';
+import { useBattleTimer } from './hooks/useBattleTimer';
 import { getObjectionConfig, isInputDisabled } from './utils/battlePhase';
 import useModal from '@/commons/hooks/useModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
@@ -23,7 +24,6 @@ export default function BattlePage() {
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const [objections, setObjections] = useState<Objection[]>([]);
-  const [remainingTime, setRemainingTime] = useState<number>(0);
   const {
     isOpen: isTeamChangeModalOpen,
     openModal: openTeamChangeModal,
@@ -36,26 +36,9 @@ export default function BattlePage() {
     team: selectedTeam
   });
 
-  useEffect(() => {
-    if (!battleProgress?.expiredAt) return;
-
-    const updateRemainingTime = () => {
-      const now = Date.now();
-      const remaining = Math.max(0, battleProgress.expiredAt - now);
-      setRemainingTime(Math.floor(remaining / 1000));
-    };
-
-    updateRemainingTime();
-    const interval = setInterval(updateRemainingTime, 1000);
-
-    return () => clearInterval(interval);
-  }, [battleProgress?.expiredAt]);
-
-  const formatTime = (seconds: number): string => {
-    const minutes = Math.floor(seconds / 60);
-    const secs = seconds % 60;
-    return `${minutes}:${secs.toString().padStart(2, '0')}`;
-  };
+  const { formattedTime } = useBattleTimer({
+    expiredAt: battleProgress?.expiredAt
+  });
 
   useEffect(() => {
     if (battleProgress?.phase === 'TEAM_SWITCH') {
@@ -216,7 +199,7 @@ export default function BattlePage() {
           title="배열에서 중복 제거하기"
           description="배열에서 중복된 요소를 제거하는 최적의 방법은?"
           status={currentStage || 'END'}
-          timer={formatTime(remainingTime)}
+          timer={formattedTime}
           teamACounts={1}
           teamBCounts={1}
           teamNoneCounts={0}


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #73

## ✅ 작업 내용
실시간 타이머를 구현하여 배틀 페이지 헤더에 현재 턴의 남은 시간 표시 및 TeamChangeModal에도 타이머 적용하여 팀 선택 제한 시간 표시 한다 

### 💡개선 사항

#### 실시간 카운트다운 타이머 구현

- 배틀 페이지 헤더에 현재 턴의 남은 시간을 1초 단위로 최신화 하는 로직을 추가했습니다. 
- TeamChangeModal에도 타이머 적용하여 팀 선택 제한 시간을  1초 단위로 최신화 하는 로직을 추가했습니다. 

####  실시간 타이머 기능을 하는 `useBattleTimer` 커스텀 훅

`useBattleTimer` 커스텀 훅으로 타이머 로직 분리 했습니다. 
턴 관련 소켓 이벤트 response 값인 `expiredAt` 기반으로 카운트다운 계산하여 포멧팅 값을 반환하는 로직을 구현했습니다.

<br />

## 구현 내용 
### 배틀 페이지 헤더 현재 턴 남은 시간 UI에 실시간 타이머 적용 부분
![20251219-0125-10 8314514](https://github.com/user-attachments/assets/5413e2d8-538d-4a4e-a3e0-93e374d5387c)

### 진영 변경 모달에 실시간 타이머 적용한 부분


## 💬 질문사항 (고민했던 부분)
- 현재는 빠른 프로토타입 구현을 위해 클라이언트상 기능 구현을 위주로 구현해서 백엔드와 정확한 sync가 맞지 않을거라 생각됩니다. 추후에 서버와 정확한 sync를 맞출 수 있는 로직을 고려해봐야겠네요
