### PR TITLE
[Feature] 배틀 페이지 입장시 서버 데이터와 동기화한다

### DIFF
--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -611,6 +611,11 @@ export class BattlesService extends EventEmitter {
 
     if (userTeam === BATTLE_TEAM.NONE) return false
 
+    // OPINION_SHARE 단계에서는 모든 팀이 의견 제출 가능
+    if (phase === 'OPINION_SHARE') {
+      return true
+    }
+
     if (phase === 'TEAM_A_ATTACK' && turn?.status === 'A_ATTACK' && userTeam === BATTLE_TEAM.A) {
       return true
     }

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -567,6 +567,7 @@ export class BattlesService extends EventEmitter {
       status: 'PENDING',
     }
 
+    battleState.all.attacks.push(attack)
     if (team === BATTLE_TEAM.A) {
       battleState.teamA.attacks.push(attack)
     } else {
@@ -595,6 +596,7 @@ export class BattlesService extends EventEmitter {
       status: 'PENDING',
     }
 
+    battleState.all.defenses.push(defense)
     if (team === BATTLE_TEAM.A) {
       battleState.teamA.defenses.push(defense)
     } else {

--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -25,9 +25,11 @@ export type TurnStatus = 'A_ATTACK' | 'B_ATTACK' | 'A_DEFENSE' | 'B_DEFENSE';
 export interface BattleDiscussion {
   discussionId: string;
   authorId: string;
-  type: string;
+  type: 'ATTACK' | 'DEFENSE';
   content: string;
   upvotes: number;
+  votes: string[];
+  status: 'PENDING' | 'SELECTED' | 'REJECTED';
 }
 
 // BattleDefense 타입

--- a/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
@@ -7,6 +7,7 @@ interface ChatMessageProps {
   timestamp: string;
   showTeamBadge?: boolean;
   type?: 'normal' | 'objection' | 'rebuttal';
+  currentUserId?: string;
 }
 
 const TEAM_NICKNAME_COLORS = {
@@ -27,9 +28,16 @@ const TEAM_LABELS = {
   NONE: '중립'
 };
 
-export default function ChatMessage({ user, team, content, timestamp, showTeamBadge = false }: ChatMessageProps) {
+export default function ChatMessage({
+  user,
+  team,
+  content,
+  timestamp,
+  showTeamBadge = false,
+  currentUserId
+}: ChatMessageProps) {
   const nickNameColor = TEAM_NICKNAME_COLORS[team];
-  const isYou = user === 'You';
+  const isYou = user === currentUserId;
 
   return (
     <div className={`flex ${isYou ? 'flex-col items-end' : 'flex-col items-start'} mb-3`}>

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -26,6 +26,7 @@ interface ChatSectionProps {
   aTeamMemebers: number;
   onSendMessage?: (content: string) => void;
   team: 'A' | 'B' | 'NONE';
+  userId: string;
 }
 
 export default function ChatSection({
@@ -35,7 +36,8 @@ export default function ChatSection({
   team,
   battleId,
   chats,
-  allChats
+  allChats,
+  userId
 }: ChatSectionProps) {
   const [teamMessages, setTeamMessages] = useState<Message[]>([]);
   const [allMessages, setAllMessages] = useState<Message[]>([]);
@@ -178,6 +180,7 @@ export default function ChatSection({
               content={message.content}
               timestamp={message.timestamp}
               showTeamBadge={activeTab === 'all'}
+              currentUserId={userId}
             />
           )
         )}

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -23,7 +23,8 @@ interface ChatSectionProps {
   battleId?: string;
   chats: BattleChat[];
   allChats: BattleChat[];
-  aTeamMemebers: number;
+  teamACounts: number;
+  teamBCounts: number;
   onSendMessage?: (content: string) => void;
   team: 'A' | 'B' | 'NONE';
   userId: string;
@@ -31,7 +32,8 @@ interface ChatSectionProps {
 
 export default function ChatSection({
   socket,
-  aTeamMemebers,
+  teamACounts,
+  teamBCounts,
   onSendMessage,
   team,
   battleId,
@@ -47,6 +49,13 @@ export default function ChatSection({
   const currentMessages = useMemo(() => {
     return activeTab === 'team' ? teamMessages : allMessages;
   }, [activeTab, teamMessages, allMessages]);
+
+  const currentMemberCount = useMemo(() => {
+    if (activeTab === 'all') {
+      return teamACounts + teamBCounts;
+    }
+    return team === 'A' ? teamACounts : teamBCounts;
+  }, [activeTab, team, teamACounts, teamBCounts]);
 
   useEffect(() => {
     const newChats =
@@ -155,7 +164,7 @@ export default function ChatSection({
           </div>
           <span className="text-[12px] text-[#99A1AF] flex items-center gap-1">
             <PeoplesIcons />
-            {aTeamMemebers}
+            {currentMemberCount}
           </span>
         </div>
 

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -93,6 +93,8 @@ export default function ChatSection({
   }, [currentMessages]);
 
   useEffect(() => {
+    if (!socket) return;
+
     const handleChatUpdate = (message: BattleChat) => {
       const newMessage: Message = {
         id: message.messageId,
@@ -113,9 +115,13 @@ export default function ChatSection({
         onSendMessage(newMessage.content);
       }
     };
-    socket?.on('battle:chatUpdate', handleChatUpdate);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [socket]);
+
+    socket.on('battle:chatUpdate', handleChatUpdate);
+
+    return () => {
+      socket.off('battle:chatUpdate', handleChatUpdate);
+    };
+  }, [socket, onSendMessage]);
 
   const handleSendMessage = (content: string) => {
     if (!socket) return;

--- a/frontend/src/pages/battlePage/components/objection/ObjectionVote.tsx
+++ b/frontend/src/pages/battlePage/components/objection/ObjectionVote.tsx
@@ -24,6 +24,11 @@ export { type Objection };
 export default function ObjectionVote({ objections, onVote, phase, team }: ObjectionVoteProps) {
   const isAttacking = isMyTeamAttacking(team || 'NONE', phase);
 
+  // OPINION_SHARE 단계에서는 투표 UI를 표시하지 않음
+  if (phase === 'OPINION_SHARE') {
+    return null;
+  }
+
   const headerText = isAttacking ? '제출된 이의제기 목록' : '제출된 반론 목록';
   const infoText = isAttacking
     ? '이의제기가 실시간으로 추가되며, 바로 투표 가능합니다!'

--- a/frontend/src/pages/battlePage/components/timeline/TimelineCard.tsx
+++ b/frontend/src/pages/battlePage/components/timeline/TimelineCard.tsx
@@ -1,14 +1,10 @@
 import LikeIcon from '@/assets/icon/like.svg?react';
 import BattleIcon from '@/assets/icon/battle.svg?react';
 import ShieldIcon from '@/assets/icon/shield.svg?react';
+import type { BattleDiscussion } from '@/commons/types/battle';
 
 interface TimelineCardProps {
-  user: string;
-  team: 'A' | 'B';
-  type: '이의제기' | '반박';
-  content: string;
-  timestamp: string;
-  voteCount: number;
+  discussionDetails: BattleDiscussion;
 }
 
 const TYPE_COLORS = {
@@ -37,9 +33,13 @@ const TEAM_COLORS = {
   }
 };
 
-export default function TimelineCard({ user, team, type, content, voteCount }: TimelineCardProps) {
-  const typeColors = TYPE_COLORS[type];
-  const teamColors = TEAM_COLORS[team];
+const TEAM = 'A'; // 임시
+
+export default function TimelineCard({ discussionDetails }: TimelineCardProps) {
+  const { authorId, content, upvotes, type } = discussionDetails;
+  const discussionType = type === 'ATTACK' ? '이의제기' : '반박';
+  const typeColors = TYPE_COLORS[discussionType];
+  const teamColors = TEAM_COLORS[TEAM];
 
   return (
     <div
@@ -50,19 +50,19 @@ export default function TimelineCard({ user, team, type, content, voteCount }: T
           <div
             className={`w-[36px] h-[20px] ${teamColors.badge} rounded-sm flex items-center justify-center text-white font-bold text-[12px] mb-2`}
           >
-            {team}팀
+            {TEAM}팀
           </div>
-          <span className={`text-[18px] font-bold ${teamColors.text}`}>{user}</span>
-          {type === '이의제기' ? (
+          <span className={`text-[18px] font-bold ${teamColors.text}`}>{authorId}</span>
+          {discussionType === '이의제기' ? (
             <BattleIcon className={`w-[20px] h-[20px] ${typeColors.icon}`} />
           ) : (
             <ShieldIcon className={`w-[20px] h-[20px] ${typeColors.icon}`} />
           )}
-          <span className={`text-[14px] font-medium ${typeColors.icon}`}>{type}</span>
+          <span className={`text-[14px] font-medium ${typeColors.icon}`}>{discussionType}</span>
         </div>
         <div className="flex items-center gap-2 rounded-md px-2 py-1 bg-[#2D2D3F]">
           <LikeIcon className="w-[20px] h-[20px]" />
-          <span className="text-[13px] text-white font-medium">{voteCount}</span>
+          <span className="text-[13px] text-white font-medium">{upvotes}</span>
         </div>
       </div>
       <p className="text-[16px] text-white pl-[12px] text-left">{content}</p>

--- a/frontend/src/pages/battlePage/components/timeline/TimelineSection.tsx
+++ b/frontend/src/pages/battlePage/components/timeline/TimelineSection.tsx
@@ -1,56 +1,30 @@
-import { useState } from 'react';
+import { useMemo } from 'react';
 import BattleIcon from '@/assets/icon/battle.svg?react';
 import DownArrowIcon from '@/assets/icon/downArrow.svg?react';
 import TimelineCard from './TimelineCard';
+import type { BattleDiscussion } from '@/commons/types/battle';
 
-interface TimelineItem {
-  id: number;
-  user: string;
-  team: 'A' | 'B';
-  type: '이의제기' | '반박';
-  content: string;
-  timestamp: string;
-  voteCount: number;
+interface TimelineSectionProps {
+  attackList?: BattleDiscussion[];
+  defenseList?: BattleDiscussion[];
 }
 
-const MOCK_TIMELINE: TimelineItem[] = [
-  {
-    id: 1,
-    user: 'Alice',
-    team: 'A',
-    type: '이의제기',
-    content: '구현 A의 Set 사용이 더 효율적입니다. O(1) 시간 복잡도로 중복을 제거합니다.',
-    timestamp: '2024-12-16 21:30:00',
-    voteCount: 15
-  },
-  {
-    id: 2,
-    user: 'Bob',
-    team: 'B',
-    type: '반박',
-    content: '구현 B의 반복문 사용이 더 명확하고 이해하기 쉽습니다.',
-    timestamp: '2024-12-16 21:30:00',
-    voteCount: 15
-  },
-  {
-    id: 3,
-    user: 'Alice',
-    team: 'A',
-    type: '이의제기',
-    content: '구현 A의 Set 사용이 더 효율적입니다. O(1) 시간 복잡도로 중복을 제거합니다.',
-    timestamp: '2024-12-16 21:30:00',
-    voteCount: 15
-  }
-];
+export default function TimelineSection({ attackList = [], defenseList = [] }: TimelineSectionProps) {
+  const timeLines = useMemo(() => {
+    const maxLength = attackList.length;
+    const result: BattleDiscussion[] = [];
 
-export default function TimelineSection() {
-  const [timeline] = useState<TimelineItem[]>(MOCK_TIMELINE);
+    for (let i = 0; i < maxLength; i++) {
+      if (i < attackList.length) {
+        result.push(attackList[i]);
+      }
+      if (i < defenseList.length) {
+        result.push(defenseList[i]);
+      }
+    }
 
-  /*
-  useEffect(() => {
-    // @Todos : 소켓으로 타임 라인 데이터 구독 로직 추가 필요
-  }, []);
-  */
+    return result;
+  }, [attackList, defenseList]);
 
   return (
     <section className="w-[1193px] mt-2">
@@ -63,22 +37,15 @@ export default function TimelineSection() {
           각 진영의 주장과 반박을 시간순으로 확인하고 투표하세요
         </h3>
         <div className="space-y-4">
-          {timeline.map((item) => (
-            <div key={item.id} className="relative">
-              {item.type === '반박' && (
+          {timeLines.map((item) => (
+            <div key={item.discussionId} className="relative">
+              {item.type === 'DEFENSE' && (
                 <div className="flex gap-2 items-center my-4 ml-17">
                   <DownArrowIcon className="w-[32px] h-[32px] bg-[#59168B] fill-[#C27AFF] rounded-full px-1 py-1" />
                   <p className="text-[14px] text-[#C27AFF]">반박</p>
                 </div>
               )}
-              <TimelineCard
-                user={item.user}
-                team={item.team}
-                type={item.type}
-                content={item.content}
-                timestamp={item.timestamp}
-                voteCount={item.voteCount}
-              />
+              <TimelineCard discussionDetails={item} />
             </div>
           ))}
         </div>

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -45,8 +45,11 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
         expiredAt: data.expiredAt
       });
 
-      // 초기 currentStage 설정
-      setCurrentStage(data.phase);
+      if (data.phase === 'OPINION_SHARE' || data.phase === 'TEAM_SWITCH') {
+        setCurrentStage(data.phase);
+      } else {
+        setCurrentStage(data.turn?.status || data.phase);
+      }
     });
 
     // Phase 변경 이벤트 구독

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -8,11 +8,22 @@ import type {
   BattleDefensedResult
 } from '@/commons/types/battle';
 
+interface Objection {
+  id: number;
+  user: string;
+  team: 'A' | 'B';
+  content: string;
+  votes: number;
+  totalVotes: number;
+  hasVoted: boolean;
+}
+
 export function useBattleSocket({ battleId, userId, team, password }: UseBattleSocketProps) {
   const [battleData, setBattleData] = useState<BattleJoinData | null>(null);
   const [battleProgress, setBattleProgressState] = useState<BattleProgressState | null>(null);
   const [currentStage, setCurrentStage] = useState<string | null>(null);
   const [isConnected, setIsConnected] = useState(false);
+  const [objections, setObjections] = useState<Objection[]>([]);
   const socketRef = useRef<Socket | null>(null);
 
   useEffect(() => {
@@ -65,6 +76,7 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
           : null
       );
       setCurrentStage(data.phase);
+      setObjections([]);
     });
 
     // Turn 변경 이벤트 구독
@@ -80,6 +92,7 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
           : null
       );
       setCurrentStage(data.turn?.status || null);
+      setObjections([]);
     });
 
     // Round 변경 이벤트 구독
@@ -98,10 +111,53 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       console.log('Battle:Attacked received:', data);
     });
 
-    // Battle:Defensed 이벤트 구독 (방어 결과)
     newSocket.on('battle:defensed', (data: BattleDefensedResult) => {
       console.log('Battle:Defensed received:', data);
     });
+
+    // 투표 업데이트 이벤트
+    const handleVoteUpdate = (data: { discussionId: string; upvotes: number; votes: string[] }) => {
+      setObjections((prev) => {
+        const updated = prev.map((obj) => {
+          const isTarget = String(obj.id) === data.discussionId;
+          return isTarget ? { ...obj, votes: data.upvotes, hasVoted: data.votes.includes(userId) } : obj;
+        });
+        const totalVotes = updated.reduce((sum, obj) => sum + obj.votes, 0);
+        return updated.map((obj) => ({ ...obj, totalVotes }));
+      });
+    };
+
+    // 새 이의제기/반론 추가
+    const handleNewDiscussion = (data: {
+      discussionId: string;
+      authorId: string;
+      content: string;
+      upvotes: number;
+      votes: string[];
+    }) => {
+      if (team === 'NONE') return;
+
+      setObjections((prev) => {
+        const totalVotes = prev.reduce((sum, obj) => sum + obj.votes, 0);
+        return [
+          ...prev,
+          {
+            id: data.discussionId as unknown as number,
+            user: data.authorId === userId ? 'You' : `User-${data.authorId.slice(0, 4)}`,
+            team: team as 'A' | 'B',
+            content: data.content,
+            votes: data.upvotes,
+            totalVotes,
+            hasVoted: data.votes.includes(userId)
+          }
+        ];
+      });
+    };
+
+    newSocket.on('battle:attackvote:update', handleVoteUpdate);
+    newSocket.on('battle:defensevote:update', handleVoteUpdate);
+    newSocket.on('Battle:NewAttack', handleNewDiscussion);
+    newSocket.on('Battle:NewDefense', handleNewDiscussion);
 
     return () => {
       newSocket.disconnect();
@@ -113,6 +169,7 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
     battleData,
     battleProgress,
     currentStage,
-    isConnected
+    isConnected,
+    objections
   };
 }

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -16,7 +16,7 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
   const socketRef = useRef<Socket | null>(null);
 
   useEffect(() => {
-    const newSocket = io('/', {
+    const newSocket = io(import.meta.env.VITE_API_URL, {
       transports: ['websocket']
     });
 

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -186,6 +186,17 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
     newSocket.on('Battle:NewDefense', handleNewDiscussion);
 
     return () => {
+      newSocket.off('connect');
+      newSocket.off('battle:joined');
+      newSocket.off('battle:phase:update');
+      newSocket.off('battle:turn:update');
+      newSocket.off('battle:round:update');
+      newSocket.off('battle:attacked');
+      newSocket.off('battle:defensed');
+      newSocket.off('battle:attackvote:update', handleVoteUpdate);
+      newSocket.off('battle:defensevote:update', handleVoteUpdate);
+      newSocket.off('Battle:NewAttack', handleNewDiscussion);
+      newSocket.off('Battle:NewDefense', handleNewDiscussion);
       newSocket.disconnect();
     };
   }, [battleId, userId, team, password]);

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -64,14 +64,14 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
 
       // 초기 투표 리스트 동기화
       if (team !== 'NONE' && data.turn?.status) {
-        const voteMap: Record<string, typeof data.attacks | typeof data.defenses> = {
-          'A_ATTACK-A': data.attacks,
-          'B_DEFENSE-B': data.defenses,
-          'B_ATTACK-B': data.attacks,
-          'A_DEFENSE-A': data.defenses
+        const VOTE_MAP: Record<string, typeof data.attacks | typeof data.defenses> = {
+          A_ATTACK_B: data.attacks,
+          B_DEFENSE_A: data.defenses,
+          B_ATTACK_A: data.attacks,
+          A_DEFENSE_B: data.defenses
         };
 
-        const currentVoteList = voteMap[`${data.turn.status}-${team}`];
+        const currentVoteList = VOTE_MAP[`${data.turn.status}_${team}`];
         if (currentVoteList?.length) {
           const totalVotes = currentVoteList.reduce((sum, { upvotes }) => sum + upvotes, 0);
           setObjections(

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -61,6 +61,32 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       } else {
         setCurrentStage(data.turn?.status || data.phase);
       }
+
+      // 초기 투표 리스트 동기화
+      if (team !== 'NONE' && data.turn?.status) {
+        const voteMap: Record<string, typeof data.attacks | typeof data.defenses> = {
+          'A_ATTACK-A': data.attacks,
+          'B_DEFENSE-B': data.defenses,
+          'B_ATTACK-B': data.attacks,
+          'A_DEFENSE-A': data.defenses
+        };
+
+        const currentVoteList = voteMap[`${data.turn.status}-${team}`];
+        if (currentVoteList?.length) {
+          const totalVotes = currentVoteList.reduce((sum, { upvotes }) => sum + upvotes, 0);
+          setObjections(
+            currentVoteList.map(({ discussionId, authorId, content, upvotes, votes }) => ({
+              id: discussionId as unknown as number,
+              user: authorId === userId ? 'You' : `User-${authorId.slice(0, 4)}`,
+              team: team as 'A' | 'B',
+              content,
+              votes: upvotes,
+              totalVotes,
+              hasVoted: votes.includes(userId)
+            }))
+          );
+        }
+      }
     });
 
     // Phase 변경 이벤트 구독

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -210,12 +210,7 @@ export default function BattlePage() {
       content,
       team: selectedTeam
     });
-
-    // 서버에서 Battle:NewAttack/NewDefense로 받을 예정이므로 여기서는 optimistic update 제거
-    // 중복 추가 방지
   };
-
-  //@Todo 초기 이의제기/반론 목록 로드 소켓 로직 추가 필요
 
   useEffect(() => {
     if (!socket) return;
@@ -268,7 +263,7 @@ export default function BattlePage() {
               codeA={battleInfo.aCode}
               codeB={battleInfo.bCode}
             />
-            <TimelineSection />
+            <TimelineSection attackList={battleData?.timelines.attacks} defenseList={battleData?.timelines.defenses} />
           </div>
           <aside className="flex flex-col gap-4 w-[590px]">
             <ChatSection

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -157,8 +157,8 @@ export default function BattlePage() {
     <div className="text-white flex flex-col items-center">
       <div className="w-[1800px]">
         <BattleHeader
-          title="배열에서 중복 제거하기"
-          description="배열에서 중복된 요소를 제거하는 최적의 방법은?"
+          title={battleInfo.title}
+          description={battleInfo.description}
           status={currentStage || 'END'}
           timer={formattedTime}
           teamACounts={battleData?.counts.teamA || 0}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -186,6 +186,7 @@ export default function BattlePage() {
               battleId={id}
               chats={battleData?.chats || []}
               allChats={battleData?.allChats || []}
+              userId={userId}
             />
             <ObjectionInput
               onSubmit={handleObjectionSubmit}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -180,7 +180,8 @@ export default function BattlePage() {
           </div>
           <aside className="flex flex-col gap-4 w-[590px]">
             <ChatSection
-              aTeamMemebers={102}
+              teamACounts={battleData?.counts.teamA || 0}
+              teamBCounts={battleData?.counts.teamB || 0}
               team={selectedTeam}
               socket={socket}
               battleId={id}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -253,8 +253,8 @@ export default function BattlePage() {
           description="배열에서 중복된 요소를 제거하는 최적의 방법은?"
           status={currentStage || 'END'}
           timer={formattedTime}
-          teamACounts={1}
-          teamBCounts={1}
+          teamACounts={battleData?.counts.teamA || 0}
+          teamBCounts={battleData?.counts.teamB || 0}
           teamNoneCounts={0}
         />
       </div>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -5,7 +5,7 @@ import BattleHeader from './components/header/BattleHeader';
 import CodeSection from './components/codeview/CodeSection';
 import ChatSection from './components/chatting/ChatSection';
 import ObjectionInput from './components/objection/ObjectionInput';
-import ObjectionVote, { type Objection } from './components/objection/ObjectionVote';
+import ObjectionVote from './components/objection/ObjectionVote';
 import TimelineSection from './components/timeline/TimelineSection';
 import { useBattleSocket } from './hooks/useBattleSocket';
 import { useBattleTimer } from './hooks/useBattleTimer';
@@ -29,7 +29,6 @@ export default function BattlePage() {
 
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
-  const [objections, setObjections] = useState<Objection[]>([]);
   const { effectModal, showEffect, hideEffect } = useEffectModal();
   const {
     isOpen: isTeamChangeModalOpen,
@@ -47,7 +46,7 @@ export default function BattlePage() {
     return id;
   });
 
-  const { socket, currentStage, battleProgress, battleData } = useBattleSocket({
+  const { socket, currentStage, battleProgress, battleData, objections } = useBattleSocket({
     battleId: id || '1',
     userId,
     team: selectedTeam
@@ -68,92 +67,6 @@ export default function BattlePage() {
   }, [battleProgress?.phase, openTeamChangeModal]);
 
   // 턴 변경 시 투표 리스트 초기화
-  useEffect(() => {
-    setObjections([]);
-  }, [battleProgress?.turn?.status, battleProgress?.phase]);
-
-  useEffect(() => {
-    if (!socket) return;
-
-    const handleVoteUpdate = (data: { discussionId: string; upvotes: number; votes: string[] }) => {
-      setObjections((prev) => {
-        const updated = prev.map((obj) => {
-          const isTarget = String(obj.id) === data.discussionId;
-          return isTarget ? { ...obj, votes: data.upvotes, hasVoted: data.votes.includes(userId) } : obj;
-        });
-        const totalVotes = updated.reduce((sum, obj) => sum + obj.votes, 0);
-        return updated.map((obj) => ({ ...obj, totalVotes }));
-      });
-    };
-
-    // 다른 사람이 제출한 이의제기/반론 수신
-    const handleNewAttack = (data: {
-      discussionId: string;
-      authorId: string;
-      content: string;
-      upvotes: number;
-      votes: string[];
-    }) => {
-      setObjections((prev) => {
-        const totalVotes = prev.reduce((sum, obj) => sum + obj.votes, 0);
-
-        if (selectedTeam === 'NONE') {
-          return prev;
-        }
-        const newObjection: Objection = {
-          id: data.discussionId as unknown as number,
-          user: data.authorId === userId ? 'You' : `User-${data.authorId.slice(0, 4)}`,
-          team: selectedTeam,
-          content: data.content,
-          votes: data.upvotes,
-          totalVotes,
-          hasVoted: data.votes.includes(userId)
-        };
-
-        return [...prev, newObjection];
-      });
-    };
-
-    const handleNewDefense = (data: {
-      discussionId: string;
-      authorId: string;
-      content: string;
-      upvotes: number;
-      votes: string[];
-    }) => {
-      setObjections((prev) => {
-        if (selectedTeam === 'NONE') {
-          return prev;
-        }
-        const totalVotes = prev.reduce((sum, obj) => sum + obj.votes, 0);
-        const newObjection: Objection = {
-          id: data.discussionId as unknown as number,
-          user: data.authorId === userId ? 'You' : `User-${data.authorId.slice(0, 4)}`,
-          team: selectedTeam,
-          content: data.content,
-          votes: data.upvotes,
-          totalVotes,
-          hasVoted: data.votes.includes(userId)
-        };
-
-        return [...prev, newObjection];
-      });
-    };
-
-    socket.on('battle:attackvote:update', handleVoteUpdate);
-    socket.on('battle:defensevote:update', handleVoteUpdate);
-    socket.on('Battle:NewAttack', handleNewAttack);
-    socket.on('Battle:NewDefense', handleNewDefense);
-
-    return () => {
-      socket.off('battle:attackvote:update', handleVoteUpdate);
-      socket.off('battle:defensevote:update', handleVoteUpdate);
-      socket.off('Battle:NewAttack', handleNewAttack);
-      socket.off('Battle:NewDefense', handleNewDefense);
-    };
-  }, [socket, selectedTeam, userId]);
-
-  // battle:attacked / battle:defensed 이벤트 처리
   useEffect(() => {
     if (!socket) return;
 
@@ -180,7 +93,7 @@ export default function BattlePage() {
   const handleVote = (objectionId: number) => {
     if (!socket || selectedTeam === 'NONE') return;
 
-    const targetObjection = objections.find((obj) => obj.id === objectionId);
+    const targetObjection = objections?.find((obj) => obj.id === objectionId);
     if (targetObjection?.hasVoted) return;
 
     const { isAttacking } = getObjectionConfig(selectedTeam, battleProgress?.phase);

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -148,10 +148,17 @@ export default function BattlePage() {
 
   useEffect(() => {
     if (!socket) return;
-    socket.on('battle:closed', (payload: { battleId: string }) => {
+
+    const handleBattleClosed = (payload: { battleId: string }) => {
       navigate(`/battle/${payload.battleId}/result`);
-    });
-  }, [socket]);
+    };
+
+    socket.on('battle:closed', handleBattleClosed);
+
+    return () => {
+      socket.off('battle:closed', handleBattleClosed);
+    };
+  }, [socket, navigate]);
 
   return (
     <div className="text-white flex flex-col items-center">

--- a/frontend/src/pages/battlePage/utils/getTurnInfo.ts
+++ b/frontend/src/pages/battlePage/utils/getTurnInfo.ts
@@ -13,7 +13,7 @@ export const getTurnInfo = (stage: string | null): TurnInfo => {
     };
   }
 
-  const phaseMap: Record<BattlePhase, TurnInfo> = {
+  const PHASE_MAP: Record<BattlePhase, TurnInfo> = {
     OPINION_SHARE: {
       title: '의견 공유 시간',
       description: '코드를 분석하고 팀원들과 의견을 나누세요.'
@@ -32,7 +32,7 @@ export const getTurnInfo = (stage: string | null): TurnInfo => {
     }
   };
 
-  const turnMap: Record<TurnStatus, TurnInfo> = {
+  const TURN_MAP: Record<TurnStatus, TurnInfo> = {
     A_ATTACK: {
       title: 'A팀 이의제기 시간',
       description: 'A팀이 코드의 문제점을 지적하세요.'
@@ -51,12 +51,12 @@ export const getTurnInfo = (stage: string | null): TurnInfo => {
     }
   };
 
-  if (stage in turnMap) {
-    return turnMap[stage as TurnStatus];
+  if (stage in TURN_MAP) {
+    return TURN_MAP[stage as TurnStatus];
   }
 
-  if (stage in phaseMap) {
-    return phaseMap[stage as BattlePhase];
+  if (stage in PHASE_MAP) {
+    return PHASE_MAP[stage as BattlePhase];
   }
 
   return {


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #74

## ✅ 작업 내용
### 💡개선 사항
#### 1. 배틀 초기 진입 시 실시간 데이터 동기화
기존에는 UI 배치를 위해 임시용으로 하드코딩된 값을 사용했었는데, 현재 동기화 수신 이벤트도 구현됐기에 해당 이벤트를 통해 배틀 페이지 진입 시 최초 1회 실시간 데이터 동기화 하는 로직을 적용했습니다. **이로써 사용자가 게임 중간에 진입해도 문제 없이 게임 진행 할 수 있습니다!**

- **팀 인원수 동기화** - `battle:joined` 이벤트로 A/B팀 실시간 인원수 표시
- **Phase & Turn 상태 동기화** - 현재 진행 중인 게임 단계와 턴 상태를 정확히 반영
- **타임라인 데이터 동기화** - attack/defense 배열을 순차적으로 타임라인에 표기
- **투표 항목 동기화** - 턴 상태와 팀 조합으로 올바른 투표 리스트 매핑
- **채팅 라운지 인원 수 동기화** - 각 채팅 라운지에 현재 참여 중인 인원이 몇 명인지 표기 
- **채팅 내역 동기화** - 이 부분은 이미 #75 에서 구현됐기에 따로 건들진 않았습니다. 

<br/>

#### 2. 배틀 헤더에  방 제목과 방 설명 부분을 `/join` Api에서 가져온 실제 데이터로 표시하는 로직으로 변경
기존에 방 제목, 방 설명 text 내용을 모킹 용 상수 부분으로 채워져 있었는데,  `/join` Api에서 가져온 실제 데이터로 표시하여 동기화 시키는 로직을 적용 했습니다. 

<br/>

#### 3. 투표 시스템 아키텍처 임시 개선
현재 배틀페이지 index.tsx에 투표 관련 로직이 라인 분산되어 있어 중복 코드 발생 및 유지보수 어려움 겪고 있었습니다. 그래서 투표 상태 및 관련 처리 로직을 임시적으로 `useBattleSocket `훅으로 이동시켰습니다. (새롭게 추가될 투표 동기화 로직을 포함하면 거진 86줄..)

**개선 내용**:
- 투표 상태 관리 및 소켓 이벤트 처리 로직 `useBattleSocket`훅으로 이동 관련 사유는 고민 내용에 적어두겠습니다. 

<br/>

#### 4. API 엔드 포인트 URL 환경 변수 적용 
소켓 연결 URL이 하드코딩되어 있어 `개발/프로덕션` 환경 전환 시 코드를 수동으로 변경 해야 하는 상황이 생기는 것 같아서 환경 변수를 적용 했습니다. 

##### 기존 
```javascript
// useBattleSocket.ts
  // 배포 환경
    const newSocket = io("/", {
      transports: ['websocket']
    });
// dev 환경 아래처럼 수동 변경 필요
      const newSocket = io("http://localhost:3000", {
      transports: ['websocket']
    });
```
##### 이후
```javascript
  const newSocket = io(import.meta.env.VITE_API_URL, {
      transports: ['websocket']
    });
```
위 부분은 다음 스크럼에서 다시 한번 언급하겠습니다.  

<br/>

#### 5. 타입 시스템 개선
최초 동기화 할 때 받아오는 게임 데이터에 대한 타입을 선언 했었는데 (`BattleDiscussion`) 그 것을 깜빡하고 추가적으로  타임라인 컴포넌트 부분에서 `TimelineItemTypes`를 중복적으로 만들어 사용하고 있었던것을 확인했습니다. 그래서  `TimelineItemTypes`을 지워 불필요하게 중복 타입 사용하는 것을 개선했습니다. 

- `TimelineItemTypes` 제거 → `BattleDiscussion` 타입으로 통일
- 추가적으로 프론트 타입을 백엔드 응답 타입과 일치 작업 진행(누락된 필드를 추가했습니다.)

<br/>

#### 6. 서버에서 새로운 타임라인이 생길 시 전체 배열 저장에는 저장 안하는 버그 수정
##### 서버내의 배틀 상태 저장하는 객체 중 일부
```javascript
activeBattleState: {
  teamA: {
    ... //  <-  새로운 이의 제기/ 반론이 생겨도 추가 하고 있음
  },
  teamB: {
    ... //  <-  새로운 이의 제기/ 반론이 생겨도 추가 하고 있음
  },
  all: {
    ... //  <-  새로운 이의 제기/ 반론이 생겨도 추가 안하고 있었음.
  }
}
```
위의 간략한 예시처럼 새롭게 이의 제기/반론이 선정됐을 때  팀 배열에만 저장하고 전체 배열 저장 부분은 누락된 것으로 확인됐습니다. 그래서 전체 배열에도 선정된 이의 제기/반론 데이터를 저장하는 로직을 추가했습니다.

<br />

## 📸 참고 사항
### 배틀 페이지내 상태 / 비즈니스 로직의 분리가 매우 필요한 문제..
프로토타입 개발 마감이 다가올 수록 가독성 및 확장성 있는 코드를 고려하지 못하고 배틀 페이지 index.tsx에 다 때려박는 문제가 생겼던것 같습니다. 주로 소켓으로부터 게임 데이터 값을 받아와 변환, 처리하는 로직이 100줄이 넘을정도로 많았는데, 이거 때문에 투표 동기화 관련 로직을 추가 할 때도 복잡하고 난잡해서 시간이 더 걸렸던 것 같습니다. 이번 PR 작업하면서 이 부분을 같이 리펙토링 하고 싶었으나... 너무 방대한 작업으로 이어질 것 같아서 새롭게 이슈 만들어서 진행하겠습니다. 

방법은 고민중인데... 배틀 데이터 상태 처리 관련 내용을 `useBattleSocket.ts` 혼자 감당하기엔 너무 많습니다. 그리고 결합도도 너무 높고요.. 그래서 관심사에 따른 훅을 분리해서 만들어서 처리할 지 (ex. 투표 / 타임 라인 / 채팅 / 게임 진행) 아니면 zustand 나 reducer를 사용해서 store들을 분리 해볼 까 고민 중입니다. 

<br />

### `/joined` Event에서 중립 인원 수 필드 누락 문제 
<img width="122" height="78" alt="image" src="https://github.com/user-attachments/assets/3f5e1e38-747e-4881-9fa4-7f2980761c4b" />

게임 입장시 실시간 게임 참여 중인 진영 별 인원 수를 동기화 해야하는데, 반환 값에는 A팀, B팀 인원 수 밖에 없습니다.  해당 부분도 추후에 추가 해야할 것 같네요