### PR TITLE
[Feature] 투표 업데이트 구현

### DIFF
--- a/backend/src/battles/dto/discussionVoteResponse.dto.ts
+++ b/backend/src/battles/dto/discussionVoteResponse.dto.ts
@@ -1,24 +1,16 @@
 import { BattleDiscussion } from '../types/battles.types'
 
 export class DiscussionVoteResponseDto {
-  battleId: string
-  attackId?: string
-  defenseId?: string
-  count: number
+  discussionId: string
+  upvotes: number
+  votes: string[]
 
   static fromEntity(battleId: string, discussion: BattleDiscussion): DiscussionVoteResponseDto {
     const dto = new DiscussionVoteResponseDto()
 
-    dto.battleId = battleId
-    dto.count = discussion.upvotes
-
-    if (discussion.type === 'ATTACK') {
-      dto.attackId = discussion.discussionId
-    }
-
-    if (discussion.type === 'DEFENSE') {
-      dto.defenseId = discussion.discussionId
-    }
+    dto.discussionId = discussion.discussionId
+    dto.upvotes = discussion.upvotes
+    dto.votes = [...discussion.votes]
 
     return dto
   }

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -113,34 +113,40 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     }
   }
 
-  @SubscribeMessage('battle:attackvote')
+  @SubscribeMessage('Battle:AttackVote')
   handleAttackVote(@MessageBody() dto: AttackVoteRequestDto, @ConnectedSocket() client: Socket) {
     try {
       const { battleId, discussionId, userId, team } = dto
-      const attack = this.battlesService.handleAttackVote(battleId, discussionId, { userId, team })
+      const updates = this.battlesService.handleAttackVote(battleId, discussionId, { userId, team })
       const teamRoom = this.battlesService.getBattleRoomId(battleId, team)
 
-      this.server.to(teamRoom).emit('battle:attackvote:update', attack)
+      // 모든 변경된 항목(기존 투표 취소 + 새 투표)을 전송
+      updates.forEach(update => {
+        this.server.to(teamRoom).emit('Battle:AttackVoteUpdate', update)
+      })
     } catch (error) {
       if (error instanceof Error) {
-        client.emit('battle:attackvote:error', {
+        client.emit('Battle:AttackVote:Error', {
           message: error.message,
         })
       }
     }
   }
 
-  @SubscribeMessage('battle:defensevote')
+  @SubscribeMessage('Battle:DefenseVote')
   handleDefenseVote(@MessageBody() dto: DefenseVoteRequestDto, @ConnectedSocket() client: Socket) {
     try {
       const { battleId, discussionId, userId, team } = dto
-      const defense = this.battlesService.handleDefenseVote(battleId, discussionId, { userId, team })
+      const updates = this.battlesService.handleDefenseVote(battleId, discussionId, { userId, team })
       const teamRoom = this.battlesService.getBattleRoomId(battleId, team)
 
-      this.server.to(teamRoom).emit('battle:defensevote:update', defense)
+      // 모든 변경된 항목(기존 투표 취소 + 새 투표)을 전송
+      updates.forEach(update => {
+        this.server.to(teamRoom).emit('Battle:DefenseVoteUpdate', update)
+      })
     } catch (error) {
       if (error instanceof Error) {
-        client.emit('battle:defensevote:error', {
+        client.emit('Battle:DefenseVote:Error', {
           message: error.message,
         })
       }

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -113,7 +113,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     }
   }
 
-  @SubscribeMessage('Battle:AttackVote')
+  @SubscribeMessage('battle:attackvote')
   handleAttackVote(@MessageBody() dto: AttackVoteRequestDto, @ConnectedSocket() client: Socket) {
     try {
       const { battleId, discussionId, userId, team } = dto
@@ -122,18 +122,18 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
       // 모든 변경된 항목(기존 투표 취소 + 새 투표)을 전송
       updates.forEach(update => {
-        this.server.to(teamRoom).emit('Battle:AttackVoteUpdate', update)
+        this.server.to(teamRoom).emit('battle:attackvote:update', update)
       })
     } catch (error) {
       if (error instanceof Error) {
-        client.emit('Battle:AttackVote:Error', {
+        client.emit('battle:attackvote:error', {
           message: error.message,
         })
       }
     }
   }
 
-  @SubscribeMessage('Battle:DefenseVote')
+  @SubscribeMessage('battle:defensevote')
   handleDefenseVote(@MessageBody() dto: DefenseVoteRequestDto, @ConnectedSocket() client: Socket) {
     try {
       const { battleId, discussionId, userId, team } = dto
@@ -142,11 +142,11 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
       // 모든 변경된 항목(기존 투표 취소 + 새 투표)을 전송
       updates.forEach(update => {
-        this.server.to(teamRoom).emit('Battle:DefenseVoteUpdate', update)
+        this.server.to(teamRoom).emit('battle:defensevote:update', update)
       })
     } catch (error) {
       if (error instanceof Error) {
-        client.emit('Battle:DefenseVote:Error', {
+        client.emit('battle:defensevote:error', {
           message: error.message,
         })
       }

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -453,6 +453,7 @@ export class BattlesService extends EventEmitter {
     switch (state.turn.status) {
       case BATTLE_TURN.A_ATTACK.name: {
         this.emitAttackedResult(state.battleId, BATTLE_TEAM.A)
+        this.resetDiscussionsByTurn(state.battleId)
 
         state.turn.status = BATTLE_TURN.B_DEFENSE.name
         state.expiredAt = now + BATTLE_TURN.B_DEFENSE.time
@@ -461,6 +462,7 @@ export class BattlesService extends EventEmitter {
 
       case BATTLE_TURN.B_DEFENSE.name: {
         this.emitDefensedResult(state.battleId, BATTLE_TEAM.B)
+        this.resetDiscussionsByTurn(state.battleId)
 
         if (state.turn.count < 2) {
           state.turn.status = BATTLE_TURN.A_ATTACK.name
@@ -477,6 +479,7 @@ export class BattlesService extends EventEmitter {
 
       case BATTLE_TURN.B_ATTACK.name: {
         this.emitAttackedResult(state.battleId, BATTLE_TEAM.B)
+        this.resetDiscussionsByTurn(state.battleId)
 
         state.turn.status = BATTLE_TURN.A_DEFENSE.name
         state.expiredAt = now + BATTLE_TURN.A_DEFENSE.time
@@ -485,6 +488,7 @@ export class BattlesService extends EventEmitter {
 
       case BATTLE_TURN.A_DEFENSE.name: {
         this.emitDefensedResult(state.battleId, BATTLE_TEAM.A)
+        this.resetDiscussionsByTurn(state.battleId)
 
         if (state.turn.count < 2) {
           state.turn.status = BATTLE_TURN.B_ATTACK.name
@@ -805,6 +809,36 @@ export class BattlesService extends EventEmitter {
       votes: discussion.votes.filter(id => id !== userId),
       upvotes: discussion.upvotes - 1,
     }
+  }
+
+  private resetDiscussionsByTurn(battleId: string) {
+    const battleState = this.getBattleState(battleId)
+
+    // 모든 공격 의견의 투표 기록 초기화
+    battleState.teamA.attacks = battleState.teamA.attacks.map(attack => ({
+      ...attack,
+      votes: [],
+      upvotes: 0,
+    }))
+
+    battleState.teamB.attacks = battleState.teamB.attacks.map(attack => ({
+      ...attack,
+      votes: [],
+      upvotes: 0,
+    }))
+
+    // 모든 반론 의견의 투표 기록 초기화
+    battleState.teamA.defenses = battleState.teamA.defenses.map(defense => ({
+      ...defense,
+      votes: [],
+      upvotes: 0,
+    }))
+
+    battleState.teamB.defenses = battleState.teamB.defenses.map(defense => ({
+      ...defense,
+      votes: [],
+      upvotes: 0,
+    }))
   }
 
   private scheduleNextTick(battleId: string) {

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -632,7 +632,7 @@ export class BattlesService extends EventEmitter {
     return false
   }
 
-  handleAttackVote(battleId: string, discussionId: string, data: { userId: string; team: BattleTeam }): DiscussionVoteResponseDto {
+  handleAttackVote(battleId: string, discussionId: string, data: { userId: string; team: BattleTeam }): DiscussionVoteResponseDto[] {
     //Todo: 턴 관리 pr 머지 후 턴 고려
     const { userId, team } = data
 
@@ -658,13 +658,26 @@ export class BattlesService extends EventEmitter {
       throw new BadRequestException('이미 투표한 항목입니다.')
     }
 
+    const updatedDiscussions: DiscussionVoteResponseDto[] = []
+
+    // 다른 항목에 투표한 기록이 있으면 취소
+    discussions.forEach((discussion, i) => {
+      if (i !== idx && this.hasAlreadyVoted(discussion.votes, userId)) {
+        const canceled = this.removeVote(discussion, userId)
+        discussions[i] = canceled
+        updatedDiscussions.push(DiscussionVoteResponseDto.of(battleId, canceled))
+      }
+    })
+
+    // 새 항목에 투표 적용
     const updated = this.applyVote(target, userId)
     discussions[idx] = updated
+    updatedDiscussions.push(DiscussionVoteResponseDto.of(battleId, updated))
 
-    return DiscussionVoteResponseDto.of(battleId, updated)
+    return updatedDiscussions
   }
 
-  handleDefenseVote(battleId: string, discussionId: string, data: { userId: string; team: BattleTeam }): DiscussionVoteResponseDto {
+  handleDefenseVote(battleId: string, discussionId: string, data: { userId: string; team: BattleTeam }): DiscussionVoteResponseDto[] {
     const { userId, team } = data
 
     if (team === BATTLE_TEAM.NONE) {
@@ -689,10 +702,23 @@ export class BattlesService extends EventEmitter {
       throw new BadRequestException('이미 투표한 항목입니다.')
     }
 
+    const updatedDiscussions: DiscussionVoteResponseDto[] = []
+
+    // 다른 항목에 투표한 기록이 있으면 취소
+    discussions.forEach((discussion, i) => {
+      if (i !== idx && this.hasAlreadyVoted(discussion.votes, userId)) {
+        const canceled = this.removeVote(discussion, userId)
+        discussions[i] = canceled
+        updatedDiscussions.push(DiscussionVoteResponseDto.of(battleId, canceled))
+      }
+    })
+
+    // 새 항목에 투표 적용
     const updated = this.applyVote(target, userId)
     discussions[idx] = updated
+    updatedDiscussions.push(DiscussionVoteResponseDto.of(battleId, updated))
 
-    return DiscussionVoteResponseDto.of(battleId, updated)
+    return updatedDiscussions
   }
 
   //turn 끝나면 최고 득표한 이의제기 항목 선정 후 이벤트 발행
@@ -770,6 +796,14 @@ export class BattlesService extends EventEmitter {
       ...discussion,
       votes: [...discussion.votes, userId],
       upvotes: discussion.upvotes + 1,
+    }
+  }
+
+  private removeVote<T extends { votes: string[]; upvotes: number }>(discussion: T, userId: string): T {
+    return {
+      ...discussion,
+      votes: discussion.votes.filter(id => id !== userId),
+      upvotes: discussion.upvotes - 1,
     }
   }
 

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -131,14 +131,14 @@ export default function BattlePage() {
       });
     };
 
-    socket.on('Battle:AttackVoteUpdate', handleVoteUpdate);
-    socket.on('Battle:DefenseVoteUpdate', handleVoteUpdate);
+    socket.on('battle:attackvote:update', handleVoteUpdate);
+    socket.on('battle:defensevote:update', handleVoteUpdate);
     socket.on('Battle:NewAttack', handleNewAttack);
     socket.on('Battle:NewDefense', handleNewDefense);
 
     return () => {
-      socket.off('Battle:AttackVoteUpdate', handleVoteUpdate);
-      socket.off('Battle:DefenseVoteUpdate', handleVoteUpdate);
+      socket.off('battle:attackvote:update', handleVoteUpdate);
+      socket.off('battle:defensevote:update', handleVoteUpdate);
       socket.off('Battle:NewAttack', handleNewAttack);
       socket.off('Battle:NewDefense', handleNewDefense);
     };
@@ -151,7 +151,7 @@ export default function BattlePage() {
     if (targetObjection?.hasVoted) return;
 
     const { isAttacking } = getObjectionConfig(selectedTeam, battleProgress?.phase);
-    const eventName = isAttacking ? 'Battle:AttackVote' : 'Battle:DefenseVote';
+    const eventName = isAttacking ? 'battle:attackvote' : 'battle:defensevote';
 
     socket.emit(eventName, {
       battleId: id || '1',

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -30,10 +30,20 @@ export default function BattlePage() {
     closeModal: closeTeamChangeModal
   } = useModal(false);
 
+  // 각 탭/브라우저별 고유 userId 생성 (테스트용)
+  const [userId] = useState(() => {
+    let id = sessionStorage.getItem('testUserId');
+    if (!id) {
+      id = `user-${Math.random().toString(36).substr(2, 9)}`;
+      sessionStorage.setItem('testUserId', id);
+    }
+    return id;
+  });
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { socket, currentStage, battleProgress, isConnected, battleData } = useBattleSocket({
     battleId: id || '1',
-    userId: 'abc',
+    userId,
     team: selectedTeam
   });
 
@@ -60,7 +70,7 @@ export default function BattlePage() {
       setObjections((prev) => {
         const updated = prev.map((obj) => {
           const isTarget = String(obj.id) === data.discussionId;
-          return isTarget ? { ...obj, votes: data.upvotes, hasVoted: data.votes.includes('abc') } : obj;
+          return isTarget ? { ...obj, votes: data.upvotes, hasVoted: data.votes.includes(userId) } : obj;
         });
         const totalVotes = updated.reduce((sum, obj) => sum + obj.votes, 0);
         return updated.map((obj) => ({ ...obj, totalVotes }));
@@ -132,7 +142,7 @@ export default function BattlePage() {
       socket.off('Battle:NewAttack', handleNewAttack);
       socket.off('Battle:NewDefense', handleNewDefense);
     };
-  }, [socket, selectedTeam]);
+  }, [socket, selectedTeam, userId]);
 
   const handleVote = (objectionId: number) => {
     if (!socket || selectedTeam === 'NONE') return;
@@ -146,7 +156,7 @@ export default function BattlePage() {
     socket.emit(eventName, {
       battleId: id || '1',
       discussionId: String(objectionId),
-      userId: 'abc', // TODO: 실제 userId로 교체 필요
+      userId,
       team: selectedTeam
     });
 


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #78

## ✅ 작업 내용

### 💡개선 사항

#### 1. 투표 변경 시 이전 투표 자동 취소 기능 구현
- 사용자가 다른 의견에 투표하면 기존 투표가 자동으로 취소되고 새 투표가 적용됩니다
- Service 레이어에서 투표 변경 시 이전 투표를 찾아 취소한 후 새 투표를 적용합니다
- 취소된 투표와 새 투표 정보를 배열로 반환하여 모든 변경사항을 클라이언트에 전달합니다

#### 2. 투표 변경 실시간 동기화
- 투표 변경 시 같은 팀의 모든 사용자에게 실시간으로 업데이트를 브로드캐스트합니다
- Gateway에서 DTO 배열을 순회하며 각 변경사항(취소+신규)을 개별적으로 emit합니다
- 프론트엔드는 기존 핸들러로 두 개의 업데이트를 처리합니다

#### 3. WebSocket 이벤트명 소문자 통일
- 백엔드와 프론트엔드의 WebSocket 이벤트명을 모두 소문자로 통일했습니다
- 이벤트명: `battle:attackvote`, `battle:defensevote`, `battle:attackvote:update`, `battle:defensevote:update`

#### 4. 다중 사용자 테스트를 위한 세션별 userId 생성
- sessionStorage를 활용하여 각 브라우저 탭마다 고유한 userId를 생성합니다
- 같은 브라우저에서 여러 탭을 열어 다중 사용자 시나리오를 테스트할 수 있습니다

#### 5. 턴 전환 시 투표 기록 초기화
- 각 턴(공격/반론) 종료 시 모든 의견의 투표 기록을 초기화합니다
- `resetDiscussionsByTurn` 메서드를 구현하여 새로운 턴에서 사용자들이 새롭게 투표할 수 있도록 개선했습니다
- 공격 턴→반론 턴, 반론 턴→다음 공격 턴 전환 시마다 자동으로 호출됩니다

<br />

## 📸 참고 사항

### 주요 변경 파일
- `backend/src/battles/service/battles.service.ts`: 투표 변경 로직 및 턴별 초기화 로직 구현
- `backend/src/battles/gateway/battles.gateway.ts`: 배열 기반 브로드캐스팅 및 이벤트명 변경
- `backend/src/battles/dto/discussionVoteResponse.dto.ts`: DTO 구조 변경 (battleId 제거, discussionId/upvotes/votes 포함)
- `frontend/src/pages/battlePage/index.tsx`: sessionStorage 기반 userId 생성 및 이벤트명 변경

### 핵심 구현 내용
1. **Service 레이어 (`handleAttackVote`, `handleDefenseVote`)**:
   - 반환 타입을 `DiscussionVoteResponseDto[]`로 변경
   - 투표 전 해당 사용자의 기존 투표를 찾아 `removeVote()` 호출
   - 취소된 투표 DTO와 새 투표 DTO를 배열에 담아 반환

2. **Helper 메서드**:
   - `removeVote()`: 특정 사용자의 투표를 제거하고 upvotes 감소
   - `applyVote()`: 특정 사용자의 투표를 추가하고 upvotes 증가
   - `hasAlreadyVoted()`: 사용자가 이미 투표했는지 확인
   - `resetDiscussionsByTurn()`: 턴 전환 시 모든 투표 기록 초기화

3. **Gateway 레이어**:
   - 배열로 받은 DTO들을 `forEach`로 순회하며 각각 emit
   - 프론트엔드 변경 없이 기존 핸들러로 처리 가능

<br />

## 💬 질문사항 (고민했던 부분)

### 1. 단일 DTO에서 배열 DTO로 변경한 이유
- 투표 변경 시 이전 투표 취소와 새 투표 적용이라는 **두 가지 상태 변화**가 발생합니다
- 각 변경사항을 개별 이벤트로 브로드캐스트하여 모든 사용자가 일관된 상태를 유지할 수 있도록 했습니다
- 프론트엔드는 기존 핸들러를 그대로 사용하여 두 개의 업데이트를 순차적으로 처리합니다

### 2. 턴 전환 시 투표 초기화 타이밍
- `emitAttackedResult` / `emitDefensedResult` 직후에 `resetDiscussionsByTurn`을 호출합니다
- 최고 득표 의견을 선정한 후 투표 기록을 초기화하여 다음 턴에서 새롭게 투표할 수 있도록 했습니다