### PR TITLE
[Hotfix] battle:joined 브로드 캐스팅 제거

### DIFF
--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -68,8 +68,8 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
       client.emit('battle:joined', { ...res })
 
-      client.to(battleRoomId).emit('battle:joined', { ...res, participantId: client.id })
-      client.to(battleTeamRoom).emit('battle:joined', { ...res, participantId: client.id })
+      // client.to(battleRoomId).emit('battle:joined', { ...res, participantId: client.id })
+      // client.to(battleTeamRoom).emit('battle:joined', { ...res, participantId: client.id })
     } catch (error) {
       if (error instanceof Error) {
         client.emit('battle:join:error', {

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -362,11 +362,7 @@ export class BattlesService extends EventEmitter {
       this.emit('battle:phase:update', res)
     }
 
-    if (
-      state.turn?.status &&
-      !(prevPhase === BATTLE_PHASE.OPINION_SHARE.name && nextPhase === BATTLE_PHASE.TEAM_A_ATTACK) &&
-      prevTurn !== state.turn.status
-    ) {
+    if (state.turn?.status && prevTurn !== state.turn.status) {
       const res = BattleTurnResponseDto.of({
         battleId,
         turn: state.turn,


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

## ✅ 작업 내용

- 클라이언트 배틀 참여 시에 모든 참여자에게 브로드캐스팅 시, 채팅 중복 현상 발생
- `battle:joined` 시 참여 클라이언트에게만 전달
- 전체 배틀 업데이트는 추후 이벤트 분리 필요

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
