### PR TITLE
[Hotfix] 턴 전환 시 항목 배열 초기화

### DIFF
--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -814,31 +814,10 @@ export class BattlesService extends EventEmitter {
   private resetDiscussionsByTurn(battleId: string) {
     const battleState = this.getBattleState(battleId)
 
-    // 모든 공격 의견의 투표 기록 초기화
-    battleState.teamA.attacks = battleState.teamA.attacks.map(attack => ({
-      ...attack,
-      votes: [],
-      upvotes: 0,
-    }))
-
-    battleState.teamB.attacks = battleState.teamB.attacks.map(attack => ({
-      ...attack,
-      votes: [],
-      upvotes: 0,
-    }))
-
-    // 모든 반론 의견의 투표 기록 초기화
-    battleState.teamA.defenses = battleState.teamA.defenses.map(defense => ({
-      ...defense,
-      votes: [],
-      upvotes: 0,
-    }))
-
-    battleState.teamB.defenses = battleState.teamB.defenses.map(defense => ({
-      ...defense,
-      votes: [],
-      upvotes: 0,
-    }))
+    battleState.teamA.attacks = []
+    battleState.teamB.attacks = []
+    battleState.teamA.defenses = []
+    battleState.teamB.defenses = []
   }
 
   private scheduleNextTick(battleId: string) {


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->
- 새로운 phase에서 이의제기 후 투표를 했음에도 예전 투표 항목이 선정되는 문제가 그대로 발생했습니다
- 이전 코드는 “투표 기록만 초기화”였고, 공격/방어 항목 배열 자체는 그대로 유지되었던 문제가 있어서, BattleDiscussion 항목 배열을 비우도록 수정하였습니다.

<br />

