### PR TITLE
[Feature] 최종 이의제기/ 반론 투표 결과에 따른 이펙트 UI 구현

### DIFF
--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -80,3 +80,27 @@ export interface BattleProgressState {
   startedAt: number;
   expiredAt: number;
 }
+
+// Battle:Attacked 이벤트 응답 타입
+export interface BattleAttackedResult {
+  battleId: string;
+  attack: {
+    discussionId: string;
+    authorId: string;
+    type: string;
+    content: string;
+    upvotes: number;
+  };
+}
+
+// Battle:Defensed 이벤트 응답 타입
+export interface BattleDefensedResult {
+  battleId: string;
+  defense: {
+    discussionId: string;
+    authorId: string;
+    type: string;
+    content: string;
+    upvotes: number;
+  };
+}

--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -104,3 +104,6 @@ export interface BattleDefensedResult {
     upvotes: number;
   };
 }
+
+// 이펙트 타입
+export type BattleEffectType = 'OBJECTION' | 'REVERSAL' | 'SURRENDER';

--- a/frontend/src/pages/battlePage/components/effects/ObjectionModal.tsx
+++ b/frontend/src/pages/battlePage/components/effects/ObjectionModal.tsx
@@ -4,6 +4,7 @@ interface ObjectionModalProps {
   isOpen: boolean;
   team: 'A' | 'B';
   content: string;
+  type: 'attack' | 'defense';
   onClose: () => void;
 }
 
@@ -24,7 +25,7 @@ const ANIMATION_DURATION = {
   HIDE: 300
 } as const;
 
-export default function ObjectionModal({ isOpen, team, content, onClose }: ObjectionModalProps) {
+export default function ObjectionModal({ isOpen, team, content, type, onClose }: ObjectionModalProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
 
@@ -73,7 +74,9 @@ export default function ObjectionModal({ isOpen, team, content, onClose }: Objec
           <div
             className={`px-6 py-2 rounded-full bg-gradient-to-r ${gradient} shadow-lg ${glow} transition-all duration-500 ${badgeClass}`}
           >
-            <span className="text-white font-bold text-lg tracking-wider">{team}팀 이의제기</span>
+            <span className="text-white font-bold text-lg tracking-wider">
+              {team}팀 {type === 'attack' ? '이의제기' : '반론'}
+            </span>
           </div>
 
           <div className={`relative transition-all duration-700 delay-200 ${textClass}`}>
@@ -84,7 +87,7 @@ export default function ObjectionModal({ isOpen, team, content, onClose }: Objec
                 textShadow: '0 0 40px rgba(255, 255, 255, 0.5), 0 0 80px rgba(255, 255, 255, 0.3)'
               }}
             >
-              이의 있음!!
+              {type === 'attack' ? '이의 있음!!' : '반론!!'}
             </h1>
           </div>
 

--- a/frontend/src/pages/battlePage/components/effects/ObjectionModal.tsx
+++ b/frontend/src/pages/battlePage/components/effects/ObjectionModal.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState, useCallback } from 'react';
+
+interface ObjectionModalProps {
+  isOpen: boolean;
+  team: 'A' | 'B';
+  content: string;
+  onClose: () => void;
+}
+
+const TEAM_STYLES = {
+  A: {
+    gradient: 'from-cyan-500 to-blue-500',
+    glow: 'shadow-cyan-500/50'
+  },
+  B: {
+    gradient: 'from-orange-500 to-red-500',
+    glow: 'shadow-orange-500/50'
+  }
+} as const;
+
+const ANIMATION_DURATION = {
+  SHOW: 50,
+  AUTO_CLOSE: 3000,
+  HIDE: 300
+} as const;
+
+export default function ObjectionModal({ isOpen, team, content, onClose }: ObjectionModalProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  const handleClose = useCallback(() => {
+    setIsAnimating(false);
+    setTimeout(() => {
+      setIsVisible(false);
+      onClose();
+    }, ANIMATION_DURATION.HIDE);
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    setIsVisible(true);
+    const showTimer = setTimeout(() => setIsAnimating(true), ANIMATION_DURATION.SHOW);
+    const closeTimer = setTimeout(handleClose, ANIMATION_DURATION.AUTO_CLOSE);
+
+    return () => {
+      clearTimeout(showTimer);
+      clearTimeout(closeTimer);
+    };
+  }, [isOpen, handleClose]);
+
+  if (!isVisible) return null;
+
+  const { gradient, glow } = TEAM_STYLES[team];
+  const animationClass = isAnimating ? 'opacity-100' : 'opacity-0';
+  const scaleClass = isAnimating ? 'scale-100 opacity-100' : 'scale-50 opacity-0';
+  const badgeClass = isAnimating ? 'translate-y-0 opacity-100' : '-translate-y-10 opacity-0';
+  const textClass = isAnimating ? 'scale-100' : 'scale-0';
+  const cardClass = isAnimating ? 'translate-y-0 opacity-100' : 'translate-y-10 opacity-0';
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm transition-opacity duration-300 ${animationClass}`}
+      onClick={handleClose}
+    >
+      <div
+        className={`relative flex flex-col items-center transition-all duration-500 ${scaleClass}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className={`absolute inset-0 blur-3xl bg-gradient-to-r ${gradient} opacity-30 animate-pulse`} />
+
+        <div className="relative z-10 flex flex-col items-center gap-8">
+          <div
+            className={`px-6 py-2 rounded-full bg-gradient-to-r ${gradient} shadow-lg ${glow} transition-all duration-500 ${badgeClass}`}
+          >
+            <span className="text-white font-bold text-lg tracking-wider">{team}팀 이의제기</span>
+          </div>
+
+          <div className={`relative transition-all duration-700 delay-200 ${textClass}`}>
+            <h1
+              className="text-8xl font-black text-transparent bg-clip-text bg-gradient-to-b from-white to-gray-300"
+              style={{
+                WebkitTextStroke: '3px rgba(255, 255, 255, 0.3)',
+                textShadow: '0 0 40px rgba(255, 255, 255, 0.5), 0 0 80px rgba(255, 255, 255, 0.3)'
+              }}
+            >
+              이의 있음!!
+            </h1>
+          </div>
+
+          <div
+            className={`max-w-2xl px-8 py-6 bg-gray-800/80 backdrop-blur-sm rounded-2xl border-2 border-gray-700 shadow-2xl transition-all duration-500 delay-400 ${cardClass}`}
+          >
+            <p className="text-gray-100 text-lg leading-relaxed">{content}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -1,6 +1,12 @@
 import { useEffect, useState, useRef } from 'react';
 import { io, Socket } from 'socket.io-client';
-import type { BattleJoinData, UseBattleSocketProps, BattleProgressState } from '@/commons/types/battle';
+import type {
+  BattleJoinData,
+  UseBattleSocketProps,
+  BattleProgressState,
+  BattleAttackedResult,
+  BattleDefensedResult
+} from '@/commons/types/battle';
 
 export function useBattleSocket({ battleId, userId, team, password }: UseBattleSocketProps) {
   const [battleData, setBattleData] = useState<BattleJoinData | null>(null);
@@ -83,6 +89,15 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
             }
           : null
       );
+    });
+
+    newSocket.on('battle:attacked', (data: BattleAttackedResult) => {
+      console.log('Battle:Attacked received:', data);
+    });
+
+    // Battle:Defensed 이벤트 구독 (방어 결과)
+    newSocket.on('battle:defensed', (data: BattleDefensedResult) => {
+      console.log('Battle:Defensed received:', data);
     });
 
     return () => {

--- a/frontend/src/pages/battlePage/hooks/useEffectModal.ts
+++ b/frontend/src/pages/battlePage/hooks/useEffectModal.ts
@@ -1,0 +1,38 @@
+import { useState, useCallback } from 'react';
+import type { Team } from '@/commons/types/battle';
+
+interface EffectModalState {
+  isOpen: boolean;
+  team: Team;
+  content: string;
+}
+
+export function useEffectModal() {
+  const [effectModal, setEffectModal] = useState<EffectModalState>({
+    isOpen: false,
+    team: 'A',
+    content: ''
+  });
+
+  const showEffect = useCallback((team: Team, content: string) => {
+    setEffectModal({
+      isOpen: true,
+      team,
+      content
+    });
+  }, []);
+
+  const hideEffect = useCallback(() => {
+    setEffectModal({
+      isOpen: false,
+      team: 'A',
+      content: ''
+    });
+  }, []);
+
+  return {
+    effectModal,
+    showEffect,
+    hideEffect
+  };
+}

--- a/frontend/src/pages/battlePage/hooks/useEffectModal.ts
+++ b/frontend/src/pages/battlePage/hooks/useEffectModal.ts
@@ -5,20 +5,23 @@ interface EffectModalState {
   isOpen: boolean;
   team: Team;
   content: string;
+  type: 'attack' | 'defense';
 }
 
 export function useEffectModal() {
   const [effectModal, setEffectModal] = useState<EffectModalState>({
     isOpen: false,
     team: 'A',
-    content: ''
+    content: '',
+    type: 'attack'
   });
 
-  const showEffect = useCallback((team: Team, content: string) => {
+  const showEffect = useCallback((team: Team, content: string, type: 'attack' | 'defense') => {
     setEffectModal({
       isOpen: true,
       team,
-      content
+      content,
+      type
     });
   }, []);
 
@@ -26,7 +29,8 @@ export function useEffectModal() {
     setEffectModal({
       isOpen: false,
       team: 'A',
-      content: ''
+      content: '',
+      type: 'attack'
     });
   }, []);
 

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useLoaderData, useLocation } from 'react-router-dom';
-import type { BattleInfo } from '@/commons/types/battle';
+import type { BattleInfo, BattleAttackedResult, BattleDefensedResult } from '@/commons/types/battle';
 import BattleHeader from './components/header/BattleHeader';
 import CodeSection from './components/codeview/CodeSection';
 import ChatSection from './components/chatting/ChatSection';
@@ -9,9 +9,11 @@ import ObjectionVote, { type Objection } from './components/objection/ObjectionV
 import TimelineSection from './components/timeline/TimelineSection';
 import { useBattleSocket } from './hooks/useBattleSocket';
 import { useBattleTimer } from './hooks/useBattleTimer';
+import { useEffectModal } from './hooks/useEffectModal';
 import { getObjectionConfig, isInputDisabled } from './utils/battlePhase';
 import useModal from '@/commons/hooks/useModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
+import ObjectionModal from './components/effects/ObjectionModal';
 
 type LocationState = {
   selectedTeam?: 'A' | 'B' | 'NONE';
@@ -24,6 +26,7 @@ export default function BattlePage() {
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const [objections, setObjections] = useState<Objection[]>([]);
+  const { effectModal, showEffect, hideEffect } = useEffectModal();
   const {
     isOpen: isTeamChangeModalOpen,
     openModal: openTeamChangeModal,
@@ -133,6 +136,27 @@ export default function BattlePage() {
       socket.off('Battle:NewDefense', handleNewDefense);
     };
   }, [socket, selectedTeam]);
+
+  // battle:attacked / battle:defensed 이벤트 처리
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleAttacked = (data: BattleAttackedResult) => {
+      const attackTeam = selectedTeam === 'A' ? 'B' : 'A';
+      showEffect(attackTeam, data.attack.content);
+    };
+    const handleDefensed = (data: BattleDefensedResult) => {
+      showEffect(selectedTeam, data.defense.content);
+    };
+
+    socket.on('battle:attacked', handleAttacked);
+    socket.on('battle:defensed', handleDefensed);
+
+    return () => {
+      socket.off('battle:attacked', handleAttacked);
+      socket.off('battle:defensed', handleDefensed);
+    };
+  }, [socket, selectedTeam, showEffect]);
 
   const handleVote = (objectionId: number) => {
     if (!socket || selectedTeam === 'NONE') return;
@@ -252,6 +276,15 @@ export default function BattlePage() {
           currentTeam={selectedTeam}
           handleTeamChange={handleTeamChange}
           onClose={closeTeamChangeModal}
+        />
+      )}
+
+      {effectModal.isOpen && effectModal.team !== 'NONE' && (
+        <ObjectionModal
+          isOpen={effectModal.isOpen}
+          team={effectModal.team}
+          content={effectModal.content}
+          onClose={hideEffect}
         />
       )}
     </div>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -143,10 +143,10 @@ export default function BattlePage() {
 
     const handleAttacked = (data: BattleAttackedResult) => {
       const attackTeam = selectedTeam === 'A' ? 'B' : 'A';
-      showEffect(attackTeam, data.attack.content);
+      showEffect(attackTeam, data.attack.content, 'attack');
     };
     const handleDefensed = (data: BattleDefensedResult) => {
-      showEffect(selectedTeam, data.defense.content);
+      showEffect(selectedTeam, data.defense.content, 'defense');
     };
 
     socket.on('battle:attacked', handleAttacked);
@@ -284,6 +284,7 @@ export default function BattlePage() {
           isOpen={effectModal.isOpen}
           team={effectModal.team}
           content={effectModal.content}
+          type={effectModal.type}
           onClose={hideEffect}
         />
       )}


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #24 

## ✅ 작업 내용
최종 이의제기/ 반론 투표 결과에 따른 이펙트 UI 구현

### 💡개선 사항
#### 투표 결과 확정 시 이펙트 모달 UI 구현

- **이벤트 수신 처리**
  - 공격 채택 결과 이벤트 수신 - `battle:attacked`  
  - 방어 채택 결과 수신 이벤트 - `battle:defensed` 
  - 현재 턴 상태(`battleProgress.turn.status`)로 팀 판단

#### 최종 이의제기/ 반론 투표 결과에 따른 이펙트 UI 구현
- 팀별 시각적 구분
  - A팀: Cyan/Blue 그라데이션 계열 적용
  - B팀: Orange/Red 그라데이션 계열 적용
- 동적 텍스트 렌더링
  - 공격 채택: "A팀 이의제기" 배지 + "이의 있음!!" 메인 텍스트
  - 방어 채택: "B팀 반론" 배지 + "반론!!" 메인 텍스트
- 다단계 애니메이션 연출
  - 배경 오버레이 페이드인 (300ms)
- 3초 후 자동 닫기 및 역방향 애니메이션 적용

#### 이펙트 전용 모달 관리 커스텀 훅 구현
 - 모달 상태(isOpen, team, content, type) 캡슐화
- `showEffect(team, content, type)`: 모달 표시 함수
- `hideEffect()`: 모달 숨김 함수
- `useCallback`으로 함수 메모이제이션하여 불필요한 리렌더링 방지

##### 구현체
```javascript
import { useState, useCallback } from 'react';
import type { Team } from '@/commons/types/battle';

interface EffectModalState {
  isOpen: boolean;
  team: Team;
  content: string;
  type: 'attack' | 'defense';
}

export function useEffectModal() {
  const [effectModal, setEffectModal] = useState<EffectModalState>({
    isOpen: false,
    team: 'A',
    content: '',
    type: 'attack'
  });

  const showEffect = useCallback((team: Team, content: string, type: 'attack' | 'defense') => {
    setEffectModal({
      isOpen: true,
      team,
      content,
      type
    });
  }, []);

  const hideEffect = useCallback(() => {
    setEffectModal({
      isOpen: false,
      team: 'A',
      content: '',
      type: 'attack'
    });
  }, []);

  return {
    effectModal,
    showEffect,
    hideEffect
  };
}
```
<br />

## 📸 참고 사항

### 주요 파일
- `frontend/src/pages/battlePage/components/effects/ObjectionModal.tsx` (신규)
- `frontend/src/pages/battlePage/hooks/useEffectModal.ts` (신규)
- `frontend/src/pages/battlePage/index.tsx` (이벤트 수신 로직 추가)
