### PR TITLE
[Hotfix] 병합과정간에 누락 됐던 프론트엔드 인게임 로직 복구

### DIFF
--- a/backend/src/battles/const/battles.const.ts
+++ b/backend/src/battles/const/battles.const.ts
@@ -5,15 +5,15 @@ export const BATTLE_PHASE = {
   // },
   OPINION_SHARE: {
     name: 'OPINION_SHARE',
-    time: 60 * 1000, // 1분
+    time: 10 * 1000, // 1분
   },
   TEAM_A_ATTACK: {
     name: 'TEAM_A_ATTACK',
-    time: 120 * 1000, // 2분
+    time: 20 * 1000, // 2분
   },
   TEAM_B_ATTACK: {
     name: 'TEAM_B_ATTACK',
-    time: 120 * 1000, // 2분
+    time: 20 * 1000, // 2분
   },
   TEAM_SWITCH: {
     name: 'TEAM_SWITCH',
@@ -22,10 +22,10 @@ export const BATTLE_PHASE = {
 } as const
 
 export const BATTLE_TURN = {
-  A_ATTACK: { name: 'A_ATTACK', time: 30 * 1000 },
-  B_ATTACK: { name: 'B_ATTACK', time: 30 * 1000 },
-  A_DEFENSE: { name: 'A_DEFENSE', time: 30 * 1000 },
-  B_DEFENSE: { name: 'B_DEFENSE', time: 30 * 1000 },
+  A_ATTACK: { name: 'A_ATTACK', time: 10 * 1000 },
+  B_ATTACK: { name: 'B_ATTACK', time: 10 * 1000 },
+  A_DEFENSE: { name: 'A_DEFENSE', time: 10 * 1000 },
+  B_DEFENSE: { name: 'B_DEFENSE', time: 10 * 1000 },
 } as const
 
 export const BATTLE_STATUS = {

--- a/backend/src/battles/const/battles.const.ts
+++ b/backend/src/battles/const/battles.const.ts
@@ -5,15 +5,15 @@ export const BATTLE_PHASE = {
   // },
   OPINION_SHARE: {
     name: 'OPINION_SHARE',
-    time: 10 * 1000, // 1분
+    time: 60 * 1000, // 1분
   },
   TEAM_A_ATTACK: {
     name: 'TEAM_A_ATTACK',
-    time: 20 * 1000, // 2분
+    time: 120 * 1000, // 2분
   },
   TEAM_B_ATTACK: {
     name: 'TEAM_B_ATTACK',
-    time: 20 * 1000, // 2분
+    time: 120 * 1000, // 2분
   },
   TEAM_SWITCH: {
     name: 'TEAM_SWITCH',
@@ -22,10 +22,10 @@ export const BATTLE_PHASE = {
 } as const
 
 export const BATTLE_TURN = {
-  A_ATTACK: { name: 'A_ATTACK', time: 10 * 1000 },
-  B_ATTACK: { name: 'B_ATTACK', time: 10 * 1000 },
-  A_DEFENSE: { name: 'A_DEFENSE', time: 10 * 1000 },
-  B_DEFENSE: { name: 'B_DEFENSE', time: 10 * 1000 },
+  A_ATTACK: { name: 'A_ATTACK', time: 30 * 1000 },
+  B_ATTACK: { name: 'B_ATTACK', time: 30 * 1000 },
+  A_DEFENSE: { name: 'A_DEFENSE', time: 30 * 1000 },
+  B_DEFENSE: { name: 'B_DEFENSE', time: 30 * 1000 },
 } as const
 
 export const BATTLE_STATUS = {

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -67,9 +67,6 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
       await client.join(battleTeamRoom)
 
       client.emit('battle:joined', { ...res })
-
-      // client.to(battleRoomId).emit('battle:joined', { ...res, participantId: client.id })
-      // client.to(battleTeamRoom).emit('battle:joined', { ...res, participantId: client.id })
     } catch (error) {
       if (error instanceof Error) {
         client.emit('battle:join:error', {

--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -88,7 +88,7 @@ export interface BattleAttackedResult {
     discussionId: string;
     authorId: string;
     type: string;
-    content: string;
+    text: string;
     upvotes: number;
   };
 }
@@ -100,7 +100,7 @@ export interface BattleDefensedResult {
     discussionId: string;
     authorId: string;
     type: string;
-    content: string;
+    text: string;
     upvotes: number;
   };
 }

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -18,68 +18,6 @@ interface Message {
   type?: 'normal' | 'objection' | 'rebuttal';
 }
 
-const MOCK_TEAM_MESSAGES: Message[] = [
-  {
-    id: '1',
-    user: 'CodeMaster',
-    team: 'A',
-    content: '구현스가 Set을 사용해서 더 간결하네요',
-    timestamp: '2025-12-16 21:30:00',
-    type: 'normal'
-  },
-  {
-    id: '2',
-    user: 'JSLover',
-    team: 'A',
-    content: 'Set 사용이 훨씬 직관적인 것 같은데요',
-    timestamp: '2025-12-16 21:31:00',
-    type: 'normal'
-  },
-  {
-    id: '3',
-    user: 'You',
-    team: 'A',
-    content: '코드가 구려요',
-    timestamp: '2025-12-16 21:32:00',
-    type: 'objection'
-  },
-  {
-    id: '4',
-    user: 'You',
-    team: 'A',
-    content: '별론데요',
-    timestamp: '2025-12-16 21:32:30',
-    type: 'normal'
-  }
-];
-
-const MOCK_ALL_MESSAGES: Message[] = [
-  {
-    id: '1',
-    user: 'PlayerB',
-    team: 'B',
-    content: 'B팀도 나쁘지 않은데요?',
-    timestamp: '2025-12-16 21:30:30',
-    type: 'objection'
-  },
-  {
-    id: '2',
-    user: 'CodeMaster',
-    team: 'A',
-    content: 'A팀이 더 나은 것 같습니다',
-    timestamp: '2025-12-16 21:31:00',
-    type: 'rebuttal'
-  },
-  {
-    id: '3',
-    user: 'Observer',
-    team: 'NONE',
-    content: '둘 다 장단점이 있네요',
-    timestamp: '2025-12-16 21:31:30',
-    type: 'normal'
-  }
-];
-
 interface ChatSectionProps {
   socket: Socket | null;
   battleId?: string;
@@ -99,8 +37,8 @@ export default function ChatSection({
   chats,
   allChats
 }: ChatSectionProps) {
-  const [teamMessages, setTeamMessages] = useState<Message[]>(MOCK_TEAM_MESSAGES);
-  const [allMessages, setAllMessages] = useState<Message[]>(MOCK_ALL_MESSAGES);
+  const [teamMessages, setTeamMessages] = useState<Message[]>([]);
+  const [allMessages, setAllMessages] = useState<Message[]>([]);
   const [activeTab, setActiveTab] = useState<'team' | 'all'>(team === 'NONE' ? 'all' : 'team');
   const chatContainerRef = useRef<HTMLDivElement>(null);
 

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -33,7 +33,7 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
     });
 
     // 배틀 참여 성공시 데이터 수신
-    newSocket.on('battle:joined', (data: BattleJoinData) => {
+    newSocket.once('battle:joined', (data: BattleJoinData) => {
       setBattleData(data);
 
       // 초기 battleState 설정

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -16,7 +16,7 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
   const socketRef = useRef<Socket | null>(null);
 
   useEffect(() => {
-    const newSocket = io('/', {
+    const newSocket = io('http://localhost:3000', {
       transports: ['websocket']
     });
 

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -16,7 +16,7 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
   const socketRef = useRef<Socket | null>(null);
 
   useEffect(() => {
-    const newSocket = io('http://localhost:3000', {
+    const newSocket = io('/', {
       transports: ['websocket']
     });
 

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -153,11 +153,14 @@ export default function BattlePage() {
     if (!socket) return;
 
     const handleAttacked = (data: BattleAttackedResult) => {
-      const attackTeam = selectedTeam === 'A' ? 'B' : 'A';
-      showEffect(attackTeam, data.attack.text, 'attack');
+      // 턴 상태로 공격하는 팀 판단
+      const attackingTeam = battleProgress?.turn?.status === 'A_ATTACK' ? 'A' : 'B';
+      showEffect(attackingTeam, data.attack.text, 'attack');
     };
     const handleDefensed = (data: BattleDefensedResult) => {
-      showEffect(selectedTeam, data.defense.text, 'defense');
+      // 턴 상태로 방어하는 팀 판단
+      const defendingTeam = battleProgress?.turn?.status === 'A_DEFENSE' ? 'A' : 'B';
+      showEffect(defendingTeam, data.defense.text, 'defense');
     };
 
     socket.on('battle:attacked', handleAttacked);
@@ -167,7 +170,7 @@ export default function BattlePage() {
       socket.off('battle:attacked', handleAttacked);
       socket.off('battle:defensed', handleDefensed);
     };
-  }, [socket, selectedTeam, showEffect]);
+  }, [socket, battleProgress?.turn?.status, showEffect]);
 
   const handleVote = (objectionId: number) => {
     if (!socket || selectedTeam === 'NONE') return;

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -155,10 +155,10 @@ export default function BattlePage() {
 
     const handleAttacked = (data: BattleAttackedResult) => {
       const attackTeam = selectedTeam === 'A' ? 'B' : 'A';
-      showEffect(attackTeam, data.attack.content, 'attack');
+      showEffect(attackTeam, data.attack.text, 'attack');
     };
     const handleDefensed = (data: BattleDefensedResult) => {
-      showEffect(selectedTeam, data.defense.content, 'defense');
+      showEffect(selectedTeam, data.defense.text, 'defense');
     };
 
     socket.on('battle:attacked', handleAttacked);

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -67,7 +67,6 @@ export default function BattlePage() {
     setObjections([]);
   }, [battleProgress?.turn?.status, battleProgress?.phase]);
 
-  // 투표 결과 업데이트 수신
   useEffect(() => {
     if (!socket) return;
 
@@ -184,20 +183,6 @@ export default function BattlePage() {
       discussionId: String(objectionId),
       userId,
       team: selectedTeam
-    });
-
-    setObjections((prev) => {
-      const updated = prev.map((obj) => {
-        if (obj.id === objectionId) {
-          return { ...obj, hasVoted: true, votes: obj.votes + 1 };
-        } else if (obj.hasVoted) {
-          return { ...obj, hasVoted: false, votes: obj.votes - 1 };
-        }
-        return obj;
-      });
-
-      const totalVotes = updated.reduce((sum, obj) => sum + obj.votes, 0);
-      return updated.map((obj) => ({ ...obj, totalVotes }));
     });
   };
 

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -22,7 +22,6 @@ type LocationState = {
 export default function BattlePage() {
   const { id } = useParams<{ id: string }>();
   const { state } = useLocation();
-  // const { selectedTeam = 'NONE' } = (state || {}) as LocationState;
   const [selectedTeam, setSelectedTeam] = useState<'A' | 'B' | 'NONE'>(
     (state as LocationState)?.selectedTeam || 'NONE'
   );
@@ -99,12 +98,12 @@ export default function BattlePage() {
         }
         const newObjection: Objection = {
           id: data.discussionId as unknown as number,
-          user: data.authorId === 'abc' ? 'You' : `User-${data.authorId.slice(0, 4)}`,
+          user: data.authorId === userId ? 'You' : `User-${data.authorId.slice(0, 4)}`,
           team: selectedTeam,
           content: data.content,
           votes: data.upvotes,
           totalVotes,
-          hasVoted: data.votes.includes('abc')
+          hasVoted: data.votes.includes(userId)
         };
 
         return [...prev, newObjection];
@@ -125,12 +124,12 @@ export default function BattlePage() {
         const totalVotes = prev.reduce((sum, obj) => sum + obj.votes, 0);
         const newObjection: Objection = {
           id: data.discussionId as unknown as number,
-          user: data.authorId === 'abc' ? 'You' : `User-${data.authorId.slice(0, 4)}`,
+          user: data.authorId === userId ? 'You' : `User-${data.authorId.slice(0, 4)}`,
           team: selectedTeam,
           content: data.content,
           votes: data.upvotes,
           totalVotes,
-          hasVoted: data.votes.includes('abc')
+          hasVoted: data.votes.includes(userId)
         };
 
         return [...prev, newObjection];
@@ -214,7 +213,7 @@ export default function BattlePage() {
 
     socket.emit(isAttacking ? 'Battle:Attack' : 'Battle:Defense', {
       battleId: id || '1',
-      authorId: 'abc', // TODO: 실제 userId로 교체 필요
+      authorId: userId,
       content,
       team: selectedTeam
     });

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -58,7 +58,11 @@ export default function BattlePage() {
 
   useEffect(() => {
     if (battleProgress?.phase === 'TEAM_SWITCH') {
-      openTeamChangeModal();
+      const timer = setTimeout(() => {
+        openTeamChangeModal();
+      }, 4000);
+
+      return () => clearTimeout(timer);
     }
   }, [battleProgress?.phase, openTeamChangeModal]);
 


### PR DESCRIPTION
## 🔗 관련 이슈
Hotfix

## ✅ 작업 내용

### 💡개선 사항
#### 버그 수정
- **배틀 턴별 팀 표시 오류 수정**
  - 클라이언트 `selectedTeam` 대신 서버 턴 상태 기준으로 팀 판단
  - A팀/B팀 공격 턴에 올바른 팀 이의제기 메시지 표시
- **이의제기 투표 현황 소켓 이벤트 수신 버그 수정** 
  - 이전 커밋에서 누락된 투표 업데이트 로직 복구
- **공격/반론 데이터 필드명 통일**
  - 백엔드-프론트엔드 간 데이터 필드를 `text`로 통일

#### 기능 추가
- **팀 변경 모달 4초 지연 표시**
  - TEAM_SWITCH 페이즈 이벤트 수신 후 4초 대기

#### 리팩토링
- 이전 pr에서 새롭게 유저 ID 모킹 방식을 미 적용 부분들이 발견되어 수정했습니다 . 
  - 고정값 'abc' → 세션별 난수 생성 방식으로 변경
- **채팅 및 소켓 초기화 개선**
  - ChatSection 목 데이터 제거
  - `battle:joined` 이벤트 핸들러를 `once`로 변경하여 중복 실행 방지

## 📸 참고 사항
- 앞으로 병합할 때 더 신중하게 해야겠네요...
- 팀 변경 모달을 임시적으로 서버로부터 팀 변경 이벤트를 받은 후에 4초 뒤에 생기는 로직을 추가했는데, 제 생각엔 좋은 방법은 아닌 것 같습니다. 서버에서 팀 변경 턴 전에 잠시 A팀 반론 UI를 보여줄 새로운 턴을 만들어줘야 할 듯 합니다. 자세한 이야기는 월요일 회의 때 진행하시죠
<br />

