### PR TITLE
[Refactor] BattlePage 관심사 분리 (상태 관리/ 비즈니스/ UI) 및 테스트 코드 추가

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.11.0",
-    "socket.io-client": "^4.8.1"
+    "socket.io-client": "^4.8.1",
+    "zustand": "^5.0.9"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,10 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest --coverage"
   },
   "dependencies": {
     "react": "^19.2.0",
@@ -20,6 +23,10 @@
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.1.18",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.1",
+    "@testing-library/react-hooks": "^8.0.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
@@ -29,11 +36,13 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^27.4.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^7.2.4",
-    "vite-plugin-svgr": "^4.5.0"
+    "vite-plugin-svgr": "^4.5.0",
+    "vitest": "^4.0.16"
   }
 }

--- a/frontend/src/commons/hooks/useAutoScroll.ts
+++ b/frontend/src/commons/hooks/useAutoScroll.ts
@@ -1,0 +1,13 @@
+import { useRef, useEffect } from 'react';
+
+export function useAutoScrollDown<T>(deps: T[]) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, deps);
+
+  return scrollRef;
+}

--- a/frontend/src/pages/battlePage/components/chatting/ChatInput.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatInput.tsx
@@ -11,7 +11,6 @@ export default function ChatInput({ onSend }: ChatInputProps) {
   const handleSend = () => {
     if (inputValue) {
       onSend(inputValue);
-      // @Todo : 소켓으로 메세지 전송 이벤트 로직 필요.
       setInputValue('');
     }
   };

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -1,6 +1,6 @@
 import ChatInput from './ChatInput';
 import ChatMessage from './ChatMessage';
-import ObjectionMessage from './ObjectionMessage';
+import DiscussionMessage from './DiscussionMessage';
 import ChatTabs from './ChatTabs';
 import PeoplesIcons from '@/assets/icon/peoples.svg?react';
 import MessageIcon from '@/assets/icon/message.svg?react';
@@ -15,25 +15,27 @@ export default function ChatSection() {
   const team = useBattleStore(selectSelectedTeam);
   const { teamACount, teamBCount } = useBattleStore(selectTeamCounts);
 
+  const [activeTab, setActiveTab] = useState<'team' | 'all'>('team');
+
   const { teamMessages, allMessages, sendMessage } = useBattleChat();
 
-  const [activeTab, setActiveTab] = useState<'team' | 'all'>(team === 'NONE' ? 'all' : 'team');
+  const currentTab = team === 'NONE' ? 'all' : activeTab;
 
   const currentMessages = useMemo(() => {
-    return activeTab === 'team' ? teamMessages : allMessages;
-  }, [activeTab, teamMessages, allMessages]);
+    return currentTab === 'team' ? teamMessages : allMessages;
+  }, [currentTab, teamMessages, allMessages]);
 
   const chatContainerRef = useAutoScrollDown([currentMessages]);
 
   const currentMemberCount = useMemo(() => {
-    if (activeTab === 'all') {
+    if (currentTab === 'all') {
       return teamACount + teamBCount;
     }
     return team === 'A' ? teamACount : teamBCount;
-  }, [activeTab, team, teamACount, teamBCount]);
+  }, [currentTab, team, teamACount, teamBCount]);
 
   const handleSendMessage = (content: string) => {
-    const scope = activeTab === 'team' ? 'TEAM' : 'ALL';
+    const scope = currentTab === 'team' ? 'TEAM' : 'ALL';
     sendMessage(content, scope);
   };
 
@@ -51,13 +53,13 @@ export default function ChatSection() {
           </span>
         </div>
 
-        <ChatTabs activeTab={activeTab} onTabChange={setActiveTab} team={team} />
+        <ChatTabs activeTab={currentTab} onTabChange={setActiveTab} team={team} />
       </div>
 
       <div ref={chatContainerRef} className="h-[422px] px-4 py-2 overflow-y-auto scrollbar-thin">
         {currentMessages.map((message) =>
-          message.type === 'objection' || message.type === 'rebuttal' ? (
-            <ObjectionMessage
+          message.type === 'attack' || message.type === 'defense' ? (
+            <DiscussionMessage
               key={message.id}
               team={message.team}
               content={message.content}
@@ -71,7 +73,7 @@ export default function ChatSection() {
               team={message.team}
               content={message.content}
               timestamp={message.timestamp}
-              showTeamBadge={activeTab === 'all'}
+              showTeamBadge={currentTab === 'all'}
               currentUserId={userId}
             />
           )

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -6,43 +6,19 @@ import PeoplesIcons from '@/assets/icon/peoples.svg?react';
 import MessageIcon from '@/assets/icon/message.svg?react';
 
 import { useState, useRef, useEffect, useMemo } from 'react';
-import type { BattleChat } from '@/commons/types/battle';
-import {
-  useBattleStore,
-  selectSocket,
-  selectUserId,
-  selectBattleId,
-  selectSelectedTeam,
-  selectChats,
-  selectTeamCounts
-} from '../../stores/battleStore';
+import { useBattleStore, selectUserId, selectSelectedTeam, selectTeamCounts } from '../../stores/battleStore';
+import { useBattleChat } from '../../hooks/useBattleChat';
 
-interface Message {
-  id: string;
-  user: string;
-  team: 'A' | 'B' | 'NONE';
-  content: string;
-  timestamp: string;
-  type?: 'normal' | 'objection' | 'rebuttal';
-}
-
-interface ChatSectionProps {
-  onSendMessage?: (content: string) => void;
-}
-
-export default function ChatSection({ onSendMessage }: ChatSectionProps) {
-  const socket = useBattleStore(selectSocket);
+export default function ChatSection() {
   const userId = useBattleStore(selectUserId);
-  const battleId = useBattleStore(selectBattleId);
   const team = useBattleStore(selectSelectedTeam);
-  const chats = useBattleStore(selectChats);
   const teamCounts = useBattleStore(selectTeamCounts);
+
+  const { teamMessages, allMessages, sendMessage } = useBattleChat();
 
   const teamACounts = teamCounts?.teamA || 0;
   const teamBCounts = teamCounts?.teamB || 0;
-  const allChats = chats || [];
-  const [teamMessages, setTeamMessages] = useState<Message[]>([]);
-  const [allMessages, setAllMessages] = useState<Message[]>([]);
+
   const [activeTab, setActiveTab] = useState<'team' | 'all'>(team === 'NONE' ? 'all' : 'team');
   const chatContainerRef = useRef<HTMLDivElement>(null);
 
@@ -58,107 +34,15 @@ export default function ChatSection({ onSendMessage }: ChatSectionProps) {
   }, [activeTab, team, teamACounts, teamBCounts]);
 
   useEffect(() => {
-    const newChats =
-      chats?.map(
-        (chat: BattleChat): Message => ({
-          id: chat.messageId,
-          user: chat.sender,
-          team: chat.team,
-          content: chat.text,
-          timestamp: new Date(chat.createdAt).toISOString().replace('T', ' ').substring(0, 19),
-          type: 'normal'
-        })
-      ) ?? [];
-
-    const newAllchats =
-      allChats?.map(
-        (chat: BattleChat): Message => ({
-          id: chat.messageId,
-          user: chat.sender,
-          team: chat.team,
-          content: chat.text,
-          timestamp: new Date(chat.createdAt).toISOString().replace('T', ' ').substring(0, 19),
-          type: 'normal'
-        })
-      ) ?? [];
-
-    setTeamMessages((prev) => [...prev, ...newChats]);
-    setAllMessages((prev) => [...prev, ...newAllchats]);
-  }, [chats, allChats]);
-
-  useEffect(() => {
     if (chatContainerRef.current) {
       chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight;
     }
   }, [currentMessages]);
 
-  useEffect(() => {
-    if (!socket) return;
-
-    const handleChatUpdate = (message: BattleChat) => {
-      const newMessage: Message = {
-        id: message.messageId,
-        user: message.sender,
-        team: message.team,
-        content: message.text,
-        timestamp: new Date(message.createdAt).toISOString().replace('T', ' ').substring(0, 19),
-        type: 'normal'
-      };
-
-      if (message.scope === 'TEAM') {
-        setTeamMessages((prev) => [...prev, newMessage]);
-      } else {
-        setAllMessages((prev) => [...prev, newMessage]);
-      }
-
-      if (onSendMessage) {
-        onSendMessage(newMessage.content);
-      }
-    };
-
-    socket.on('battle:chatUpdate', handleChatUpdate);
-
-    return () => {
-      socket.off('battle:chatUpdate', handleChatUpdate);
-    };
-  }, [socket, onSendMessage]);
-
   const handleSendMessage = (content: string) => {
-    if (!socket) return;
-
     const scope = activeTab === 'team' ? 'TEAM' : 'ALL';
-
-    const chatMessage = {
-      battleId,
-      scope,
-      team,
-      text: content.trim()
-    };
-
-    socket.emit('battle:chat', chatMessage);
-
-    const newMessage: Message = {
-      id: currentMessages.length + 1 + '',
-      user: 'You',
-      team: team,
-      content,
-      timestamp: new Date().toISOString().replace('T', ' ').substring(0, 19),
-      type: 'normal'
-    };
-
-    if (activeTab === 'team') {
-      setTeamMessages((prev) => [...prev, newMessage]);
-    } else {
-      setAllMessages((prev) => [...prev, newMessage]);
-    }
-    if (onSendMessage) {
-      onSendMessage(content);
-    }
+    sendMessage(content, scope);
   };
-
-  /*Todo 채팅 소켓 구동 이벤트로직 필요.
-    setTeamMessages() / setAllMessages()
-  */
 
   return (
     <section className="w-full flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden">

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -5,39 +5,32 @@ import ChatTabs from './ChatTabs';
 import PeoplesIcons from '@/assets/icon/peoples.svg?react';
 import MessageIcon from '@/assets/icon/message.svg?react';
 
-import { useState, useRef, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { useBattleStore, selectUserId, selectSelectedTeam, selectTeamCounts } from '../../stores/battleStore';
 import { useBattleChat } from '../../hooks/useBattleChat';
+import { useAutoScrollDown } from '@/commons/hooks/useAutoScroll';
 
 export default function ChatSection() {
   const userId = useBattleStore(selectUserId);
   const team = useBattleStore(selectSelectedTeam);
-  const teamCounts = useBattleStore(selectTeamCounts);
+  const { teamACount, teamBCount } = useBattleStore(selectTeamCounts);
 
   const { teamMessages, allMessages, sendMessage } = useBattleChat();
 
-  const teamACounts = teamCounts?.teamA || 0;
-  const teamBCounts = teamCounts?.teamB || 0;
-
   const [activeTab, setActiveTab] = useState<'team' | 'all'>(team === 'NONE' ? 'all' : 'team');
-  const chatContainerRef = useRef<HTMLDivElement>(null);
 
   const currentMessages = useMemo(() => {
     return activeTab === 'team' ? teamMessages : allMessages;
   }, [activeTab, teamMessages, allMessages]);
 
+  const chatContainerRef = useAutoScrollDown([currentMessages]);
+
   const currentMemberCount = useMemo(() => {
     if (activeTab === 'all') {
-      return teamACounts + teamBCounts;
+      return teamACount + teamBCount;
     }
-    return team === 'A' ? teamACounts : teamBCounts;
-  }, [activeTab, team, teamACounts, teamBCounts]);
-
-  useEffect(() => {
-    if (chatContainerRef.current) {
-      chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight;
-    }
-  }, [currentMessages]);
+    return team === 'A' ? teamACount : teamBCount;
+  }, [activeTab, team, teamACount, teamBCount]);
 
   const handleSendMessage = (content: string) => {
     const scope = activeTab === 'team' ? 'TEAM' : 'ALL';

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -6,8 +6,16 @@ import PeoplesIcons from '@/assets/icon/peoples.svg?react';
 import MessageIcon from '@/assets/icon/message.svg?react';
 
 import { useState, useRef, useEffect, useMemo } from 'react';
-import { Socket } from 'socket.io-client';
 import type { BattleChat } from '@/commons/types/battle';
+import {
+  useBattleStore,
+  selectSocket,
+  selectUserId,
+  selectBattleId,
+  selectSelectedTeam,
+  selectChats,
+  selectTeamCounts
+} from '../../stores/battleStore';
 
 interface Message {
   id: string;
@@ -19,28 +27,20 @@ interface Message {
 }
 
 interface ChatSectionProps {
-  socket: Socket | null;
-  battleId?: string;
-  chats: BattleChat[];
-  allChats: BattleChat[];
-  teamACounts: number;
-  teamBCounts: number;
   onSendMessage?: (content: string) => void;
-  team: 'A' | 'B' | 'NONE';
-  userId: string;
 }
 
-export default function ChatSection({
-  socket,
-  teamACounts,
-  teamBCounts,
-  onSendMessage,
-  team,
-  battleId,
-  chats,
-  allChats,
-  userId
-}: ChatSectionProps) {
+export default function ChatSection({ onSendMessage }: ChatSectionProps) {
+  const socket = useBattleStore(selectSocket);
+  const userId = useBattleStore(selectUserId);
+  const battleId = useBattleStore(selectBattleId);
+  const team = useBattleStore(selectSelectedTeam);
+  const chats = useBattleStore(selectChats);
+  const teamCounts = useBattleStore(selectTeamCounts);
+
+  const teamACounts = teamCounts?.teamA || 0;
+  const teamBCounts = teamCounts?.teamB || 0;
+  const allChats = chats || [];
   const [teamMessages, setTeamMessages] = useState<Message[]>([]);
   const [allMessages, setAllMessages] = useState<Message[]>([]);
   const [activeTab, setActiveTab] = useState<'team' | 'all'>(team === 'NONE' ? 'all' : 'team');

--- a/frontend/src/pages/battlePage/components/chatting/DiscussionMessage.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/DiscussionMessage.tsx
@@ -2,28 +2,28 @@ import { getTimeAgo } from '@/commons/utils/getTimeAgo';
 import BattleIcon from '@/assets/icon/battle.svg?react';
 import ShieldIcon from '@/assets/icon/shield.svg?react';
 
-interface ObjectionMessageProps {
+interface DiscussionMessageProps {
   team: 'A' | 'B' | 'NONE';
   content: string;
   timestamp: string;
-  type: 'objection' | 'rebuttal';
+  type: 'attack' | 'defense';
 }
 
-export default function ObjectionMessage({ team, content, timestamp, type }: ObjectionMessageProps) {
+export default function DiscussionMessage({ team, content, timestamp, type }: DiscussionMessageProps) {
   return (
     <div className={`flex justify-end mb-3 w-full shadow-lg `}>
       <div
-        className={`flex flex-col items-end  rounded-lg px-3 min-w-[300px] max-w-[350px] ${type === 'objection' ? 'bg-red-700' : 'bg-blue-700'} `}
+        className={`flex flex-col items-end  rounded-lg px-3 min-w-[300px] max-w-[350px] ${type === 'attack' ? 'bg-red-700' : 'bg-blue-700'} `}
       >
         <div className="w-full flex justify-between items-center gap-2 mb-1 text-[15px] mt-1">
           <div className="flex gap-2">
-            {type === 'objection' ? (
+            {type === 'attack' ? (
               <BattleIcon className="w-[24px] h-[24px]" />
             ) : (
               <ShieldIcon className="w-[26px] h-[26px]" />
             )}
             <span className="font-semibold">
-              {team}팀 {type === 'objection' ? '이의제기' : '반박'}
+              {team}팀 {type === 'attack' ? '공격' : '방어'}
             </span>
           </div>
           <span className="text-[11px] text-slate-100">{getTimeAgo(timestamp)}</span>

--- a/frontend/src/pages/battlePage/components/chatting/test/ChatSection.test.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/test/ChatSection.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChatSection from '@/pages/battlePage/components/chatting/ChatSection';
+import type { Message } from '@/pages/battlePage/utils/convertChatMessage';
+import type { Team } from '@/commons/types/battle';
+
+let mockUserId = 'user-123';
+let mockSelectedTeam: Team = 'A';
+let mockTeamCounts = { teamACount: 5, teamBCount: 3 };
+let mockTeamMessages: Message[] = [];
+let mockAllMessages: Message[] = [];
+
+vi.mock('@/pages/battlePage/stores/battleStore', () => ({
+  useBattleStore: vi.fn((selector) => {
+    const state = {
+      userId: mockUserId,
+      selectedTeam: mockSelectedTeam,
+      teamCounts: mockTeamCounts
+    };
+    return selector(state);
+  }),
+  selectUserId: (state: { userId: string }) => state.userId,
+  selectSelectedTeam: (state: { selectedTeam: Team }) => state.selectedTeam,
+  selectTeamCounts: (state: { teamCounts: { teamACount: number; teamBCount: number } }) => state.teamCounts
+}));
+
+vi.mock('@/pages/battlePage/hooks/useBattleChat', () => ({
+  useBattleChat: () => ({
+    teamMessages: mockTeamMessages,
+    allMessages: mockAllMessages,
+    sendMessage: vi.fn()
+  })
+}));
+
+vi.mock('@/commons/hooks/useAutoScroll', () => ({
+  useAutoScrollDown: () => ({ current: null })
+}));
+
+describe('배틀 페이지에 ChatSection 통합 테스트', () => {
+  beforeEach(() => {
+    mockUserId = 'user-123';
+    mockSelectedTeam = 'A';
+    mockTeamCounts = { teamACount: 5, teamBCount: 3 };
+
+    mockTeamMessages = [
+      { id: '1', user: 'You', team: 'A', content: 'A팀 메시지', timestamp: '2026-01-04 10:00:00', type: 'normal' }
+    ];
+
+    mockAllMessages = [
+      { id: '1', user: 'You', team: 'A', content: 'A팀 메시지', timestamp: '2026-01-04 10:00:00', type: 'normal' },
+      { id: '2', user: 'user-789', team: 'B', content: 'B팀 메시지', timestamp: '2026-01-04 10:02:00', type: 'normal' }
+    ];
+  });
+
+  it('팀 채팅 활성화시 현재 팀 메시지만 표시되는지', () => {
+    mockSelectedTeam = 'A';
+    mockTeamMessages = [
+      { id: '1', user: 'You', team: 'A', content: 'A팀 메시지', timestamp: '2026-01-04 10:00:00', type: 'normal' }
+    ];
+    render(<ChatSection />);
+
+    expect(screen.getByText('A팀 메시지')).toBeInTheDocument();
+    expect(screen.queryByText('B팀 메시지')).not.toBeInTheDocument();
+  });
+
+  it('전체 채팅 전환시 모든 팀 메시지 표시 되는지', () => {
+    mockSelectedTeam = 'NONE';
+    render(<ChatSection />);
+
+    expect(screen.getByText('A팀 메시지')).toBeInTheDocument();
+    expect(screen.getByText('B팀 메시지')).toBeInTheDocument();
+  });
+
+  it('멤버 수: 전체 = A + B', () => {
+    mockSelectedTeam = 'NONE';
+    render(<ChatSection />);
+
+    expect(screen.getByText('8')).toBeInTheDocument();
+  });
+
+  it('멤버 수: 팀 = 현재 팀만', () => {
+    mockSelectedTeam = 'A';
+    render(<ChatSection />);
+
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('팀 채팅 탭이 활성화 된 상태에서 전체 라운지 탭 전환 눌렀을 때 잘 변환 되는지', async () => {
+    mockSelectedTeam = 'A';
+    render(<ChatSection />);
+
+    // 초기: 팀 채팅 (B팀 메시지 안 보임)
+    expect(screen.queryByText('B팀 메시지')).not.toBeInTheDocument();
+
+    // 전체 라운지 탭 클릭
+    await userEvent.click(screen.getByText('전체 라운지'));
+
+    // 이제 B팀 메시지도 보임
+    expect(screen.getByText('B팀 메시지')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/battlePage/components/codeview/test/CodeSection.test.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/test/CodeSection.test.tsx
@@ -70,42 +70,6 @@ describe('CodeSection', () => {
     expect(screen.getByText(/function teamB/)).toBeInTheDocument();
   });
 
-  it('스플릿 뷰 버튼 클릭 시 onViewChange 콜백 호출', async () => {
-    const user = userEvent.setup();
-    render(
-      <CodeSection
-        onViewChange={mockOnViewChange}
-        currentView="tab"
-        codeA={mockCodeA}
-        codeB={mockCodeB}
-        language="JavaScript"
-      />
-    );
-
-    const splitButton = screen.getByRole('button', { name: '스플릿 뷰' });
-    await user.click(splitButton);
-
-    expect(mockOnViewChange).toHaveBeenCalledWith('split');
-  });
-
-  it('탭 뷰 버튼 클릭 시 onViewChange 콜백 호출', async () => {
-    const user = userEvent.setup();
-    render(
-      <CodeSection
-        onViewChange={mockOnViewChange}
-        currentView="split"
-        codeA={mockCodeA}
-        codeB={mockCodeB}
-        language="JavaScript"
-      />
-    );
-
-    const tabButton = screen.getByRole('button', { name: '탭 뷰' });
-    await user.click(tabButton);
-
-    expect(mockOnViewChange).toHaveBeenCalledWith('tab');
-  });
-
   it('split 뷰에서는 A/B 탭 버튼이 표시되지 않음', () => {
     render(
       <CodeSection

--- a/frontend/src/pages/battlePage/components/codeview/test/CodeSection.test.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/test/CodeSection.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CodeSection from '@/pages/battlePage/components/codeview/CodeSection';
+
+vi.mock('@/pages/battlePage/components/codeview/CodeViewer', () => ({
+  default: ({ team, code }: { team: 'A' | 'B'; code: string }) => (
+    <div data-testid={`code-viewer-${team}`}>
+      <span>구현 {team}</span>
+      <pre>{code}</pre>
+    </div>
+  )
+}));
+
+describe('CodeSection', () => {
+  const mockCodeA = 'function teamA() {\n  return "A";\n}';
+  const mockCodeB = 'function teamB() {\n  return "B";\n}';
+  const mockOnViewChange = vi.fn();
+
+  it('split 뷰에서 A, B 코드 모두 렌더링', () => {
+    render(
+      <CodeSection
+        onViewChange={mockOnViewChange}
+        currentView="split"
+        codeA={mockCodeA}
+        codeB={mockCodeB}
+        language="JavaScript"
+      />
+    );
+
+    expect(screen.getByTestId('code-viewer-A')).toBeInTheDocument();
+    expect(screen.getByTestId('code-viewer-B')).toBeInTheDocument();
+    expect(screen.getByText(/function teamA/)).toBeInTheDocument();
+    expect(screen.getByText(/function teamB/)).toBeInTheDocument();
+  });
+
+  it('tab 뷰에서 현재 탭 코드만 렌더링 (기본 A팀)', () => {
+    render(
+      <CodeSection
+        onViewChange={mockOnViewChange}
+        currentView="tab"
+        codeA={mockCodeA}
+        codeB={mockCodeB}
+        language="JavaScript"
+      />
+    );
+
+    expect(screen.getByTestId('code-viewer-A')).toBeInTheDocument();
+    expect(screen.queryByTestId('code-viewer-B')).not.toBeInTheDocument();
+    expect(screen.getByText(/function teamA/)).toBeInTheDocument();
+  });
+
+  it('tab 뷰에서 B팀 탭 클릭 시 B 코드로 전환', async () => {
+    const user = userEvent.setup();
+    render(
+      <CodeSection
+        onViewChange={mockOnViewChange}
+        currentView="tab"
+        codeA={mockCodeA}
+        codeB={mockCodeB}
+        language="JavaScript"
+      />
+    );
+
+    const bTeamButton = screen.getByRole('button', { name: 'B팀' });
+    await user.click(bTeamButton);
+
+    expect(screen.getByTestId('code-viewer-B')).toBeInTheDocument();
+    expect(screen.queryByTestId('code-viewer-A')).not.toBeInTheDocument();
+    expect(screen.getByText(/function teamB/)).toBeInTheDocument();
+  });
+
+  it('스플릿 뷰 버튼 클릭 시 onViewChange 콜백 호출', async () => {
+    const user = userEvent.setup();
+    render(
+      <CodeSection
+        onViewChange={mockOnViewChange}
+        currentView="tab"
+        codeA={mockCodeA}
+        codeB={mockCodeB}
+        language="JavaScript"
+      />
+    );
+
+    const splitButton = screen.getByRole('button', { name: '스플릿 뷰' });
+    await user.click(splitButton);
+
+    expect(mockOnViewChange).toHaveBeenCalledWith('split');
+  });
+
+  it('탭 뷰 버튼 클릭 시 onViewChange 콜백 호출', async () => {
+    const user = userEvent.setup();
+    render(
+      <CodeSection
+        onViewChange={mockOnViewChange}
+        currentView="split"
+        codeA={mockCodeA}
+        codeB={mockCodeB}
+        language="JavaScript"
+      />
+    );
+
+    const tabButton = screen.getByRole('button', { name: '탭 뷰' });
+    await user.click(tabButton);
+
+    expect(mockOnViewChange).toHaveBeenCalledWith('tab');
+  });
+
+  it('split 뷰에서는 A/B 탭 버튼이 표시되지 않음', () => {
+    render(
+      <CodeSection
+        onViewChange={mockOnViewChange}
+        currentView="split"
+        codeA={mockCodeA}
+        codeB={mockCodeB}
+        language="JavaScript"
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'A팀' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'B팀' })).not.toBeInTheDocument();
+  });
+
+  it('tab 뷰에서는 A/B 탭 버튼이 표시됨', () => {
+    render(
+      <CodeSection
+        onViewChange={mockOnViewChange}
+        currentView="tab"
+        codeA={mockCodeA}
+        codeB={mockCodeB}
+        language="JavaScript"
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'A팀' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'B팀' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react';
-import { isInputDisabled, getObjectionConfig } from '../../utils/battlePhase';
+import { isInputDisabled, getDiscussionConfig } from '../../utils/battlePhase';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from '../../stores/battleStore';
 
-interface ObjectionInputProps {
+interface DiscussionInputProps {
   disabled?: boolean;
   onSubmit?: (content: string) => void;
 }
 
-export default function ObjectionInput({ disabled = false, onSubmit }: ObjectionInputProps) {
+export default function DiscussionInput({ disabled = false, onSubmit }: DiscussionInputProps) {
   const battleProgress = useBattleStore(selectBattleProgress);
   const team = useBattleStore(selectSelectedTeam);
   const [inputValue, setInputValue] = useState('');
@@ -15,7 +15,7 @@ export default function ObjectionInput({ disabled = false, onSubmit }: Objection
   const phase = battleProgress?.phase;
   const turnStatus = battleProgress?.turn?.status;
 
-  const { placeholderText, buttonText, Icon } = getObjectionConfig(team, phase);
+  const { placeholderText, buttonText, Icon } = getDiscussionConfig(team, phase);
   const disabled_input = isInputDisabled(team, phase, turnStatus, disabled);
 
   const handleSubmit = () => {

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionVote.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionVote.tsx
@@ -1,9 +1,9 @@
 import ScaleIcon from '@/assets/icon/scale.svg?react';
-import ObjectionVoteItem from './ObjectionVoteItem';
+import DiscussionVoteItem from './DiscussionVoteItem';
 import { isMyTeamAttacking } from '../../utils/battlePhase';
 import { useBattleStore, selectDiscussions, selectBattleProgress, selectSelectedTeam } from '../../stores/battleStore';
 
-interface Objection {
+interface Discussion {
   id: number;
   user: string;
   team: 'A' | 'B';
@@ -13,14 +13,14 @@ interface Objection {
   hasVoted: boolean;
 }
 
-interface ObjectionVoteProps {
-  onVote: (objectionId: number) => void;
+interface DiscussionVoteProps {
+  onVote: (discussionId: number) => void;
 }
 
-export { type Objection };
+export { type Discussion };
 
-export default function ObjectionVote({ onVote }: ObjectionVoteProps) {
-  const objections = useBattleStore(selectDiscussions);
+export default function DiscussionVote({ onVote }: DiscussionVoteProps) {
+  const discussions = useBattleStore(selectDiscussions);
   const battleProgress = useBattleStore(selectBattleProgress);
   const team = useBattleStore(selectSelectedTeam);
 
@@ -38,7 +38,7 @@ export default function ObjectionVote({ onVote }: ObjectionVoteProps) {
     : '반론이 실시간으로 추가되며, 바로 투표 가능합니다!';
   const summaryText = isAttacking ? '이의제기' : '반론';
 
-  if (objections.length === 0) {
+  if (discussions.length === 0) {
     return null;
   }
 
@@ -58,16 +58,16 @@ export default function ObjectionVote({ onVote }: ObjectionVoteProps) {
 
       <div className="p-4 bg-gradient-to-r from-[#1E1E2F] to-[#59168B]">
         <div className="space-y-3 ">
-          {objections.map((objection) => (
-            <ObjectionVoteItem
-              key={objection.id}
-              user={objection.user}
-              team={objection.team}
-              content={objection.content}
-              votes={objection.votes}
-              totalVotes={objection.totalVotes}
-              hasVoted={objection.hasVoted}
-              onVote={() => onVote(objection.id)}
+          {discussions.map((discussion) => (
+            <DiscussionVoteItem
+              key={discussion.id}
+              user={discussion.user}
+              team={discussion.team}
+              content={discussion.content}
+              votes={discussion.votes}
+              totalVotes={discussion.totalVotes}
+              hasVoted={discussion.hasVoted}
+              onVote={() => onVote(discussion.id)}
             />
           ))}
         </div>
@@ -75,7 +75,7 @@ export default function ObjectionVote({ onVote }: ObjectionVoteProps) {
       <div className="py-4 bg-gradient-to-r from-[#1C398E] to-[#59168B] border-t border-[#2D2D3F] flex items-center justify-center gap-2 text-[13px]">
         <span className="text-[#FFB800]">⚡</span>
         <span className="text-white font-medium">
-          총 {objections.length}개의 {summaryText}
+          총 {discussions.length}개의 {summaryText}
         </span>
         <span className="text-[#99A1AF]">/ 투표 완료</span>
       </div>

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionVoteItem.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionVoteItem.tsx
@@ -1,4 +1,4 @@
-interface ObjectionVoteItemProps {
+interface DiscussionVoteItemProps {
   user: string;
   team: 'A' | 'B';
   content: string;
@@ -8,7 +8,7 @@ interface ObjectionVoteItemProps {
   onVote: () => void;
 }
 
-export default function ObjectionVoteItem({
+export default function DiscussionVoteItem({
   user,
   team,
   content,
@@ -16,7 +16,7 @@ export default function ObjectionVoteItem({
   totalVotes,
   hasVoted,
   onVote
-}: ObjectionVoteItemProps) {
+}: DiscussionVoteItemProps) {
   const getVotePercentage = (votes: number, total: number) => {
     if (total === 0) return 0;
     return Math.round((votes / total) * 100);

--- a/frontend/src/pages/battlePage/components/discussion/test/DiscussionInput.test.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/test/DiscussionInput.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DiscussionInput from '@/pages/battlePage/components/discussion/DiscussionInput';
+
+let mockBattleProgress: {
+  phase: string;
+  turn: { status: string } | null;
+} = {
+  phase: 'TEAM_A_ATTACK',
+  turn: { status: 'A_ATTACK' }
+};
+let mockSelectedTeam: 'A' | 'B' = 'A';
+
+vi.mock('@/pages/battlePage/stores/battleStore', () => ({
+  useBattleStore: vi.fn((selector) => {
+    const state = {
+      battleProgress: mockBattleProgress,
+      selectedTeam: mockSelectedTeam
+    };
+    return selector(state);
+  }),
+  selectBattleProgress: (state: { battleProgress: { phase: string; turn: { status: string } | null } }) =>
+    state.battleProgress,
+  selectSelectedTeam: (state: { selectedTeam: 'A' | 'B' }) => state.selectedTeam
+}));
+
+describe('DiscussionInput', () => {
+  const mockOnSubmit = vi.fn();
+
+  beforeEach(() => {
+    mockOnSubmit.mockClear();
+    mockBattleProgress = {
+      phase: 'TEAM_A_ATTACK',
+      turn: { status: 'A_ATTACK' }
+    };
+    mockSelectedTeam = 'A';
+  });
+
+  it('공격 팀일 때 "상대 진영에 이의제기..." placeholder 표시', () => {
+    mockSelectedTeam = 'A';
+    mockBattleProgress = { phase: 'TEAM_A_ATTACK', turn: { status: 'A_ATTACK' } };
+
+    render(<DiscussionInput onSubmit={mockOnSubmit} />);
+
+    expect(screen.getByPlaceholderText('상대 진영에 이의제기...')).toBeInTheDocument();
+    expect(screen.getByText('이의제기')).toBeInTheDocument();
+  });
+
+  it('방어 팀일 때 "상대 진영에 반론..." placeholder 표시', () => {
+    mockSelectedTeam = 'A';
+    mockBattleProgress = { phase: 'TEAM_B_ATTACK', turn: { status: 'B_ATTACK' } };
+
+    render(<DiscussionInput onSubmit={mockOnSubmit} />);
+
+    expect(screen.getByPlaceholderText('상대 진영에 반론...')).toBeInTheDocument();
+    expect(screen.getByText('반론')).toBeInTheDocument();
+  });
+
+  it('버튼 클릭 시 제출', async () => {
+    const user = userEvent.setup();
+    render(<DiscussionInput onSubmit={mockOnSubmit} />);
+
+    const input = screen.getByPlaceholderText(/상대 진영에/);
+    await user.type(input, '버튼 클릭 테스트');
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    expect(mockOnSubmit).toHaveBeenCalledWith('버튼 클릭 테스트');
+  });
+
+  it('제출 후 input 초기화', async () => {
+    const user = userEvent.setup();
+    render(<DiscussionInput onSubmit={mockOnSubmit} />);
+
+    const input = screen.getByPlaceholderText(/상대 진영에/) as HTMLInputElement;
+    await user.type(input, '초기화 테스트');
+    await user.click(screen.getByRole('button'));
+
+    expect(input.value).toBe('');
+  });
+
+  it('빈 문자열 제출 불가', async () => {
+    const user = userEvent.setup();
+    render(<DiscussionInput onSubmit={mockOnSubmit} />);
+
+    const input = screen.getByPlaceholderText(/상대 진영에/);
+    await user.type(input, '   {Enter}'); // 공백만 입력
+
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  it('OPINION_SHARE 단계에서 input 비활성화', () => {
+    mockBattleProgress = { phase: 'OPINION_SHARE', turn: null };
+
+    render(<DiscussionInput onSubmit={mockOnSubmit} />);
+
+    const input = screen.getByPlaceholderText(/상대 진영에/);
+    expect(input).toBeDisabled();
+  });
+
+  it('잘못된 턴에는 input 비활성화', () => {
+    mockSelectedTeam = 'A';
+    mockBattleProgress = { phase: 'TEAM_A_ATTACK', turn: { status: 'B_DEFENSE' } };
+
+    render(<DiscussionInput onSubmit={mockOnSubmit} />);
+
+    const input = screen.getByPlaceholderText(/상대 진영에/);
+    expect(input).toBeDisabled();
+  });
+
+  it('disabled prop이 true일 때 input 비활성화', () => {
+    render(<DiscussionInput onSubmit={mockOnSubmit} disabled={true} />);
+
+    const input = screen.getByPlaceholderText(/상대 진영에/);
+    expect(input).toBeDisabled();
+  });
+});

--- a/frontend/src/pages/battlePage/components/discussion/test/DiscussionVote.test.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/test/DiscussionVote.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DiscussionVote from '@/pages/battlePage/components/discussion/DiscussionVote';
+import type { Discussion } from '@/pages/battlePage/components/discussion/DiscussionVote';
+
+let mockDiscussions: Discussion[] = [];
+let mockBattleProgress: {
+  phase: string;
+  turn: { status: string };
+} = {
+  phase: 'TEAM_A_ATTACK',
+  turn: { status: 'A_ATTACK' }
+};
+let mockSelectedTeam: 'A' | 'B' = 'A';
+
+vi.mock('@/pages/battlePage/stores/battleStore', () => ({
+  useBattleStore: vi.fn((selector) => {
+    const state = {
+      discussions: mockDiscussions,
+      battleProgress: mockBattleProgress,
+      selectedTeam: mockSelectedTeam
+    };
+    return selector(state);
+  }),
+  selectDiscussions: (state: { discussions: Discussion[] }) => state.discussions,
+  selectBattleProgress: (state: { battleProgress: { phase: string; turn: { status: string } } }) =>
+    state.battleProgress,
+  selectSelectedTeam: (state: { selectedTeam: 'A' | 'B' }) => state.selectedTeam
+}));
+
+vi.mock('@/pages/battlePage/components/discussion/DiscussionVoteItem', () => ({
+  default: ({ user, content, votes, onVote }: { user: string; content: string; votes: number; onVote: () => void }) => (
+    <div data-testid="discussion-item">
+      <span>{user}</span>
+      <span>{content}</span>
+      <span>{votes}표</span>
+      <button onClick={onVote}>투표</button>
+    </div>
+  )
+}));
+
+describe('DiscussionVote', () => {
+  const mockOnVote = vi.fn();
+
+  beforeEach(() => {
+    mockOnVote.mockClear();
+    mockDiscussions = [];
+    mockBattleProgress = {
+      phase: 'TEAM_A_ATTACK',
+      turn: { status: 'A_ATTACK' }
+    };
+    mockSelectedTeam = 'A';
+  });
+
+  it('OPINION_SHARE 단계에서는 렌더링하지 않음', () => {
+    mockBattleProgress = { phase: 'OPINION_SHARE', turn: { status: 'A_ATTACK' } };
+
+    const { container } = render(<DiscussionVote onVote={mockOnVote} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('토론이 없을 때 렌더링하지 않음', () => {
+    mockDiscussions = [];
+
+    const { container } = render(<DiscussionVote onVote={mockOnVote} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('공격 팀일 때 "제출된 이의제기 목록" 헤더 표시', () => {
+    mockSelectedTeam = 'A';
+    mockBattleProgress = { phase: 'TEAM_A_ATTACK', turn: { status: 'A_ATTACK' } };
+    mockDiscussions = [
+      { id: 1, user: 'user1', team: 'A', content: '테스트', votes: 5, totalVotes: 10, hasVoted: false }
+    ];
+
+    render(<DiscussionVote onVote={mockOnVote} />);
+
+    expect(screen.getByText('제출된 이의제기 목록')).toBeInTheDocument();
+    expect(screen.getByText(/이의제기가 실시간으로 추가/)).toBeInTheDocument();
+  });
+
+  it('방어 팀일 때 "제출된 반론 목록" 헤더 표시', () => {
+    mockSelectedTeam = 'A';
+    mockBattleProgress = { phase: 'TEAM_B_ATTACK', turn: { status: 'B_ATTACK' } };
+    mockDiscussions = [
+      { id: 1, user: 'user1', team: 'B', content: '테스트', votes: 5, totalVotes: 10, hasVoted: false }
+    ];
+
+    render(<DiscussionVote onVote={mockOnVote} />);
+
+    expect(screen.getByText('제출된 반론 목록')).toBeInTheDocument();
+    expect(screen.getByText(/반론이 실시간으로 추가/)).toBeInTheDocument();
+  });
+
+  it('토론 목록과 총 개수 정확히 표시', () => {
+    mockDiscussions = [
+      { id: 1, user: 'user1', team: 'A', content: '첫번째 의견', votes: 5, totalVotes: 10, hasVoted: false },
+      { id: 2, user: 'user2', team: 'A', content: '두번째 의견', votes: 3, totalVotes: 10, hasVoted: false }
+    ];
+
+    render(<DiscussionVote onVote={mockOnVote} />);
+
+    expect(screen.getAllByTestId('discussion-item')).toHaveLength(2);
+    expect(screen.getByText('첫번째 의견')).toBeInTheDocument();
+    expect(screen.getByText('두번째 의견')).toBeInTheDocument();
+    expect(screen.getByText(/총 2개의/)).toBeInTheDocument();
+  });
+
+  it('토론 아이템 투표 시 onVote 콜백 호출', () => {
+    mockDiscussions = [
+      { id: 1, user: 'user1', team: 'A', content: '테스트', votes: 5, totalVotes: 10, hasVoted: false }
+    ];
+
+    render(<DiscussionVote onVote={mockOnVote} />);
+
+    const voteButton = screen.getByText('투표');
+    voteButton.click();
+
+    expect(mockOnVote).toHaveBeenCalledWith(1);
+  });
+});

--- a/frontend/src/pages/battlePage/components/effects/DiscussionModal.tsx
+++ b/frontend/src/pages/battlePage/components/effects/DiscussionModal.tsx
@@ -75,7 +75,7 @@ export default function DiscussionModal({ isOpen, team, content, type, onClose }
             className={`px-6 py-2 rounded-full bg-gradient-to-r ${gradient} shadow-lg ${glow} transition-all duration-500 ${badgeClass}`}
           >
             <span className="text-white font-bold text-lg tracking-wider">
-              {team}팀 {type === 'attack' ? '공격' : '방어'}
+              {team}팀 {type === 'attack' ? '이의제기' : '반론'}
             </span>
           </div>
 
@@ -87,7 +87,7 @@ export default function DiscussionModal({ isOpen, team, content, type, onClose }
                 textShadow: '0 0 40px rgba(255, 255, 255, 0.5), 0 0 80px rgba(255, 255, 255, 0.3)'
               }}
             >
-              {type === 'attack' ? '공격!!' : '방어!!'}
+              {type === 'attack' ? '이의제기!!' : '반론!!'}
             </h1>
           </div>
 

--- a/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
+++ b/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
@@ -1,25 +1,26 @@
 import StatusCard from './StatusCard';
 import VoteStatus from './VoteStatus';
+import { useBattleStore, selectCurrentStage, selectBattleProgress, selectTeamCounts } from '../../stores/battleStore';
+import { useBattleTimer } from '../../hooks/useBattleTimer';
 
 interface BattleHeaderProps {
   title: string;
   description: string;
-  status: string;
-  timer: string;
-  teamACounts: number;
-  teamBCounts: number;
-  teamNoneCounts: number;
 }
 
-export default function BattleHeader({
-  title,
-  description,
-  status,
-  timer,
-  teamACounts,
-  teamBCounts,
-  teamNoneCounts
-}: BattleHeaderProps) {
+export default function BattleHeader({ title, description }: BattleHeaderProps) {
+  const currentStage = useBattleStore(selectCurrentStage);
+  const battleProgress = useBattleStore(selectBattleProgress);
+  const teamCounts = useBattleStore(selectTeamCounts);
+
+  const { formattedTime } = useBattleTimer({
+    expiredAt: battleProgress?.expiredAt
+  });
+
+  const status = currentStage || 'END';
+  const teamACounts = teamCounts?.teamA || 0;
+  const teamBCounts = teamCounts?.teamB || 0;
+  const teamNoneCounts = 0;
   return (
     <header className="bg-[#1E1E2F] px-8 py-6 rounded-lg mb-2">
       <div className="flex justify-between">
@@ -28,7 +29,7 @@ export default function BattleHeader({
           <p className="text-[#99A1AF] text-[14px]">{description}</p>
         </div>
         <div className="flex items-center gap-4">
-          <StatusCard turn={status} timer={timer} />
+          <StatusCard turn={status} timer={formattedTime} />
           <VoteStatus teamACounts={teamACounts} teamBCounts={teamBCounts} teamNoneCounts={teamNoneCounts} />
         </div>
       </div>

--- a/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
+++ b/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
@@ -11,15 +11,13 @@ interface BattleHeaderProps {
 export default function BattleHeader({ title, description }: BattleHeaderProps) {
   const currentStage = useBattleStore(selectCurrentStage);
   const battleProgress = useBattleStore(selectBattleProgress);
-  const teamCounts = useBattleStore(selectTeamCounts);
+  const { teamACount, teamBCount } = useBattleStore(selectTeamCounts);
 
   const { formattedTime } = useBattleTimer({
     expiredAt: battleProgress?.expiredAt
   });
 
   const status = currentStage || 'END';
-  const teamACounts = teamCounts?.teamA || 0;
-  const teamBCounts = teamCounts?.teamB || 0;
   const teamNoneCounts = 0;
   return (
     <header className="bg-[#1E1E2F] px-8 py-6 rounded-lg mb-2">
@@ -30,7 +28,7 @@ export default function BattleHeader({ title, description }: BattleHeaderProps) 
         </div>
         <div className="flex items-center gap-4">
           <StatusCard turn={status} timer={formattedTime} />
-          <VoteStatus teamACounts={teamACounts} teamBCounts={teamBCounts} teamNoneCounts={teamNoneCounts} />
+          <VoteStatus teamACounts={teamACount} teamBCounts={teamBCount} teamNoneCounts={teamNoneCounts} />
         </div>
       </div>
     </header>

--- a/frontend/src/pages/battlePage/components/modals/TeamChangeModal.tsx
+++ b/frontend/src/pages/battlePage/components/modals/TeamChangeModal.tsx
@@ -10,7 +10,7 @@ interface TeamChangeModalProps {
 }
 
 export default function TeamChangeModal({ handleTeamChange, onClose }: TeamChangeModalProps) {
-  const teamCounts = useBattleStore(selectTeamCounts);
+  const { teamACount, teamBCount } = useBattleStore(selectTeamCounts);
   const currentTeam = useBattleStore(selectSelectedTeam);
   const battleProgress = useBattleStore(selectBattleProgress);
 
@@ -18,8 +18,6 @@ export default function TeamChangeModal({ handleTeamChange, onClose }: TeamChang
     expiredAt: battleProgress?.expiredAt
   });
 
-  const aTeamCounts = teamCounts?.teamA || 0;
-  const bTeamCounts = teamCounts?.teamB || 0;
   const noneTeamCounts = 0;
 
   const modalRoot = document.getElementById('modal-root');
@@ -51,7 +49,7 @@ export default function TeamChangeModal({ handleTeamChange, onClose }: TeamChang
           >
             {currentTeam === 'A' && <span className="absolute top-2 right-2 text-[#155DFC] text-[24px]">✓</span>}
             <span className="text-[18px] font-bold">A팀</span>
-            <span>{aTeamCounts}명</span>
+            <span>{teamACount}명</span>
           </button>
           <button
             type="button"
@@ -69,7 +67,7 @@ export default function TeamChangeModal({ handleTeamChange, onClose }: TeamChang
           >
             {currentTeam === 'B' && <span className="absolute top-2 right-2 text-[#FB2C36] text-[24px]">✓</span>}
             <span className="text-[18px] font-bold">B팀</span>
-            <span>{bTeamCounts}명</span>
+            <span>{teamBCount}명</span>
           </button>
         </div>
         <p className="text-[#6A7282] text-[14px]">💡투표 후에도 다음 투표 시간에 팀을 변경할 수 있어요</p>

--- a/frontend/src/pages/battlePage/components/modals/TeamChangeModal.tsx
+++ b/frontend/src/pages/battlePage/components/modals/TeamChangeModal.tsx
@@ -1,26 +1,27 @@
 import { createPortal } from 'react-dom';
 import VoteIcon from '@/assets/icon/vote.svg?react';
 import TimerIcon from '@/assets/icon/timer.svg?react';
+import { useBattleStore, selectTeamCounts, selectSelectedTeam, selectBattleProgress } from '../../stores/battleStore';
+import { useBattleTimer } from '../../hooks/useBattleTimer';
 
 interface TeamChangeModalProps {
-  aTeamCounts: number;
-  bTeamCounts: number;
-  currentTeam: 'A' | 'B' | 'NONE';
-  remainingTime: string;
-  noneTeamCounts: number;
   handleTeamChange: (team: 'A' | 'B' | 'NONE') => void;
   onClose: () => void;
 }
 
-export default function TeamChangeModal({
-  aTeamCounts,
-  bTeamCounts,
-  noneTeamCounts,
-  remainingTime,
-  currentTeam,
-  handleTeamChange,
-  onClose
-}: TeamChangeModalProps) {
+export default function TeamChangeModal({ handleTeamChange, onClose }: TeamChangeModalProps) {
+  const teamCounts = useBattleStore(selectTeamCounts);
+  const currentTeam = useBattleStore(selectSelectedTeam);
+  const battleProgress = useBattleStore(selectBattleProgress);
+
+  const { formattedTime: remainingTime } = useBattleTimer({
+    expiredAt: battleProgress?.expiredAt
+  });
+
+  const aTeamCounts = teamCounts?.teamA || 0;
+  const bTeamCounts = teamCounts?.teamB || 0;
+  const noneTeamCounts = 0;
+
   const modalRoot = document.getElementById('modal-root');
   if (!modalRoot) return null;
 

--- a/frontend/src/pages/battlePage/components/objection/ObjectionInput.tsx
+++ b/frontend/src/pages/battlePage/components/objection/ObjectionInput.tsx
@@ -1,20 +1,22 @@
 import { useState } from 'react';
 import { isInputDisabled, getObjectionConfig } from '../../utils/battlePhase';
-import type { TurnStatus } from '@/commons/types/battle';
+import { useBattleStore, selectBattleProgress, selectSelectedTeam } from '../../stores/battleStore';
 
 interface ObjectionInputProps {
   disabled?: boolean;
   onSubmit?: (content: string) => void;
-  phase?: 'OPINION_SHARE' | 'TEAM_A_ATTACK' | 'TEAM_B_ATTACK' | 'TEAM_SWITCH';
-  team?: 'A' | 'B' | 'NONE';
-  turnStatus?: TurnStatus | null;
 }
 
-export default function ObjectionInput({ disabled = false, onSubmit, phase, team, turnStatus }: ObjectionInputProps) {
+export default function ObjectionInput({ disabled = false, onSubmit }: ObjectionInputProps) {
+  const battleProgress = useBattleStore(selectBattleProgress);
+  const team = useBattleStore(selectSelectedTeam);
   const [inputValue, setInputValue] = useState('');
 
-  const { placeholderText, buttonText, Icon } = getObjectionConfig(team || 'NONE', phase);
-  const disabled_input = isInputDisabled(team || 'NONE', phase, turnStatus, disabled);
+  const phase = battleProgress?.phase;
+  const turnStatus = battleProgress?.turn?.status;
+
+  const { placeholderText, buttonText, Icon } = getObjectionConfig(team, phase);
+  const disabled_input = isInputDisabled(team, phase, turnStatus, disabled);
 
   const handleSubmit = () => {
     if (inputValue.trim() && !disabled_input) {

--- a/frontend/src/pages/battlePage/components/objection/ObjectionVote.tsx
+++ b/frontend/src/pages/battlePage/components/objection/ObjectionVote.tsx
@@ -1,6 +1,7 @@
 import ScaleIcon from '@/assets/icon/scale.svg?react';
 import ObjectionVoteItem from './ObjectionVoteItem';
 import { isMyTeamAttacking } from '../../utils/battlePhase';
+import { useBattleStore, selectDiscussions, selectBattleProgress, selectSelectedTeam } from '../../stores/battleStore';
 
 interface Objection {
   id: number;
@@ -13,16 +14,18 @@ interface Objection {
 }
 
 interface ObjectionVoteProps {
-  objections: Objection[];
   onVote: (objectionId: number) => void;
-  phase?: 'OPINION_SHARE' | 'TEAM_A_ATTACK' | 'TEAM_B_ATTACK' | 'TEAM_SWITCH';
-  team?: 'A' | 'B' | 'NONE';
 }
 
 export { type Objection };
 
-export default function ObjectionVote({ objections, onVote, phase, team }: ObjectionVoteProps) {
-  const isAttacking = isMyTeamAttacking(team || 'NONE', phase);
+export default function ObjectionVote({ onVote }: ObjectionVoteProps) {
+  const objections = useBattleStore(selectDiscussions);
+  const battleProgress = useBattleStore(selectBattleProgress);
+  const team = useBattleStore(selectSelectedTeam);
+
+  const phase = battleProgress?.phase;
+  const isAttacking = isMyTeamAttacking(team, phase);
 
   // OPINION_SHARE 단계에서는 투표 UI를 표시하지 않음
   if (phase === 'OPINION_SHARE') {

--- a/frontend/src/pages/battlePage/components/timeline/TimelineSection.tsx
+++ b/frontend/src/pages/battlePage/components/timeline/TimelineSection.tsx
@@ -3,13 +3,13 @@ import BattleIcon from '@/assets/icon/battle.svg?react';
 import DownArrowIcon from '@/assets/icon/downArrow.svg?react';
 import TimelineCard from './TimelineCard';
 import type { BattleDiscussion } from '@/commons/types/battle';
+import { useBattleStore, selectTimelines } from '../../stores/battleStore';
 
-interface TimelineSectionProps {
-  attackList?: BattleDiscussion[];
-  defenseList?: BattleDiscussion[];
-}
+export default function TimelineSection() {
+  const timelines = useBattleStore(selectTimelines);
 
-export default function TimelineSection({ attackList = [], defenseList = [] }: TimelineSectionProps) {
+  const attackList = timelines?.attacks || [];
+  const defenseList = timelines?.defenses || [];
   const timeLines = useMemo(() => {
     const maxLength = attackList.length;
     const result: BattleDiscussion[] = [];

--- a/frontend/src/pages/battlePage/components/timeline/TimelineSection.tsx
+++ b/frontend/src/pages/battlePage/components/timeline/TimelineSection.tsx
@@ -10,6 +10,7 @@ export default function TimelineSection() {
 
   const attackList = timelines?.attacks || [];
   const defenseList = timelines?.defenses || [];
+
   const timeLines = useMemo(() => {
     const maxLength = attackList.length;
     const result: BattleDiscussion[] = [];

--- a/frontend/src/pages/battlePage/hooks/useBattle.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattle.ts
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useBattleStore } from '../stores/battleStore';
+import { useBattleSocket } from './useBattleSocket';
+import { useBattleProgress } from './useBattleProgress';
+import { useBattleDiscussions } from './useBattleDiscussions';
+import { useBattleTimeline } from './useBattleTimeline';
+import { useBattleTeam } from './useBattleTeam';
+
+interface UseBattle {
+  battleId?: string;
+  onOpenTeamChangeModal: () => void;
+  onCloseTeamChangeModal: () => void;
+}
+
+export function useBattle({ battleId, onOpenTeamChangeModal, onCloseTeamChangeModal }: UseBattle) {
+  const location = useLocation();
+  const selectedTeam = (location.state as { selectedTeam?: 'A' | 'B' | 'NONE' })?.selectedTeam;
+  // 각 탭/브라우저별 고유 userId 생성 및 store 초기화
+  useEffect(() => {
+    if (!battleId) return;
+
+    let userId = sessionStorage.getItem('testUserId');
+    if (!userId) {
+      userId = `user-${Math.random().toString(36).substr(2, 9)}`;
+      sessionStorage.setItem('testUserId', userId);
+    }
+
+    useBattleStore.getState().initializeBattle({
+      userId,
+      battleId
+    });
+
+    // selectedTeam이 있으면 설정
+    if (selectedTeam) {
+      useBattleStore.getState().setSelectedTeam(selectedTeam);
+    }
+  }, [battleId, selectedTeam]);
+
+  // 모든 배틀 관련 훅 초기화
+  useBattleSocket();
+  useBattleProgress();
+
+  const { handleVote, handleDiscussionSubmit } = useBattleDiscussions();
+  const { effectModal, hideEffect } = useBattleTimeline();
+  const { handleTeamChange } = useBattleTeam({
+    onOpenTeamChangeModal,
+    onCloseTeamChangeModal
+  });
+
+  return {
+    handleVote,
+    handleDiscussionSubmit,
+    effectModal,
+    hideEffect,
+    handleTeamChange
+  };
+}

--- a/frontend/src/pages/battlePage/hooks/useBattleChat.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleChat.ts
@@ -1,0 +1,69 @@
+import { useEffect, useCallback, useMemo } from 'react';
+import type { BattleChat } from '@/commons/types/battle';
+import {
+  useBattleStore,
+  selectSocket,
+  selectUserId,
+  selectBattleId,
+  selectSelectedTeam,
+  selectChats
+} from '../stores/battleStore';
+import { convertBattleChatToMessage } from '../utils/convertChatMessage';
+
+export function useBattleChat() {
+  const socket = useBattleStore(selectSocket);
+  const userId = useBattleStore(selectUserId);
+  const battleId = useBattleStore(selectBattleId);
+  const team = useBattleStore(selectSelectedTeam);
+  const chats = useBattleStore(selectChats);
+  const addChat = useBattleStore((state) => state.addChat);
+
+  // store의 chats를 필터링/변환만 수행
+  const teamMessages = useMemo(
+    () => chats.filter((chat) => chat.scope === 'TEAM').map((chat) => convertBattleChatToMessage(chat, userId)),
+    [chats, userId]
+  );
+
+  const allMessages = useMemo(
+    () => chats.filter((chat) => chat.scope === 'ALL').map((chat) => convertBattleChatToMessage(chat, userId)),
+    [chats, userId]
+  );
+
+  // 실시간 채팅 업데이트 이벤트 구독
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleChatUpdate = (message: BattleChat) => {
+      addChat(message);
+    };
+
+    socket.on('battle:chatUpdate', handleChatUpdate);
+
+    return () => {
+      socket.off('battle:chatUpdate', handleChatUpdate);
+    };
+  }, [socket, addChat]);
+
+  // 메시지 전송
+  const sendMessage = useCallback(
+    (content: string, scope: 'TEAM' | 'ALL') => {
+      if (!socket) return;
+
+      const chatMessage = {
+        battleId,
+        scope,
+        team,
+        text: content.trim()
+      };
+
+      socket.emit('battle:chat', chatMessage);
+    },
+    [socket, battleId, team]
+  );
+
+  return {
+    teamMessages,
+    allMessages,
+    sendMessage
+  };
+}

--- a/frontend/src/pages/battlePage/hooks/useBattleChat.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleChat.ts
@@ -6,7 +6,8 @@ import {
   selectUserId,
   selectBattleId,
   selectSelectedTeam,
-  selectChats
+  selectTeamChats,
+  selectAllChats
 } from '../stores/battleStore';
 import { convertBattleChatToMessage } from '../utils/convertChatMessage';
 
@@ -15,18 +16,20 @@ export function useBattleChat() {
   const userId = useBattleStore(selectUserId);
   const battleId = useBattleStore(selectBattleId);
   const team = useBattleStore(selectSelectedTeam);
-  const chats = useBattleStore(selectChats);
+  const teamChats = useBattleStore(selectTeamChats);
+  const allChats = useBattleStore(selectAllChats);
   const addChat = useBattleStore((state) => state.addChat);
 
-  // store의 chats를 필터링/변환만 수행
+  // 팀 채팅: 같은 팀인 것만
   const teamMessages = useMemo(
-    () => chats.filter((chat) => chat.scope === 'TEAM').map((chat) => convertBattleChatToMessage(chat, userId)),
-    [chats, userId]
+    () => teamChats.filter((chat) => chat.team === team).map((chat) => convertBattleChatToMessage(chat, userId)),
+    [teamChats, team, userId]
   );
 
+  // 전체 채팅: 그대로
   const allMessages = useMemo(
-    () => chats.filter((chat) => chat.scope === 'ALL').map((chat) => convertBattleChatToMessage(chat, userId)),
-    [chats, userId]
+    () => allChats.map((chat) => convertBattleChatToMessage(chat, userId)),
+    [allChats, userId]
   );
 
   // 실시간 채팅 업데이트 이벤트 구독
@@ -56,9 +59,21 @@ export function useBattleChat() {
         text: content.trim()
       };
 
+      // Optimistic update: 즉시 로컬 state에 추가
+      const optimisticMessage: BattleChat = {
+        messageId: `temp-${Date.now()}`,
+        battleId,
+        sender: userId,
+        team,
+        scope,
+        text: content.trim(),
+        createdAt: new Date().toISOString() as any
+      };
+      addChat(optimisticMessage);
+
       socket.emit('battle:chat', chatMessage);
     },
-    [socket, battleId, team]
+    [socket, battleId, team, userId, addChat]
   );
 
   return {

--- a/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import { Socket } from 'socket.io-client';
+import { useBattleStore } from '../stores/battleStore';
+
+interface UseBattleDiscussionsProps {
+  socket: Socket | null;
+  userId: string;
+  team: 'A' | 'B' | 'NONE';
+}
+
+export function useBattleDiscussions({ socket, userId, team }: UseBattleDiscussionsProps) {
+  const { updateDiscussionVote, addDiscussion } = useBattleStore();
+
+  useEffect(() => {
+    if (!socket) return;
+
+    // 투표 업데이트 이벤트
+    const handleVoteUpdate = (data: { discussionId: string; upvotes: number; votes: string[] }) => {
+      updateDiscussionVote(data.discussionId, data.upvotes, data.votes, userId);
+    };
+
+    // 새 이의제기/반론 추가
+    const handleNewDiscussion = (data: {
+      discussionId: string;
+      authorId: string;
+      content: string;
+      upvotes: number;
+      votes: string[];
+    }) => {
+      if (team === 'NONE') return;
+
+      addDiscussion({
+        id: data.discussionId as unknown as number,
+        user: data.authorId === userId ? 'You' : `User-${data.authorId.slice(0, 4)}`,
+        team: team as 'A' | 'B',
+        content: data.content,
+        votes: data.upvotes,
+        totalVotes: 0,
+        hasVoted: data.votes.includes(userId)
+      });
+    };
+
+    socket.on('battle:attackvote:update', handleVoteUpdate);
+    socket.on('battle:defensevote:update', handleVoteUpdate);
+    socket.on('Battle:NewAttack', handleNewDiscussion);
+    socket.on('Battle:NewDefense', handleNewDiscussion);
+
+    return () => {
+      socket.off('battle:attackvote:update', handleVoteUpdate);
+      socket.off('battle:defensevote:update', handleVoteUpdate);
+      socket.off('Battle:NewAttack', handleNewDiscussion);
+      socket.off('Battle:NewDefense', handleNewDiscussion);
+    };
+  }, [socket, userId, team, updateDiscussionVote, addDiscussion]);
+}

--- a/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
@@ -1,15 +1,60 @@
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import { Socket } from 'socket.io-client';
-import { useBattleStore } from '../stores/battleStore';
+import { useBattleStore, selectBattleProgress, selectDiscussions } from '../stores/battleStore';
+import { getObjectionConfig, isInputDisabled } from '../utils/battlePhase';
 
 interface UseBattleDiscussionsProps {
   socket: Socket | null;
   userId: string;
   team: 'A' | 'B' | 'NONE';
+  battleId: string;
 }
 
-export function useBattleDiscussions({ socket, userId, team }: UseBattleDiscussionsProps) {
+export function useBattleDiscussions({ socket, userId, team, battleId }: UseBattleDiscussionsProps) {
   const { updateDiscussionVote, addDiscussion } = useBattleStore();
+  const battleProgress = useBattleStore(selectBattleProgress);
+  const objections = useBattleStore(selectDiscussions);
+
+  const handleVote = useCallback(
+    (objectionId: number) => {
+      if (!socket || team === 'NONE') return;
+
+      const targetObjection = objections?.find((obj) => obj.id === objectionId);
+      if (targetObjection?.hasVoted) return;
+
+      const { isAttacking } = getObjectionConfig(team, battleProgress?.phase);
+      const eventName = isAttacking ? 'battle:attackvote' : 'battle:defensevote';
+
+      socket.emit(eventName, {
+        battleId,
+        discussionId: String(objectionId),
+        userId,
+        team
+      });
+    },
+    [socket, team, objections, battleProgress, battleId, userId]
+  );
+
+  const handleObjectionSubmit = useCallback(
+    (content: string) => {
+      if (team === 'NONE' || !socket) return;
+
+      const { isAttacking } = getObjectionConfig(team, battleProgress?.phase);
+      const canSubmit = !isInputDisabled(team, battleProgress?.phase, battleProgress?.turn?.status);
+
+      if (!canSubmit) {
+        return;
+      }
+
+      socket.emit(isAttacking ? 'Battle:Attack' : 'Battle:Defense', {
+        battleId,
+        authorId: userId,
+        content,
+        team
+      });
+    },
+    [socket, team, battleProgress, battleId, userId]
+  );
 
   useEffect(() => {
     if (!socket) return;
@@ -52,4 +97,6 @@ export function useBattleDiscussions({ socket, userId, team }: UseBattleDiscussi
       socket.off('Battle:NewDefense', handleNewDiscussion);
     };
   }, [socket, userId, team, updateDiscussionVote, addDiscussion]);
+
+  return { handleVote, handleObjectionSubmit };
 }

--- a/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
@@ -8,7 +8,7 @@ import {
   selectBattleId,
   selectSelectedTeam
 } from '../stores/battleStore';
-import { getObjectionConfig, isInputDisabled } from '../utils/battlePhase';
+import { getDiscussionConfig, isInputDisabled } from '../utils/battlePhase';
 
 export function useBattleDiscussions() {
   const socket = useBattleStore(selectSocket);
@@ -17,33 +17,33 @@ export function useBattleDiscussions() {
   const team = useBattleStore(selectSelectedTeam);
   const { updateDiscussionVote, addDiscussion } = useBattleStore();
   const battleProgress = useBattleStore(selectBattleProgress);
-  const objections = useBattleStore(selectDiscussions);
+  const discussions = useBattleStore(selectDiscussions);
 
   const handleVote = useCallback(
-    (objectionId: number) => {
+    (discussionId: number) => {
       if (!socket || team === 'NONE') return;
 
-      const targetObjection = objections?.find((obj) => obj.id === objectionId);
-      if (targetObjection?.hasVoted) return;
+      const targetDiscussion = discussions?.find((obj) => obj.id === discussionId);
+      if (targetDiscussion?.hasVoted) return;
 
-      const { isAttacking } = getObjectionConfig(team, battleProgress?.phase);
+      const { isAttacking } = getDiscussionConfig(team, battleProgress?.phase);
       const eventName = isAttacking ? 'battle:attackvote' : 'battle:defensevote';
 
       socket.emit(eventName, {
         battleId,
-        discussionId: String(objectionId),
+        discussionId: String(discussionId),
         userId,
         team
       });
     },
-    [socket, team, objections, battleProgress, battleId, userId]
+    [socket, team, discussions, battleProgress, battleId, userId]
   );
 
-  const handleObjectionSubmit = useCallback(
+  const handleDiscussionSubmit = useCallback(
     (content: string) => {
       if (team === 'NONE' || !socket) return;
 
-      const { isAttacking } = getObjectionConfig(team, battleProgress?.phase);
+      const { isAttacking } = getDiscussionConfig(team, battleProgress?.phase);
       const canSubmit = !isInputDisabled(team, battleProgress?.phase, battleProgress?.turn?.status);
 
       if (!canSubmit) {
@@ -102,5 +102,5 @@ export function useBattleDiscussions() {
     };
   }, [socket, userId, team, updateDiscussionVote, addDiscussion]);
 
-  return { handleVote, handleObjectionSubmit };
+  return { handleVote, handleDiscussionSubmit };
 }

--- a/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
@@ -1,16 +1,20 @@
 import { useEffect, useCallback } from 'react';
-import { Socket } from 'socket.io-client';
-import { useBattleStore, selectBattleProgress, selectDiscussions } from '../stores/battleStore';
+import {
+  useBattleStore,
+  selectBattleProgress,
+  selectDiscussions,
+  selectSocket,
+  selectUserId,
+  selectBattleId,
+  selectSelectedTeam
+} from '../stores/battleStore';
 import { getObjectionConfig, isInputDisabled } from '../utils/battlePhase';
 
-interface UseBattleDiscussionsProps {
-  socket: Socket | null;
-  userId: string;
-  team: 'A' | 'B' | 'NONE';
-  battleId: string;
-}
-
-export function useBattleDiscussions({ socket, userId, team, battleId }: UseBattleDiscussionsProps) {
+export function useBattleDiscussions() {
+  const socket = useBattleStore(selectSocket);
+  const userId = useBattleStore(selectUserId);
+  const battleId = useBattleStore(selectBattleId);
+  const team = useBattleStore(selectSelectedTeam);
   const { updateDiscussionVote, addDiscussion } = useBattleStore();
   const battleProgress = useBattleStore(selectBattleProgress);
   const objections = useBattleStore(selectDiscussions);

--- a/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+import { Socket } from 'socket.io-client';
+import type { BattleProgressState } from '@/commons/types/battle';
+import { useBattleStore } from '../stores/battleStore';
+
+interface UseBattleProgressProps {
+  socket: Socket | null;
+}
+
+export function useBattleProgress({ socket }: UseBattleProgressProps) {
+  const { setCurrentStage, updateBattleProgress } = useBattleStore();
+
+  useEffect(() => {
+    if (!socket) return;
+
+    // Phase 변경 이벤트 구독
+    const handlePhaseUpdate = (data: BattleProgressState) => {
+      updateBattleProgress({
+        phase: data.phase,
+        startedAt: data.startedAt,
+        expiredAt: data.expiredAt
+      });
+      setCurrentStage(data.phase);
+    };
+
+    // Turn 변경 이벤트 구독
+    const handleTurnUpdate = (data: BattleProgressState) => {
+      updateBattleProgress({
+        turn: data.turn,
+        startedAt: data.startedAt,
+        expiredAt: data.expiredAt
+      });
+      setCurrentStage(data.turn?.status || null);
+    };
+
+    // Round 변경 이벤트 구독
+    const handleRoundUpdate = (data: { battleId: string; round: number }) => {
+      updateBattleProgress({
+        round: data.round
+      });
+    };
+
+    socket.on('battle:phase:update', handlePhaseUpdate);
+    socket.on('battle:turn:update', handleTurnUpdate);
+    socket.on('battle:round:update', handleRoundUpdate);
+
+    return () => {
+      socket.off('battle:phase:update', handlePhaseUpdate);
+      socket.off('battle:turn:update', handleTurnUpdate);
+      socket.off('battle:round:update', handleRoundUpdate);
+    };
+  }, [socket, setCurrentStage, updateBattleProgress]);
+}

--- a/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
@@ -19,6 +19,9 @@ export function useBattleProgress() {
         expiredAt: data.expiredAt
       });
       setCurrentStage(data.phase);
+
+      // 페이즈가 변경되면 투표 리스트 초기화
+      useBattleStore.getState().setDiscussions([]);
     };
 
     // Turn 변경 이벤트 구독
@@ -29,6 +32,9 @@ export function useBattleProgress() {
         expiredAt: data.expiredAt
       });
       setCurrentStage(data.turn?.status || null);
+
+      // 턴이 변경되면 투표 리스트 초기화
+      useBattleStore.getState().setDiscussions([]);
     };
 
     // Round 변경 이벤트 구독

--- a/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Socket } from 'socket.io-client';
 import type { BattleProgressState } from '@/commons/types/battle';
 import { useBattleStore } from '../stores/battleStore';
@@ -9,6 +10,7 @@ interface UseBattleProgressProps {
 
 export function useBattleProgress({ socket }: UseBattleProgressProps) {
   const { setCurrentStage, updateBattleProgress } = useBattleStore();
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!socket) return;
@@ -44,10 +46,17 @@ export function useBattleProgress({ socket }: UseBattleProgressProps) {
     socket.on('battle:turn:update', handleTurnUpdate);
     socket.on('battle:round:update', handleRoundUpdate);
 
+    // 배틀 종료 이벤트 구독
+    const handleBattleClosed = (payload: { battleId: string }) => {
+      navigate(`/battle/${payload.battleId}/result`);
+    };
+    socket.on('battle:closed', handleBattleClosed);
+
     return () => {
       socket.off('battle:phase:update', handlePhaseUpdate);
       socket.off('battle:turn:update', handleTurnUpdate);
       socket.off('battle:round:update', handleRoundUpdate);
+      socket.off('battle:closed', handleBattleClosed);
     };
-  }, [socket, setCurrentStage, updateBattleProgress]);
+  }, [socket, setCurrentStage, updateBattleProgress, navigate]);
 }

--- a/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
@@ -1,14 +1,10 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Socket } from 'socket.io-client';
 import type { BattleProgressState } from '@/commons/types/battle';
-import { useBattleStore } from '../stores/battleStore';
+import { useBattleStore, selectSocket } from '../stores/battleStore';
 
-interface UseBattleProgressProps {
-  socket: Socket | null;
-}
-
-export function useBattleProgress({ socket }: UseBattleProgressProps) {
+export function useBattleProgress() {
+  const socket = useBattleStore(selectSocket);
   const { setCurrentStage, updateBattleProgress } = useBattleStore();
   const navigate = useNavigate();
 
@@ -47,8 +43,8 @@ export function useBattleProgress({ socket }: UseBattleProgressProps) {
     socket.on('battle:round:update', handleRoundUpdate);
 
     // 배틀 종료 이벤트 구독
-    const handleBattleClosed = (payload: { battleId: string }) => {
-      navigate(`/battle/${payload.battleId}/result`);
+    const handleBattleClosed = (data: { battleId: string }) => {
+      navigate(`/battle/${data.battleId}/result`);
     };
     socket.on('battle:closed', handleBattleClosed);
 

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -11,15 +11,7 @@ import { useBattleStore } from '../stores/battleStore';
 export function useBattleSocket({ battleId, userId, team, password }: UseBattleSocketProps) {
   const [battleData, setBattleData] = useState<BattleJoinData | null>(null);
 
-  const {
-    setSocket,
-    setIsConnected,
-    setCurrentStage,
-    setBattleProgress,
-    setDiscussions,
-    addDiscussion,
-    updateDiscussionVote
-  } = useBattleStore();
+  const { setSocket, setIsConnected, setCurrentStage, setBattleProgress, setDiscussions } = useBattleStore();
 
   useEffect(() => {
     const newSocket = io(import.meta.env.VITE_API_URL, {
@@ -92,37 +84,6 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       console.log('Battle:Defensed received:', data);
     });
 
-    // 투표 업데이트 이벤트
-    const handleVoteUpdate = (data: { discussionId: string; upvotes: number; votes: string[] }) => {
-      updateDiscussionVote(data.discussionId, data.upvotes, data.votes, userId);
-    };
-
-    // 새 이의제기/반론 추가
-    const handleNewDiscussion = (data: {
-      discussionId: string;
-      authorId: string;
-      content: string;
-      upvotes: number;
-      votes: string[];
-    }) => {
-      if (team === 'NONE') return;
-
-      addDiscussion({
-        id: data.discussionId as unknown as number,
-        user: data.authorId === userId ? 'You' : `User-${data.authorId.slice(0, 4)}`,
-        team: team as 'A' | 'B',
-        content: data.content,
-        votes: data.upvotes,
-        totalVotes: 0,
-        hasVoted: data.votes.includes(userId)
-      });
-    };
-
-    newSocket.on('battle:attackvote:update', handleVoteUpdate);
-    newSocket.on('battle:defensevote:update', handleVoteUpdate);
-    newSocket.on('Battle:NewAttack', handleNewDiscussion);
-    newSocket.on('Battle:NewDefense', handleNewDiscussion);
-
     return () => {
       newSocket.off('connect');
       newSocket.off('battle:joined');
@@ -139,19 +100,7 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       setSocket(null);
       setIsConnected(false);
     };
-  }, [
-    battleId,
-    userId,
-    team,
-    password,
-    setSocket,
-    setIsConnected,
-    setCurrentStage,
-    setBattleProgress,
-    setDiscussions,
-    addDiscussion,
-    updateDiscussionVote
-  ]);
+  }, [battleId, userId, team, password, setSocket, setIsConnected, setCurrentStage, setBattleProgress, setDiscussions]);
 
   return {
     battleData

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -1,5 +1,5 @@
-import { useEffect, useState, useRef } from 'react';
-import { io, Socket } from 'socket.io-client';
+import { useEffect, useState } from 'react';
+import { io } from 'socket.io-client';
 import type {
   BattleJoinData,
   UseBattleSocketProps,
@@ -7,6 +7,7 @@ import type {
   BattleAttackedResult,
   BattleDefensedResult
 } from '@/commons/types/battle';
+import { useBattleStore } from '../stores/battleStore';
 
 interface Objection {
   id: number;
@@ -21,17 +22,16 @@ interface Objection {
 export function useBattleSocket({ battleId, userId, team, password }: UseBattleSocketProps) {
   const [battleData, setBattleData] = useState<BattleJoinData | null>(null);
   const [battleProgress, setBattleProgressState] = useState<BattleProgressState | null>(null);
-  const [currentStage, setCurrentStage] = useState<string | null>(null);
-  const [isConnected, setIsConnected] = useState(false);
   const [objections, setObjections] = useState<Objection[]>([]);
-  const socketRef = useRef<Socket | null>(null);
+
+  const { setSocket, setIsConnected, setCurrentStage } = useBattleStore();
 
   useEffect(() => {
     const newSocket = io(import.meta.env.VITE_API_URL, {
       transports: ['websocket']
     });
 
-    socketRef.current = newSocket;
+    setSocket(newSocket);
 
     newSocket.on('connect', () => {
       setIsConnected(true);
@@ -198,15 +198,14 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       newSocket.off('Battle:NewAttack', handleNewDiscussion);
       newSocket.off('Battle:NewDefense', handleNewDiscussion);
       newSocket.disconnect();
+      setSocket(null);
+      setIsConnected(false);
     };
-  }, [battleId, userId, team, password]);
+  }, [battleId, userId, team, password, setSocket, setIsConnected, setCurrentStage]);
 
   return {
-    socket: socketRef.current,
     battleData,
     battleProgress,
-    currentStage,
-    isConnected,
     objections
   };
 }

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -3,7 +3,6 @@ import { io } from 'socket.io-client';
 import type {
   BattleJoinData,
   UseBattleSocketProps,
-  BattleProgressState,
   BattleAttackedResult,
   BattleDefensedResult
 } from '@/commons/types/battle';
@@ -21,10 +20,9 @@ interface Objection {
 
 export function useBattleSocket({ battleId, userId, team, password }: UseBattleSocketProps) {
   const [battleData, setBattleData] = useState<BattleJoinData | null>(null);
-  const [battleProgress, setBattleProgressState] = useState<BattleProgressState | null>(null);
   const [objections, setObjections] = useState<Objection[]>([]);
 
-  const { setSocket, setIsConnected, setCurrentStage } = useBattleStore();
+  const { setSocket, setIsConnected, setCurrentStage, setBattleProgress } = useBattleStore();
 
   useEffect(() => {
     const newSocket = io(import.meta.env.VITE_API_URL, {
@@ -48,7 +46,7 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       setBattleData(data);
 
       // 초기 battleState 설정
-      setBattleProgressState({
+      setBattleProgress({
         round: data.round,
         phase: data.phase,
         turn: data.turn,
@@ -157,11 +155,10 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       setSocket(null);
       setIsConnected(false);
     };
-  }, [battleId, userId, team, password, setSocket, setIsConnected, setCurrentStage]);
+  }, [battleId, userId, team, password, setSocket, setIsConnected, setCurrentStage, setBattleProgress]);
 
   return {
     battleData,
-    battleProgress,
     objections
   };
 }

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -1,17 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { io } from 'socket.io-client';
-import type {
-  BattleJoinData,
-  UseBattleSocketProps,
-  BattleAttackedResult,
-  BattleDefensedResult
-} from '@/commons/types/battle';
+import type { BattleJoinData, UseBattleSocketProps } from '@/commons/types/battle';
 import { useBattleStore } from '../stores/battleStore';
 
 export function useBattleSocket({ battleId, userId, team, password }: UseBattleSocketProps) {
-  const [battleData, setBattleData] = useState<BattleJoinData | null>(null);
-
-  const { setSocket, setIsConnected, setCurrentStage, setBattleProgress, setDiscussions } = useBattleStore();
+  const {
+    setSocket,
+    setIsConnected,
+    setCurrentStage,
+    setBattleProgress,
+    setDiscussions,
+    setTeamCounts,
+    setTimelines,
+    setChats
+  } = useBattleStore();
 
   useEffect(() => {
     const newSocket = io(import.meta.env.VITE_API_URL, {
@@ -32,8 +34,6 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
 
     // 배틀 참여 성공시 데이터 수신
     newSocket.once('battle:joined', (data: BattleJoinData) => {
-      setBattleData(data);
-
       // 초기 battleState 설정
       setBattleProgress({
         round: data.round,
@@ -48,6 +48,11 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       } else {
         setCurrentStage(data.turn?.status || data.phase);
       }
+
+      // 팀 인원 수, 타임라인, 채팅 데이터 store에 저장
+      setTeamCounts(data.counts);
+      setTimelines(data.timelines);
+      setChats(data.allChats || []);
 
       // 초기 투표 리스트 동기화
       if (team !== 'NONE' && data.turn?.status) {
@@ -76,14 +81,6 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       }
     });
 
-    newSocket.on('battle:attacked', (data: BattleAttackedResult) => {
-      console.log('Battle:Attacked received:', data);
-    });
-
-    newSocket.on('battle:defensed', (data: BattleDefensedResult) => {
-      console.log('Battle:Defensed received:', data);
-    });
-
     return () => {
       newSocket.off('connect');
       newSocket.off('battle:joined');
@@ -100,9 +97,18 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       setSocket(null);
       setIsConnected(false);
     };
-  }, [battleId, userId, team, password, setSocket, setIsConnected, setCurrentStage, setBattleProgress, setDiscussions]);
-
-  return {
-    battleData
-  };
+  }, [
+    battleId,
+    userId,
+    team,
+    password,
+    setSocket,
+    setIsConnected,
+    setCurrentStage,
+    setBattleProgress,
+    setDiscussions,
+    setTeamCounts,
+    setTimelines,
+    setChats
+  ]);
 }

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -1,10 +1,12 @@
 import { useEffect } from 'react';
 import { io } from 'socket.io-client';
-import type { BattleJoinData, UseBattleSocketProps } from '@/commons/types/battle';
+import type { BattleJoinData } from '@/commons/types/battle';
 import { useBattleStore } from '../stores/battleStore';
 
-export function useBattleSocket({ battleId, userId, team, password }: UseBattleSocketProps) {
+export function useBattleSocket() {
   const {
+    userId,
+    battleId,
     setSocket,
     setIsConnected,
     setCurrentStage,
@@ -16,6 +18,8 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
   } = useBattleStore();
 
   useEffect(() => {
+    if (!userId || !battleId) return;
+
     const newSocket = io(import.meta.env.VITE_API_URL, {
       transports: ['websocket']
     });
@@ -27,8 +31,7 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       newSocket.emit('battle:join', {
         userId,
         battleId,
-        team,
-        password
+        team: 'NONE'
       });
     });
 
@@ -55,6 +58,7 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       setChats(data.allChats || []);
 
       // 초기 투표 리스트 동기화
+      const team = useBattleStore.getState().selectedTeam;
       if (team !== 'NONE' && data.turn?.status) {
         const VOTE_MAP: Record<string, typeof data.attacks | typeof data.defenses> = {
           A_ATTACK_B: data.attacks,
@@ -98,10 +102,8 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       setIsConnected(false);
     };
   }, [
-    battleId,
     userId,
-    team,
-    password,
+    battleId,
     setSocket,
     setIsConnected,
     setCurrentStage,

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -89,50 +89,6 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       }
     });
 
-    // Phase 변경 이벤트 구독
-    newSocket.on('battle:phase:update', (data: BattleProgressState) => {
-      setBattleProgressState((prev) =>
-        prev
-          ? {
-              ...prev,
-              phase: data.phase,
-              startedAt: data.startedAt,
-              expiredAt: data.expiredAt
-            }
-          : null
-      );
-      setCurrentStage(data.phase);
-      setObjections([]);
-    });
-
-    // Turn 변경 이벤트 구독
-    newSocket.on('battle:turn:update', (data: BattleProgressState) => {
-      setBattleProgressState((prev) =>
-        prev
-          ? {
-              ...prev,
-              turn: data.turn,
-              startedAt: data.startedAt,
-              expiredAt: data.expiredAt
-            }
-          : null
-      );
-      setCurrentStage(data.turn?.status || null);
-      setObjections([]);
-    });
-
-    // Round 변경 이벤트 구독
-    newSocket.on('battle:round:update', (data: { battleId: string; round: number }) => {
-      setBattleProgressState((prev) =>
-        prev
-          ? {
-              ...prev,
-              round: data.round
-            }
-          : null
-      );
-    });
-
     newSocket.on('battle:attacked', (data: BattleAttackedResult) => {
       console.log('Battle:Attacked received:', data);
     });

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -7,6 +7,7 @@ export function useBattleSocket() {
   const {
     userId,
     battleId,
+    selectedTeam,
     setSocket,
     setIsConnected,
     setCurrentStage,
@@ -14,7 +15,8 @@ export function useBattleSocket() {
     setDiscussions,
     setTeamCounts,
     setTimelines,
-    setChats
+    setTeamChats,
+    setAllChats
   } = useBattleStore();
 
   useEffect(() => {
@@ -31,7 +33,7 @@ export function useBattleSocket() {
       newSocket.emit('battle:join', {
         userId,
         battleId,
-        team: 'NONE'
+        team: selectedTeam
       });
     });
 
@@ -55,7 +57,8 @@ export function useBattleSocket() {
       // 팀 인원 수, 타임라인, 채팅 데이터 store에 저장
       setTeamCounts({ teamACount: data.counts.teamA, teamBCount: data.counts.teamB });
       setTimelines(data.timelines);
-      setChats(data.allChats || []);
+      setTeamChats(data.chats || []);
+      setAllChats(data.allChats || []);
 
       // 초기 투표 리스트 동기화
       const team = useBattleStore.getState().selectedTeam;
@@ -104,6 +107,7 @@ export function useBattleSocket() {
   }, [
     userId,
     battleId,
+    selectedTeam,
     setSocket,
     setIsConnected,
     setCurrentStage,
@@ -111,6 +115,7 @@ export function useBattleSocket() {
     setDiscussions,
     setTeamCounts,
     setTimelines,
-    setChats
+    setTeamChats,
+    setAllChats
   ]);
 }

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -8,21 +8,18 @@ import type {
 } from '@/commons/types/battle';
 import { useBattleStore } from '../stores/battleStore';
 
-interface Objection {
-  id: number;
-  user: string;
-  team: 'A' | 'B';
-  content: string;
-  votes: number;
-  totalVotes: number;
-  hasVoted: boolean;
-}
-
 export function useBattleSocket({ battleId, userId, team, password }: UseBattleSocketProps) {
   const [battleData, setBattleData] = useState<BattleJoinData | null>(null);
-  const [objections, setObjections] = useState<Objection[]>([]);
 
-  const { setSocket, setIsConnected, setCurrentStage, setBattleProgress } = useBattleStore();
+  const {
+    setSocket,
+    setIsConnected,
+    setCurrentStage,
+    setBattleProgress,
+    setDiscussions,
+    addDiscussion,
+    updateDiscussionVote
+  } = useBattleStore();
 
   useEffect(() => {
     const newSocket = io(import.meta.env.VITE_API_URL, {
@@ -72,7 +69,7 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
         const currentVoteList = VOTE_MAP[`${data.turn.status}_${team}`];
         if (currentVoteList?.length) {
           const totalVotes = currentVoteList.reduce((sum, { upvotes }) => sum + upvotes, 0);
-          setObjections(
+          setDiscussions(
             currentVoteList.map(({ discussionId, authorId, content, upvotes, votes }) => ({
               id: discussionId as unknown as number,
               user: authorId === userId ? 'You' : `User-${authorId.slice(0, 4)}`,
@@ -97,14 +94,7 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
 
     // 투표 업데이트 이벤트
     const handleVoteUpdate = (data: { discussionId: string; upvotes: number; votes: string[] }) => {
-      setObjections((prev) => {
-        const updated = prev.map((obj) => {
-          const isTarget = String(obj.id) === data.discussionId;
-          return isTarget ? { ...obj, votes: data.upvotes, hasVoted: data.votes.includes(userId) } : obj;
-        });
-        const totalVotes = updated.reduce((sum, obj) => sum + obj.votes, 0);
-        return updated.map((obj) => ({ ...obj, totalVotes }));
-      });
+      updateDiscussionVote(data.discussionId, data.upvotes, data.votes, userId);
     };
 
     // 새 이의제기/반론 추가
@@ -117,20 +107,14 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
     }) => {
       if (team === 'NONE') return;
 
-      setObjections((prev) => {
-        const totalVotes = prev.reduce((sum, obj) => sum + obj.votes, 0);
-        return [
-          ...prev,
-          {
-            id: data.discussionId as unknown as number,
-            user: data.authorId === userId ? 'You' : `User-${data.authorId.slice(0, 4)}`,
-            team: team as 'A' | 'B',
-            content: data.content,
-            votes: data.upvotes,
-            totalVotes,
-            hasVoted: data.votes.includes(userId)
-          }
-        ];
+      addDiscussion({
+        id: data.discussionId as unknown as number,
+        user: data.authorId === userId ? 'You' : `User-${data.authorId.slice(0, 4)}`,
+        team: team as 'A' | 'B',
+        content: data.content,
+        votes: data.upvotes,
+        totalVotes: 0,
+        hasVoted: data.votes.includes(userId)
       });
     };
 
@@ -155,10 +139,21 @@ export function useBattleSocket({ battleId, userId, team, password }: UseBattleS
       setSocket(null);
       setIsConnected(false);
     };
-  }, [battleId, userId, team, password, setSocket, setIsConnected, setCurrentStage, setBattleProgress]);
+  }, [
+    battleId,
+    userId,
+    team,
+    password,
+    setSocket,
+    setIsConnected,
+    setCurrentStage,
+    setBattleProgress,
+    setDiscussions,
+    addDiscussion,
+    updateDiscussionVote
+  ]);
 
   return {
-    battleData,
-    objections
+    battleData
   };
 }

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -53,7 +53,7 @@ export function useBattleSocket() {
       }
 
       // 팀 인원 수, 타임라인, 채팅 데이터 store에 저장
-      setTeamCounts(data.counts);
+      setTeamCounts({ teamACount: data.counts.teamA, teamBCount: data.counts.teamB });
       setTimelines(data.timelines);
       setChats(data.allChats || []);
 

--- a/frontend/src/pages/battlePage/hooks/useBattleTeam.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTeam.ts
@@ -1,15 +1,20 @@
 import { useEffect, useCallback } from 'react';
-import { Socket } from 'socket.io-client';
-import { useBattleStore, selectBattleProgress, selectSelectedTeam } from '../stores/battleStore';
+import {
+  useBattleStore,
+  selectBattleProgress,
+  selectSelectedTeam,
+  selectSocket,
+  selectBattleId
+} from '../stores/battleStore';
 
 interface UseBattleTeamProps {
-  socket: Socket | null;
-  battleId: string;
   onOpenTeamChangeModal: () => void;
   onCloseTeamChangeModal: () => void;
 }
 
-export function useBattleTeam({ socket, battleId, onOpenTeamChangeModal, onCloseTeamChangeModal }: UseBattleTeamProps) {
+export function useBattleTeam({ onOpenTeamChangeModal, onCloseTeamChangeModal }: UseBattleTeamProps) {
+  const socket = useBattleStore(selectSocket);
+  const battleId = useBattleStore(selectBattleId);
   const { setSelectedTeam } = useBattleStore();
   const battleProgress = useBattleStore(selectBattleProgress);
   const selectedTeam = useBattleStore(selectSelectedTeam);

--- a/frontend/src/pages/battlePage/hooks/useBattleTeam.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTeam.ts
@@ -1,0 +1,55 @@
+import { useEffect, useCallback } from 'react';
+import { Socket } from 'socket.io-client';
+import { useBattleStore, selectBattleProgress, selectSelectedTeam } from '../stores/battleStore';
+
+interface UseBattleTeamProps {
+  socket: Socket | null;
+  battleId: string;
+  onOpenTeamChangeModal: () => void;
+  onCloseTeamChangeModal: () => void;
+}
+
+export function useBattleTeam({ socket, battleId, onOpenTeamChangeModal, onCloseTeamChangeModal }: UseBattleTeamProps) {
+  const { setSelectedTeam } = useBattleStore();
+  const battleProgress = useBattleStore(selectBattleProgress);
+  const selectedTeam = useBattleStore(selectSelectedTeam);
+
+  // TEAM_SWITCH 페이즈 시 모달 자동 열기
+  useEffect(() => {
+    if (battleProgress?.phase === 'TEAM_SWITCH') {
+      const timer = setTimeout(() => {
+        onOpenTeamChangeModal();
+      }, 4000);
+
+      return () => clearTimeout(timer);
+    }
+  }, [battleProgress?.phase, onOpenTeamChangeModal]);
+
+  // 팀 변경 이벤트 수신
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleChangedTeam = (data: { battleId: string; team: 'A' | 'B' | 'NONE' }) => {
+      setSelectedTeam(data.team);
+    };
+
+    socket.on('battle:team:update', handleChangedTeam);
+
+    return () => {
+      socket.off('battle:team:update', handleChangedTeam);
+    };
+  }, [socket, setSelectedTeam]);
+
+  // 팀 변경 요청
+  const handleTeamChange = useCallback(
+    (team: 'A' | 'B' | 'NONE') => {
+      if (!socket) return;
+      socket.emit('battle:teamVote', { battleId, team });
+
+      onCloseTeamChangeModal();
+    },
+    [socket, battleId, onCloseTeamChangeModal]
+  );
+
+  return { selectedTeam, handleTeamChange };
+}

--- a/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
@@ -1,14 +1,10 @@
 import { useEffect } from 'react';
-import { Socket } from 'socket.io-client';
 import type { BattleAttackedResult, BattleDefensedResult } from '@/commons/types/battle';
-import { useBattleStore, selectBattleProgress } from '../stores/battleStore';
+import { useBattleStore, selectBattleProgress, selectSocket } from '../stores/battleStore';
 import { useEffectModal } from './useEffectModal';
 
-interface UseBattleTimelineProps {
-  socket: Socket | null;
-}
-
-export function useBattleTimeline({ socket }: UseBattleTimelineProps) {
+export function useBattleTimeline() {
+  const socket = useBattleStore(selectSocket);
   const battleProgress = useBattleStore(selectBattleProgress);
   const { effectModal, showEffect, hideEffect } = useEffectModal();
 

--- a/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { Socket } from 'socket.io-client';
+import type { BattleAttackedResult, BattleDefensedResult } from '@/commons/types/battle';
+import { useBattleStore, selectBattleProgress } from '../stores/battleStore';
+import { useEffectModal } from './useEffectModal';
+
+interface UseBattleTimelineProps {
+  socket: Socket | null;
+}
+
+export function useBattleTimeline({ socket }: UseBattleTimelineProps) {
+  const battleProgress = useBattleStore(selectBattleProgress);
+  const { effectModal, showEffect, hideEffect } = useEffectModal();
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleAttacked = (data: BattleAttackedResult) => {
+      // 턴 상태로 공격하는 팀 판단
+      const attackingTeam = battleProgress?.turn?.status === 'A_ATTACK' ? 'A' : 'B';
+      showEffect(attackingTeam, data.attack.text, 'attack');
+    };
+
+    const handleDefensed = (data: BattleDefensedResult) => {
+      // 턴 상태로 방어하는 팀 판단
+      const defendingTeam = battleProgress?.turn?.status === 'A_DEFENSE' ? 'A' : 'B';
+      showEffect(defendingTeam, data.defense.text, 'defense');
+    };
+
+    socket.on('battle:attacked', handleAttacked);
+    socket.on('battle:defensed', handleDefensed);
+
+    return () => {
+      socket.off('battle:attacked', handleAttacked);
+      socket.off('battle:defensed', handleDefensed);
+    };
+  }, [socket, battleProgress?.turn?.status, showEffect]);
+
+  return { effectModal, hideEffect };
+}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -12,7 +12,13 @@ import { useBattleTimer } from './hooks/useBattleTimer';
 import { useEffectModal } from './hooks/useEffectModal';
 import { useBattleProgress } from './hooks/useBattleProgress';
 import { getObjectionConfig, isInputDisabled } from './utils/battlePhase';
-import { useBattleStore, selectSocket, selectCurrentStage, selectBattleProgress } from './stores/battleStore';
+import {
+  useBattleStore,
+  selectSocket,
+  selectCurrentStage,
+  selectBattleProgress,
+  selectDiscussions
+} from './stores/battleStore';
 import useModal from '@/commons/hooks/useModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
 import ObjectionModal from './components/effects/ObjectionModal';
@@ -48,7 +54,7 @@ export default function BattlePage() {
     return id;
   });
 
-  const { battleData, objections } = useBattleSocket({
+  const { battleData } = useBattleSocket({
     battleId: id || '1',
     userId,
     team: selectedTeam
@@ -57,6 +63,7 @@ export default function BattlePage() {
   const socket = useBattleStore(selectSocket);
   const currentStage = useBattleStore(selectCurrentStage);
   const battleProgress = useBattleStore(selectBattleProgress);
+  const objections = useBattleStore(selectDiscussions);
 
   const { formattedTime } = useBattleTimer({
     expiredAt: battleProgress?.expiredAt

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams, useLoaderData } from 'react-router-dom';
 import type { BattleInfo } from '@/commons/types/battle';
 import BattleHeader from './components/header/BattleHeader';
@@ -8,22 +8,11 @@ import ObjectionInput from './components/objection/ObjectionInput';
 import ObjectionVote from './components/objection/ObjectionVote';
 import TimelineSection from './components/timeline/TimelineSection';
 import { useBattleSocket } from './hooks/useBattleSocket';
-import { useBattleTimer } from './hooks/useBattleTimer';
 import { useBattleProgress } from './hooks/useBattleProgress';
 import { useBattleDiscussions } from './hooks/useBattleDiscussions';
 import { useBattleTimeline } from './hooks/useBattleTimeline';
 import { useBattleTeam } from './hooks/useBattleTeam';
-import {
-  useBattleStore,
-  selectSocket,
-  selectCurrentStage,
-  selectBattleProgress,
-  selectDiscussions,
-  selectTeamCounts,
-  selectTimelines,
-  selectChats,
-  selectSelectedTeam
-} from './stores/battleStore';
+import { useBattleStore } from './stores/battleStore';
 import useModal from '@/commons/hooks/useModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
 import ObjectionModal from './components/effects/ObjectionModal';
@@ -39,46 +28,25 @@ export default function BattlePage() {
     closeModal: closeTeamChangeModal
   } = useModal(false);
 
-  // 각 탭/브라우저별 고유 userId 생성 (테스트용)
-  const [userId] = useState(() => {
-    let id = sessionStorage.getItem('testUserId');
-    if (!id) {
-      id = `user-${Math.random().toString(36).substr(2, 9)}`;
-      sessionStorage.setItem('testUserId', id);
+  // 각 탭/브라우저별 고유 userId 생성 및 store 초기화
+  useEffect(() => {
+    let userId = sessionStorage.getItem('testUserId');
+    if (!userId) {
+      userId = `user-${Math.random().toString(36).substr(2, 9)}`;
+      sessionStorage.setItem('testUserId', userId);
     }
-    return id;
-  });
+    useBattleStore.getState().initializeBattle({
+      userId,
+      battleId: id || '1'
+    });
+  }, [id]);
 
-  useBattleSocket({
-    battleId: id || '1',
-    userId,
-    team: 'NONE' // 초기값
-  });
+  useBattleSocket();
+  useBattleProgress();
 
-  const socket = useBattleStore(selectSocket);
-  const currentStage = useBattleStore(selectCurrentStage);
-  const battleProgress = useBattleStore(selectBattleProgress);
-  const objections = useBattleStore(selectDiscussions);
-  const teamCounts = useBattleStore(selectTeamCounts);
-  const timelines = useBattleStore(selectTimelines);
-  const chats = useBattleStore(selectChats);
-  const selectedTeam = useBattleStore(selectSelectedTeam);
-
-  const { formattedTime } = useBattleTimer({
-    expiredAt: battleProgress?.expiredAt
-  });
-
-  useBattleProgress({ socket });
-  const { handleVote, handleObjectionSubmit } = useBattleDiscussions({
-    socket,
-    userId,
-    team: selectedTeam,
-    battleId: id || '1'
-  });
-  const { effectModal, hideEffect } = useBattleTimeline({ socket });
+  const { handleVote, handleObjectionSubmit } = useBattleDiscussions();
+  const { effectModal, hideEffect } = useBattleTimeline();
   const { handleTeamChange } = useBattleTeam({
-    socket,
-    battleId: id || '1',
     onOpenTeamChangeModal: openTeamChangeModal,
     onCloseTeamChangeModal: closeTeamChangeModal
   });
@@ -86,15 +54,7 @@ export default function BattlePage() {
   return (
     <div className="text-white flex flex-col items-center">
       <div className="w-[1800px]">
-        <BattleHeader
-          title={battleInfo.title}
-          description={battleInfo.description}
-          status={currentStage || 'END'}
-          timer={formattedTime}
-          teamACounts={teamCounts?.teamA || 0}
-          teamBCounts={teamCounts?.teamB || 0}
-          teamNoneCounts={0}
-        />
+        <BattleHeader title={battleInfo.title} description={battleInfo.description} />
       </div>
       <main className="w-[1800px]">
         <div className="flex gap-2 py-4">
@@ -106,46 +66,17 @@ export default function BattlePage() {
               codeA={battleInfo.aCode}
               codeB={battleInfo.bCode}
             />
-            <TimelineSection attackList={timelines?.attacks} defenseList={timelines?.defenses} />
+            <TimelineSection />
           </div>
           <aside className="flex flex-col gap-4 w-[590px]">
-            <ChatSection
-              teamACounts={teamCounts?.teamA || 0}
-              teamBCounts={teamCounts?.teamB || 0}
-              team={selectedTeam}
-              socket={socket}
-              battleId={id}
-              chats={chats || []}
-              allChats={chats || []}
-              userId={userId}
-            />
-            <ObjectionInput
-              onSubmit={handleObjectionSubmit}
-              phase={battleProgress?.phase}
-              team={selectedTeam}
-              turnStatus={battleProgress?.turn?.status}
-            />
-            <ObjectionVote
-              objections={objections}
-              onVote={handleVote}
-              phase={battleProgress?.phase}
-              team={selectedTeam}
-            />
+            <ChatSection />
+            <ObjectionInput onSubmit={handleObjectionSubmit} />
+            <ObjectionVote onVote={handleVote} />
           </aside>
         </div>
       </main>
 
-      {isTeamChangeModalOpen && (
-        <TeamChangeModal
-          aTeamCounts={10}
-          bTeamCounts={8}
-          noneTeamCounts={2}
-          remainingTime={formattedTime}
-          currentTeam={selectedTeam}
-          handleTeamChange={handleTeamChange}
-          onClose={closeTeamChangeModal}
-        />
-      )}
+      {isTeamChangeModalOpen && <TeamChangeModal handleTeamChange={handleTeamChange} onClose={closeTeamChangeModal} />}
 
       {effectModal.isOpen && effectModal.team !== 'NONE' && (
         <ObjectionModal

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -10,6 +10,7 @@ import TimelineSection from './components/timeline/TimelineSection';
 import { useBattleSocket } from './hooks/useBattleSocket';
 import { useBattleTimer } from './hooks/useBattleTimer';
 import { useEffectModal } from './hooks/useEffectModal';
+import { useBattleProgress } from './hooks/useBattleProgress';
 import { getObjectionConfig, isInputDisabled } from './utils/battlePhase';
 import { useBattleStore, selectSocket, selectCurrentStage } from './stores/battleStore';
 import useModal from '@/commons/hooks/useModal';
@@ -59,6 +60,8 @@ export default function BattlePage() {
   const { formattedTime } = useBattleTimer({
     expiredAt: battleProgress?.expiredAt
   });
+
+  useBattleProgress({ socket });
 
   useEffect(() => {
     if (battleProgress?.phase === 'TEAM_SWITCH') {

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -11,6 +11,7 @@ import { useBattleSocket } from './hooks/useBattleSocket';
 import { useBattleTimer } from './hooks/useBattleTimer';
 import { useEffectModal } from './hooks/useEffectModal';
 import { useBattleProgress } from './hooks/useBattleProgress';
+import { useBattleDiscussions } from './hooks/useBattleDiscussions';
 import { getObjectionConfig, isInputDisabled } from './utils/battlePhase';
 import {
   useBattleStore,
@@ -70,6 +71,7 @@ export default function BattlePage() {
   });
 
   useBattleProgress({ socket });
+  useBattleDiscussions({ socket, userId, team: selectedTeam });
 
   useEffect(() => {
     if (battleProgress?.phase === 'TEAM_SWITCH') {

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -12,7 +12,7 @@ import { useBattleTimer } from './hooks/useBattleTimer';
 import { useEffectModal } from './hooks/useEffectModal';
 import { useBattleProgress } from './hooks/useBattleProgress';
 import { getObjectionConfig, isInputDisabled } from './utils/battlePhase';
-import { useBattleStore, selectSocket, selectCurrentStage } from './stores/battleStore';
+import { useBattleStore, selectSocket, selectCurrentStage, selectBattleProgress } from './stores/battleStore';
 import useModal from '@/commons/hooks/useModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
 import ObjectionModal from './components/effects/ObjectionModal';
@@ -48,7 +48,7 @@ export default function BattlePage() {
     return id;
   });
 
-  const { battleProgress, battleData, objections } = useBattleSocket({
+  const { battleData, objections } = useBattleSocket({
     battleId: id || '1',
     userId,
     team: selectedTeam
@@ -56,6 +56,7 @@ export default function BattlePage() {
 
   const socket = useBattleStore(selectSocket);
   const currentStage = useBattleStore(selectCurrentStage);
+  const battleProgress = useBattleStore(selectBattleProgress);
 
   const { formattedTime } = useBattleTimer({
     expiredAt: battleProgress?.expiredAt

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { useParams, useLoaderData, useLocation } from 'react-router-dom';
+import { useState } from 'react';
+import { useParams, useLoaderData } from 'react-router-dom';
 import type { BattleInfo } from '@/commons/types/battle';
 import BattleHeader from './components/header/BattleHeader';
 import CodeSection from './components/codeview/CodeSection';
@@ -12,6 +12,7 @@ import { useBattleTimer } from './hooks/useBattleTimer';
 import { useBattleProgress } from './hooks/useBattleProgress';
 import { useBattleDiscussions } from './hooks/useBattleDiscussions';
 import { useBattleTimeline } from './hooks/useBattleTimeline';
+import { useBattleTeam } from './hooks/useBattleTeam';
 import {
   useBattleStore,
   selectSocket,
@@ -20,22 +21,15 @@ import {
   selectDiscussions,
   selectTeamCounts,
   selectTimelines,
-  selectChats
+  selectChats,
+  selectSelectedTeam
 } from './stores/battleStore';
 import useModal from '@/commons/hooks/useModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
 import ObjectionModal from './components/effects/ObjectionModal';
 
-type LocationState = {
-  selectedTeam?: 'A' | 'B' | 'NONE';
-};
-
 export default function BattlePage() {
   const { id } = useParams<{ id: string }>();
-  const { state } = useLocation();
-  const [selectedTeam, setSelectedTeam] = useState<'A' | 'B' | 'NONE'>(
-    (state as LocationState)?.selectedTeam || 'NONE'
-  );
 
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
@@ -58,7 +52,7 @@ export default function BattlePage() {
   useBattleSocket({
     battleId: id || '1',
     userId,
-    team: selectedTeam
+    team: 'NONE' // 초기값
   });
 
   const socket = useBattleStore(selectSocket);
@@ -68,6 +62,7 @@ export default function BattlePage() {
   const teamCounts = useBattleStore(selectTeamCounts);
   const timelines = useBattleStore(selectTimelines);
   const chats = useBattleStore(selectChats);
+  const selectedTeam = useBattleStore(selectSelectedTeam);
 
   const { formattedTime } = useBattleTimer({
     expiredAt: battleProgress?.expiredAt
@@ -81,37 +76,12 @@ export default function BattlePage() {
     battleId: id || '1'
   });
   const { effectModal, hideEffect } = useBattleTimeline({ socket });
-
-  useEffect(() => {
-    if (battleProgress?.phase === 'TEAM_SWITCH') {
-      const timer = setTimeout(() => {
-        openTeamChangeModal();
-      }, 4000);
-
-      return () => clearTimeout(timer);
-    }
-  }, [battleProgress?.phase, openTeamChangeModal]);
-
-  useEffect(() => {
-    if (!socket) return;
-
-    const handleChangedTeam = (data: { battleId: string; team: 'A' | 'B' | 'NONE' }) => {
-      setSelectedTeam(data.team);
-    };
-
-    socket.on('battle:team:update', handleChangedTeam);
-
-    return () => {
-      socket.off('battle:team:update', handleChangedTeam);
-    };
-  }, [socket]);
-
-  const handleTeamChange = (team: 'A' | 'B' | 'NONE') => {
-    if (!socket) return;
-    socket.emit('battle:teamVote', { battleId: id, team });
-
-    closeTeamChangeModal();
-  };
+  const { handleTeamChange } = useBattleTeam({
+    socket,
+    battleId: id || '1',
+    onOpenTeamChangeModal: openTeamChangeModal,
+    onCloseTeamChangeModal: closeTeamChangeModal
+  });
 
   return (
     <div className="text-white flex flex-col items-center">

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -18,7 +18,10 @@ import {
   selectSocket,
   selectCurrentStage,
   selectBattleProgress,
-  selectDiscussions
+  selectDiscussions,
+  selectTeamCounts,
+  selectTimelines,
+  selectChats
 } from './stores/battleStore';
 import useModal from '@/commons/hooks/useModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
@@ -55,7 +58,7 @@ export default function BattlePage() {
     return id;
   });
 
-  const { battleData } = useBattleSocket({
+  useBattleSocket({
     battleId: id || '1',
     userId,
     team: selectedTeam
@@ -65,6 +68,9 @@ export default function BattlePage() {
   const currentStage = useBattleStore(selectCurrentStage);
   const battleProgress = useBattleStore(selectBattleProgress);
   const objections = useBattleStore(selectDiscussions);
+  const teamCounts = useBattleStore(selectTeamCounts);
+  const timelines = useBattleStore(selectTimelines);
+  const chats = useBattleStore(selectChats);
 
   const { formattedTime } = useBattleTimer({
     expiredAt: battleProgress?.expiredAt
@@ -185,8 +191,8 @@ export default function BattlePage() {
           description={battleInfo.description}
           status={currentStage || 'END'}
           timer={formattedTime}
-          teamACounts={battleData?.counts.teamA || 0}
-          teamBCounts={battleData?.counts.teamB || 0}
+          teamACounts={teamCounts?.teamA || 0}
+          teamBCounts={teamCounts?.teamB || 0}
           teamNoneCounts={0}
         />
       </div>
@@ -200,17 +206,17 @@ export default function BattlePage() {
               codeA={battleInfo.aCode}
               codeB={battleInfo.bCode}
             />
-            <TimelineSection attackList={battleData?.timelines.attacks} defenseList={battleData?.timelines.defenses} />
+            <TimelineSection attackList={timelines?.attacks} defenseList={timelines?.defenses} />
           </div>
           <aside className="flex flex-col gap-4 w-[590px]">
             <ChatSection
-              teamACounts={battleData?.counts.teamA || 0}
-              teamBCounts={battleData?.counts.teamB || 0}
+              teamACounts={teamCounts?.teamA || 0}
+              teamBCounts={teamCounts?.teamB || 0}
               team={selectedTeam}
               socket={socket}
               battleId={id}
-              chats={battleData?.chats || []}
-              allChats={battleData?.allChats || []}
+              chats={chats || []}
+              allChats={chats || []}
               userId={userId}
             />
             <ObjectionInput

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useParams, useLoaderData, useLocation, useNavigate } from 'react-router-dom';
+import { useParams, useLoaderData, useLocation } from 'react-router-dom';
 import type { BattleInfo, BattleAttackedResult, BattleDefensedResult } from '@/commons/types/battle';
 import BattleHeader from './components/header/BattleHeader';
 import CodeSection from './components/codeview/CodeSection';
@@ -33,7 +33,6 @@ type LocationState = {
 export default function BattlePage() {
   const { id } = useParams<{ id: string }>();
   const { state } = useLocation();
-  const navigate = useNavigate();
   const [selectedTeam, setSelectedTeam] = useState<'A' | 'B' | 'NONE'>(
     (state as LocationState)?.selectedTeam || 'NONE'
   );
@@ -137,20 +136,6 @@ export default function BattlePage() {
 
     closeTeamChangeModal();
   };
-
-  useEffect(() => {
-    if (!socket) return;
-
-    const handleBattleClosed = (payload: { battleId: string }) => {
-      navigate(`/battle/${payload.battleId}/result`);
-    };
-
-    socket.on('battle:closed', handleBattleClosed);
-
-    return () => {
-      socket.off('battle:closed', handleBattleClosed);
-    };
-  }, [socket, navigate]);
 
   return (
     <div className="text-white flex flex-col items-center">

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -12,7 +12,6 @@ import { useBattleTimer } from './hooks/useBattleTimer';
 import { useEffectModal } from './hooks/useEffectModal';
 import { useBattleProgress } from './hooks/useBattleProgress';
 import { useBattleDiscussions } from './hooks/useBattleDiscussions';
-import { getObjectionConfig, isInputDisabled } from './utils/battlePhase';
 import {
   useBattleStore,
   selectSocket,
@@ -77,7 +76,12 @@ export default function BattlePage() {
   });
 
   useBattleProgress({ socket });
-  useBattleDiscussions({ socket, userId, team: selectedTeam });
+  const { handleVote, handleObjectionSubmit } = useBattleDiscussions({
+    socket,
+    userId,
+    team: selectedTeam,
+    battleId: id || '1'
+  });
 
   useEffect(() => {
     if (battleProgress?.phase === 'TEAM_SWITCH') {
@@ -112,41 +116,6 @@ export default function BattlePage() {
       socket.off('battle:defensed', handleDefensed);
     };
   }, [socket, battleProgress?.turn?.status, showEffect]);
-
-  const handleVote = (objectionId: number) => {
-    if (!socket || selectedTeam === 'NONE') return;
-
-    const targetObjection = objections?.find((obj) => obj.id === objectionId);
-    if (targetObjection?.hasVoted) return;
-
-    const { isAttacking } = getObjectionConfig(selectedTeam, battleProgress?.phase);
-    const eventName = isAttacking ? 'battle:attackvote' : 'battle:defensevote';
-
-    socket.emit(eventName, {
-      battleId: id || '1',
-      discussionId: String(objectionId),
-      userId,
-      team: selectedTeam
-    });
-  };
-
-  const handleObjectionSubmit = (content: string) => {
-    if (selectedTeam === 'NONE' || !socket) return;
-
-    const { isAttacking } = getObjectionConfig(selectedTeam, battleProgress?.phase);
-    const canSubmit = !isInputDisabled(selectedTeam, battleProgress?.phase, battleProgress?.turn?.status);
-
-    if (!canSubmit) {
-      return;
-    }
-
-    socket.emit(isAttacking ? 'Battle:Attack' : 'Battle:Defense', {
-      battleId: id || '1',
-      authorId: userId,
-      content,
-      team: selectedTeam
-    });
-  };
 
   useEffect(() => {
     if (!socket) return;

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -1,54 +1,32 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useParams, useLoaderData } from 'react-router-dom';
 import type { BattleInfo } from '@/commons/types/battle';
 import BattleHeader from './components/header/BattleHeader';
 import CodeSection from './components/codeview/CodeSection';
 import ChatSection from './components/chatting/ChatSection';
-import ObjectionInput from './components/objection/ObjectionInput';
-import ObjectionVote from './components/objection/ObjectionVote';
+import DiscussionInput from './components/discussion/DiscussionInput';
+import DiscussionVote from './components/discussion/DiscussionVote';
 import TimelineSection from './components/timeline/TimelineSection';
-import { useBattleSocket } from './hooks/useBattleSocket';
-import { useBattleProgress } from './hooks/useBattleProgress';
-import { useBattleDiscussions } from './hooks/useBattleDiscussions';
-import { useBattleTimeline } from './hooks/useBattleTimeline';
-import { useBattleTeam } from './hooks/useBattleTeam';
-import { useBattleStore } from './stores/battleStore';
+import { useBattle } from './hooks/useBattle';
 import useModal from '@/commons/hooks/useModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
-import ObjectionModal from './components/effects/ObjectionModal';
+import DiscussionModal from './components/effects/DiscussionModal';
 
 export default function BattlePage() {
-  const { id } = useParams<{ id: string }>();
-
+  const { id: battleId } = useParams<{ id: string }>();
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
+
   const {
     isOpen: isTeamChangeModalOpen,
-    openModal: openTeamChangeModal,
-    closeModal: closeTeamChangeModal
+    openModal: handleOpenTeamChangeModal,
+    closeModal: handleCloseTeamChangeModal
   } = useModal(false);
 
-  // 각 탭/브라우저별 고유 userId 생성 및 store 초기화
-  useEffect(() => {
-    let userId = sessionStorage.getItem('testUserId');
-    if (!userId) {
-      userId = `user-${Math.random().toString(36).substr(2, 9)}`;
-      sessionStorage.setItem('testUserId', userId);
-    }
-    useBattleStore.getState().initializeBattle({
-      userId,
-      battleId: id || '1'
-    });
-  }, [id]);
-
-  useBattleSocket();
-  useBattleProgress();
-
-  const { handleVote, handleObjectionSubmit } = useBattleDiscussions();
-  const { effectModal, hideEffect } = useBattleTimeline();
-  const { handleTeamChange } = useBattleTeam({
-    onOpenTeamChangeModal: openTeamChangeModal,
-    onCloseTeamChangeModal: closeTeamChangeModal
+  const { handleVote, handleDiscussionSubmit, effectModal, hideEffect, handleTeamChange } = useBattle({
+    battleId,
+    onOpenTeamChangeModal: handleOpenTeamChangeModal,
+    onCloseTeamChangeModal: handleCloseTeamChangeModal
   });
 
   return (
@@ -70,16 +48,18 @@ export default function BattlePage() {
           </div>
           <aside className="flex flex-col gap-4 w-[590px]">
             <ChatSection />
-            <ObjectionInput onSubmit={handleObjectionSubmit} />
-            <ObjectionVote onVote={handleVote} />
+            <DiscussionInput onSubmit={handleDiscussionSubmit} />
+            <DiscussionVote onVote={handleVote} />
           </aside>
         </div>
       </main>
 
-      {isTeamChangeModalOpen && <TeamChangeModal handleTeamChange={handleTeamChange} onClose={closeTeamChangeModal} />}
+      {isTeamChangeModalOpen && (
+        <TeamChangeModal handleTeamChange={handleTeamChange} onClose={handleCloseTeamChangeModal} />
+      )}
 
       {effectModal.isOpen && effectModal.team !== 'NONE' && (
-        <ObjectionModal
+        <DiscussionModal
           isOpen={effectModal.isOpen}
           team={effectModal.team}
           content={effectModal.content}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useLoaderData, useLocation } from 'react-router-dom';
-import type { BattleInfo, BattleAttackedResult, BattleDefensedResult } from '@/commons/types/battle';
+import type { BattleInfo } from '@/commons/types/battle';
 import BattleHeader from './components/header/BattleHeader';
 import CodeSection from './components/codeview/CodeSection';
 import ChatSection from './components/chatting/ChatSection';
@@ -9,9 +9,9 @@ import ObjectionVote from './components/objection/ObjectionVote';
 import TimelineSection from './components/timeline/TimelineSection';
 import { useBattleSocket } from './hooks/useBattleSocket';
 import { useBattleTimer } from './hooks/useBattleTimer';
-import { useEffectModal } from './hooks/useEffectModal';
 import { useBattleProgress } from './hooks/useBattleProgress';
 import { useBattleDiscussions } from './hooks/useBattleDiscussions';
+import { useBattleTimeline } from './hooks/useBattleTimeline';
 import {
   useBattleStore,
   selectSocket,
@@ -39,7 +39,6 @@ export default function BattlePage() {
 
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
-  const { effectModal, showEffect, hideEffect } = useEffectModal();
   const {
     isOpen: isTeamChangeModalOpen,
     openModal: openTeamChangeModal,
@@ -81,6 +80,7 @@ export default function BattlePage() {
     team: selectedTeam,
     battleId: id || '1'
   });
+  const { effectModal, hideEffect } = useBattleTimeline({ socket });
 
   useEffect(() => {
     if (battleProgress?.phase === 'TEAM_SWITCH') {
@@ -91,30 +91,6 @@ export default function BattlePage() {
       return () => clearTimeout(timer);
     }
   }, [battleProgress?.phase, openTeamChangeModal]);
-
-  // 턴 변경 시 투표 리스트 초기화
-  useEffect(() => {
-    if (!socket) return;
-
-    const handleAttacked = (data: BattleAttackedResult) => {
-      // 턴 상태로 공격하는 팀 판단
-      const attackingTeam = battleProgress?.turn?.status === 'A_ATTACK' ? 'A' : 'B';
-      showEffect(attackingTeam, data.attack.text, 'attack');
-    };
-    const handleDefensed = (data: BattleDefensedResult) => {
-      // 턴 상태로 방어하는 팀 판단
-      const defendingTeam = battleProgress?.turn?.status === 'A_DEFENSE' ? 'A' : 'B';
-      showEffect(defendingTeam, data.defense.text, 'defense');
-    };
-
-    socket.on('battle:attacked', handleAttacked);
-    socket.on('battle:defensed', handleDefensed);
-
-    return () => {
-      socket.off('battle:attacked', handleAttacked);
-      socket.off('battle:defensed', handleDefensed);
-    };
-  }, [socket, battleProgress?.turn?.status, showEffect]);
 
   useEffect(() => {
     if (!socket) return;

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -11,6 +11,7 @@ import { useBattleSocket } from './hooks/useBattleSocket';
 import { useBattleTimer } from './hooks/useBattleTimer';
 import { useEffectModal } from './hooks/useEffectModal';
 import { getObjectionConfig, isInputDisabled } from './utils/battlePhase';
+import { useBattleStore, selectSocket, selectCurrentStage } from './stores/battleStore';
 import useModal from '@/commons/hooks/useModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
 import ObjectionModal from './components/effects/ObjectionModal';
@@ -46,11 +47,14 @@ export default function BattlePage() {
     return id;
   });
 
-  const { socket, currentStage, battleProgress, battleData, objections } = useBattleSocket({
+  const { battleProgress, battleData, objections } = useBattleSocket({
     battleId: id || '1',
     userId,
     team: selectedTeam
   });
+
+  const socket = useBattleStore(selectSocket);
+  const currentStage = useBattleStore(selectCurrentStage);
 
   const { formattedTime } = useBattleTimer({
     expiredAt: battleProgress?.expiredAt

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -7,12 +7,24 @@ interface BattleStore {
   isConnected: boolean;
   currentStage: string | null;
   battleProgress: BattleProgressState | null;
+  discussions: Array<{
+    id: number;
+    user: string;
+    team: 'A' | 'B';
+    content: string;
+    votes: number;
+    totalVotes: number;
+    hasVoted: boolean;
+  }>;
 
   setSocket: (socket: Socket | null) => void;
   setIsConnected: (connected: boolean) => void;
   setCurrentStage: (stage: string | null) => void;
   setBattleProgress: (progress: BattleProgressState | null) => void;
   updateBattleProgress: (updates: Partial<BattleProgressState>) => void;
+  setDiscussions: (discussions: BattleStore['discussions']) => void;
+  addDiscussion: (discussion: BattleStore['discussions'][0]) => void;
+  updateDiscussionVote: (discussionId: string, upvotes: number, votes: string[], userId: string) => void;
 }
 
 export const useBattleStore = create<BattleStore>((set) => ({
@@ -20,6 +32,7 @@ export const useBattleStore = create<BattleStore>((set) => ({
   isConnected: false,
   currentStage: null,
   battleProgress: null,
+  discussions: [],
 
   setSocket: (socket) => set({ socket }),
   setIsConnected: (connected) => set({ isConnected: connected }),
@@ -28,10 +41,28 @@ export const useBattleStore = create<BattleStore>((set) => ({
   updateBattleProgress: (updates) =>
     set((state) => ({
       battleProgress: state.battleProgress ? { ...state.battleProgress, ...updates } : null
-    }))
+    })),
+
+  setDiscussions: (discussions) => set({ discussions }),
+  addDiscussion: (discussion) =>
+    set((state) => ({
+      discussions: [...state.discussions, discussion]
+    })),
+  updateDiscussionVote: (discussionId, upvotes, votes, userId) =>
+    set((state) => {
+      const updated = state.discussions.map((obj) => {
+        const isTarget = String(obj.id) === discussionId;
+        return isTarget ? { ...obj, votes: upvotes, hasVoted: votes.includes(userId) } : obj;
+      });
+      const totalVotes = updated.reduce((sum, obj) => sum + obj.votes, 0);
+      return {
+        discussions: updated.map((obj) => ({ ...obj, totalVotes }))
+      };
+    })
 }));
 
 export const selectSocket = (state: BattleStore) => state.socket;
 export const selectCurrentStage = (state: BattleStore) => state.currentStage;
 export const selectIsConnected: (state: BattleStore) => boolean = (state: BattleStore) => state.isConnected;
 export const selectBattleProgress = (state: BattleStore) => state.battleProgress;
+export const selectDiscussions = (state: BattleStore) => state.discussions;

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+import { Socket } from 'socket.io-client';
+
+interface BattleStore {
+  socket: Socket | null;
+  isConnected: boolean;
+  currentStage: string | null;
+
+  setSocket: (socket: Socket | null) => void;
+  setIsConnected: (connected: boolean) => void;
+  setCurrentStage: (stage: string | null) => void;
+}
+
+export const useBattleStore = create<BattleStore>((set) => ({
+  socket: null,
+  isConnected: false,
+  currentStage: null,
+
+  setSocket: (socket) => set({ socket }),
+  setIsConnected: (connected) => set({ isConnected: connected }),
+  setCurrentStage: (stage) => set({ currentStage: stage })
+}));
+
+export const selectSocket = (state: BattleStore) => state.socket;
+export const selectCurrentStage = (state: BattleStore) => state.currentStage;
+export const selectIsConnected: (state: BattleStore) => boolean = (state: BattleStore) => state.isConnected;

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -25,6 +25,7 @@ interface BattleStore {
     defenses: BattleDefense[];
   } | null;
   chats: BattleChat[];
+  selectedTeam: 'A' | 'B' | 'NONE';
 
   setSocket: (socket: Socket | null) => void;
   setIsConnected: (connected: boolean) => void;
@@ -38,6 +39,7 @@ interface BattleStore {
   setTimelines: (timelines: { attacks: BattleDiscussion[]; defenses: BattleDefense[] }) => void;
   setChats: (chats: BattleChat[]) => void;
   addChat: (chat: BattleChat) => void;
+  setSelectedTeam: (team: 'A' | 'B' | 'NONE') => void;
 }
 
 export const useBattleStore = create<BattleStore>((set) => ({
@@ -49,6 +51,7 @@ export const useBattleStore = create<BattleStore>((set) => ({
   teamCounts: null,
   timelines: null,
   chats: [],
+  selectedTeam: 'NONE',
 
   setSocket: (socket) => set({ socket }),
   setIsConnected: (connected) => set({ isConnected: connected }),
@@ -82,7 +85,8 @@ export const useBattleStore = create<BattleStore>((set) => ({
   addChat: (chat) =>
     set((state) => ({
       chats: [...state.chats, chat]
-    }))
+    })),
+  setSelectedTeam: (team) => set({ selectedTeam: team })
 }));
 
 export const selectSocket = (state: BattleStore) => state.socket;
@@ -93,3 +97,4 @@ export const selectDiscussions = (state: BattleStore) => state.discussions;
 export const selectTeamCounts = (state: BattleStore) => state.teamCounts;
 export const selectTimelines = (state: BattleStore) => state.timelines;
 export const selectChats = (state: BattleStore) => state.chats;
+export const selectSelectedTeam = (state: BattleStore) => state.selectedTeam;

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -1,26 +1,37 @@
 import { create } from 'zustand';
 import { Socket } from 'socket.io-client';
+import type { BattleProgressState } from '@/commons/types/battle';
 
 interface BattleStore {
   socket: Socket | null;
   isConnected: boolean;
   currentStage: string | null;
+  battleProgress: BattleProgressState | null;
 
   setSocket: (socket: Socket | null) => void;
   setIsConnected: (connected: boolean) => void;
   setCurrentStage: (stage: string | null) => void;
+  setBattleProgress: (progress: BattleProgressState | null) => void;
+  updateBattleProgress: (updates: Partial<BattleProgressState>) => void;
 }
 
 export const useBattleStore = create<BattleStore>((set) => ({
   socket: null,
   isConnected: false,
   currentStage: null,
+  battleProgress: null,
 
   setSocket: (socket) => set({ socket }),
   setIsConnected: (connected) => set({ isConnected: connected }),
-  setCurrentStage: (stage) => set({ currentStage: stage })
+  setCurrentStage: (stage) => set({ currentStage: stage }),
+  setBattleProgress: (progress) => set({ battleProgress: progress }),
+  updateBattleProgress: (updates) =>
+    set((state) => ({
+      battleProgress: state.battleProgress ? { ...state.battleProgress, ...updates } : null
+    }))
 }));
 
 export const selectSocket = (state: BattleStore) => state.socket;
 export const selectCurrentStage = (state: BattleStore) => state.currentStage;
 export const selectIsConnected: (state: BattleStore) => boolean = (state: BattleStore) => state.isConnected;
+export const selectBattleProgress = (state: BattleStore) => state.battleProgress;

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -3,6 +3,8 @@ import { Socket } from 'socket.io-client';
 import type { BattleProgressState, BattleDiscussion, BattleDefense, BattleChat } from '@/commons/types/battle';
 
 interface BattleStore {
+  userId: string;
+  battleId: string;
   socket: Socket | null;
   isConnected: boolean;
   currentStage: string | null;
@@ -27,6 +29,7 @@ interface BattleStore {
   chats: BattleChat[];
   selectedTeam: 'A' | 'B' | 'NONE';
 
+  initializeBattle: (config: { userId: string; battleId: string }) => void;
   setSocket: (socket: Socket | null) => void;
   setIsConnected: (connected: boolean) => void;
   setCurrentStage: (stage: string | null) => void;
@@ -43,6 +46,8 @@ interface BattleStore {
 }
 
 export const useBattleStore = create<BattleStore>((set) => ({
+  userId: '',
+  battleId: '',
   socket: null,
   isConnected: false,
   currentStage: null,
@@ -53,6 +58,7 @@ export const useBattleStore = create<BattleStore>((set) => ({
   chats: [],
   selectedTeam: 'NONE',
 
+  initializeBattle: (config) => set({ userId: config.userId, battleId: config.battleId }),
   setSocket: (socket) => set({ socket }),
   setIsConnected: (connected) => set({ isConnected: connected }),
   setCurrentStage: (stage) => set({ currentStage: stage }),
@@ -89,6 +95,8 @@ export const useBattleStore = create<BattleStore>((set) => ({
   setSelectedTeam: (team) => set({ selectedTeam: team })
 }));
 
+export const selectUserId = (state: BattleStore) => state.userId;
+export const selectBattleId = (state: BattleStore) => state.battleId;
 export const selectSocket = (state: BattleStore) => state.socket;
 export const selectCurrentStage = (state: BattleStore) => state.currentStage;
 export const selectIsConnected: (state: BattleStore) => boolean = (state: BattleStore) => state.isConnected;

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { Socket } from 'socket.io-client';
-import type { BattleProgressState } from '@/commons/types/battle';
+import type { BattleProgressState, BattleDiscussion, BattleDefense, BattleChat } from '@/commons/types/battle';
 
 interface BattleStore {
   socket: Socket | null;
@@ -16,6 +16,15 @@ interface BattleStore {
     totalVotes: number;
     hasVoted: boolean;
   }>;
+  teamCounts: {
+    teamA: number;
+    teamB: number;
+  } | null;
+  timelines: {
+    attacks: BattleDiscussion[];
+    defenses: BattleDefense[];
+  } | null;
+  chats: BattleChat[];
 
   setSocket: (socket: Socket | null) => void;
   setIsConnected: (connected: boolean) => void;
@@ -25,6 +34,10 @@ interface BattleStore {
   setDiscussions: (discussions: BattleStore['discussions']) => void;
   addDiscussion: (discussion: BattleStore['discussions'][0]) => void;
   updateDiscussionVote: (discussionId: string, upvotes: number, votes: string[], userId: string) => void;
+  setTeamCounts: (counts: { teamA: number; teamB: number }) => void;
+  setTimelines: (timelines: { attacks: BattleDiscussion[]; defenses: BattleDefense[] }) => void;
+  setChats: (chats: BattleChat[]) => void;
+  addChat: (chat: BattleChat) => void;
 }
 
 export const useBattleStore = create<BattleStore>((set) => ({
@@ -33,6 +46,9 @@ export const useBattleStore = create<BattleStore>((set) => ({
   currentStage: null,
   battleProgress: null,
   discussions: [],
+  teamCounts: null,
+  timelines: null,
+  chats: [],
 
   setSocket: (socket) => set({ socket }),
   setIsConnected: (connected) => set({ isConnected: connected }),
@@ -58,7 +74,15 @@ export const useBattleStore = create<BattleStore>((set) => ({
       return {
         discussions: updated.map((obj) => ({ ...obj, totalVotes }))
       };
-    })
+    }),
+
+  setTeamCounts: (counts) => set({ teamCounts: counts }),
+  setTimelines: (timelines) => set({ timelines }),
+  setChats: (chats) => set({ chats }),
+  addChat: (chat) =>
+    set((state) => ({
+      chats: [...state.chats, chat]
+    }))
 }));
 
 export const selectSocket = (state: BattleStore) => state.socket;
@@ -66,3 +90,6 @@ export const selectCurrentStage = (state: BattleStore) => state.currentStage;
 export const selectIsConnected: (state: BattleStore) => boolean = (state: BattleStore) => state.isConnected;
 export const selectBattleProgress = (state: BattleStore) => state.battleProgress;
 export const selectDiscussions = (state: BattleStore) => state.discussions;
+export const selectTeamCounts = (state: BattleStore) => state.teamCounts;
+export const selectTimelines = (state: BattleStore) => state.timelines;
+export const selectChats = (state: BattleStore) => state.chats;

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -26,7 +26,8 @@ interface BattleStore {
     attacks: BattleDiscussion[];
     defenses: BattleDefense[];
   } | null;
-  chats: BattleChat[];
+  teamChats: BattleChat[];
+  allChats: BattleChat[];
   selectedTeam: 'A' | 'B' | 'NONE';
 
   initializeBattle: (config: { userId: string; battleId: string }) => void;
@@ -40,7 +41,8 @@ interface BattleStore {
   updateDiscussionVote: (discussionId: string, upvotes: number, votes: string[], userId: string) => void;
   setTeamCounts: (counts: { teamACount: number; teamBCount: number }) => void;
   setTimelines: (timelines: { attacks: BattleDiscussion[]; defenses: BattleDefense[] }) => void;
-  setChats: (chats: BattleChat[]) => void;
+  setTeamChats: (chats: BattleChat[]) => void;
+  setAllChats: (chats: BattleChat[]) => void;
   addChat: (chat: BattleChat) => void;
   setSelectedTeam: (team: 'A' | 'B' | 'NONE') => void;
 }
@@ -55,7 +57,8 @@ export const useBattleStore = create<BattleStore>((set) => ({
   discussions: [],
   teamCounts: { teamACount: 0, teamBCount: 0 },
   timelines: null,
-  chats: [],
+  teamChats: [],
+  allChats: [],
   selectedTeam: 'NONE',
 
   initializeBattle: (config) => set({ userId: config.userId, battleId: config.battleId }),
@@ -87,11 +90,16 @@ export const useBattleStore = create<BattleStore>((set) => ({
 
   setTeamCounts: (counts) => set({ teamCounts: counts }),
   setTimelines: (timelines) => set({ timelines }),
-  setChats: (chats) => set({ chats }),
+  setTeamChats: (chats) => set({ teamChats: chats }),
+  setAllChats: (chats) => set({ allChats: chats }),
   addChat: (chat) =>
-    set((state) => ({
-      chats: [...state.chats, chat]
-    })),
+    set((state) => {
+      if (chat.scope === 'TEAM') {
+        return { teamChats: [...state.teamChats, chat] };
+      } else {
+        return { allChats: [...state.allChats, chat] };
+      }
+    }),
   setSelectedTeam: (team) => set({ selectedTeam: team })
 }));
 
@@ -104,5 +112,6 @@ export const selectBattleProgress = (state: BattleStore) => state.battleProgress
 export const selectDiscussions = (state: BattleStore) => state.discussions;
 export const selectTeamCounts = (state: BattleStore) => state.teamCounts;
 export const selectTimelines = (state: BattleStore) => state.timelines;
-export const selectChats = (state: BattleStore) => state.chats;
+export const selectTeamChats = (state: BattleStore) => state.teamChats;
+export const selectAllChats = (state: BattleStore) => state.allChats;
 export const selectSelectedTeam = (state: BattleStore) => state.selectedTeam;

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -19,9 +19,9 @@ interface BattleStore {
     hasVoted: boolean;
   }>;
   teamCounts: {
-    teamA: number;
-    teamB: number;
-  } | null;
+    teamACount: number;
+    teamBCount: number;
+  };
   timelines: {
     attacks: BattleDiscussion[];
     defenses: BattleDefense[];
@@ -38,7 +38,7 @@ interface BattleStore {
   setDiscussions: (discussions: BattleStore['discussions']) => void;
   addDiscussion: (discussion: BattleStore['discussions'][0]) => void;
   updateDiscussionVote: (discussionId: string, upvotes: number, votes: string[], userId: string) => void;
-  setTeamCounts: (counts: { teamA: number; teamB: number }) => void;
+  setTeamCounts: (counts: { teamACount: number; teamBCount: number }) => void;
   setTimelines: (timelines: { attacks: BattleDiscussion[]; defenses: BattleDefense[] }) => void;
   setChats: (chats: BattleChat[]) => void;
   addChat: (chat: BattleChat) => void;
@@ -53,7 +53,7 @@ export const useBattleStore = create<BattleStore>((set) => ({
   currentStage: null,
   battleProgress: null,
   discussions: [],
-  teamCounts: null,
+  teamCounts: { teamACount: 0, teamBCount: 0 },
   timelines: null,
   chats: [],
   selectedTeam: 'NONE',

--- a/frontend/src/pages/battlePage/utils/battlePhase.ts
+++ b/frontend/src/pages/battlePage/utils/battlePhase.ts
@@ -47,7 +47,7 @@ export const isInputDisabled = (
   return true;
 };
 
-export const getObjectionConfig = (team: Team, phase?: BattlePhase) => {
+export const getDiscussionConfig = (team: Team, phase?: BattlePhase) => {
   const isAttacking = isMyTeamAttacking(team, phase);
 
   return {

--- a/frontend/src/pages/battlePage/utils/convertChatMessage.ts
+++ b/frontend/src/pages/battlePage/utils/convertChatMessage.ts
@@ -1,0 +1,19 @@
+import type { BattleChat, Team } from '@/commons/types/battle';
+
+export interface Message {
+  id: string;
+  user: string;
+  team: Team;
+  content: string;
+  timestamp: string;
+  type?: 'normal' | 'objection' | 'rebuttal';
+}
+
+export const convertBattleChatToMessage = (chat: BattleChat, userId: string): Message => ({
+  id: chat.messageId,
+  user: chat.sender === userId ? 'You' : chat.sender,
+  team: chat.team,
+  content: chat.text,
+  timestamp: new Date(chat.createdAt).toISOString().replace('T', ' ').substring(0, 19),
+  type: 'normal'
+});

--- a/frontend/src/pages/battlePage/utils/convertChatMessage.ts
+++ b/frontend/src/pages/battlePage/utils/convertChatMessage.ts
@@ -6,7 +6,7 @@ export interface Message {
   team: Team;
   content: string;
   timestamp: string;
-  type?: 'normal' | 'objection' | 'rebuttal';
+  type?: 'normal' | 'attack' | 'defense';
 }
 
 export const convertBattleChatToMessage = (chat: BattleChat, userId: string): Message => ({

--- a/frontend/src/pages/battlePage/utils/test/battlePhase.test.ts
+++ b/frontend/src/pages/battlePage/utils/test/battlePhase.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { isInputDisabled } from '../battlePhase';
+
+describe('입력 가능 조건 검증', () => {
+  it('A팀 공격 턴에 A팀은 입력 가능', () => {
+    expect(isInputDisabled('A', 'TEAM_A_ATTACK', 'A_ATTACK')).toBe(false);
+  });
+
+  it('B팀 방어 턴에 B팀은 입력 가능', () => {
+    expect(isInputDisabled('B', 'TEAM_A_ATTACK', 'B_DEFENSE')).toBe(false);
+  });
+
+  it('잘못된 턴에는 입력 불가', () => {
+    expect(isInputDisabled('B', 'TEAM_A_ATTACK', 'A_ATTACK')).toBe(true);
+  });
+});

--- a/frontend/src/pages/battlePage/utils/test/convertChatMessage.test.ts
+++ b/frontend/src/pages/battlePage/utils/test/convertChatMessage.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { convertBattleChatToMessage } from '../convertChatMessage';
+import type { BattleChat } from '@/commons/types/battle';
+
+describe('메시지 변환', () => {
+  const mockChat: BattleChat = {
+    messageId: 'msg-123',
+    battleId: 'battle-1',
+    sender: 'user-abc',
+    team: 'A',
+    scope: 'ALL',
+    text: 'Hello World',
+    createdAt: new Date('2026-01-04T10:30:00Z')
+  };
+
+  it('자신의 메시지는 "You"로 표시', () => {
+    const result = convertBattleChatToMessage(mockChat, 'user-abc');
+    expect(result.user).toBe('You');
+  });
+
+  it('다른 사용자 메시지는 ID 그대로 표시', () => {
+    const result = convertBattleChatToMessage(mockChat, 'different-user');
+    expect(result.user).toBe('user-abc');
+  });
+});

--- a/frontend/src/pages/battlePage/utils/test/getDiscussionConfig.test.ts
+++ b/frontend/src/pages/battlePage/utils/test/getDiscussionConfig.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { getDiscussionConfig } from '../battlePhase';
+import type { Team, BattlePhase } from '@/commons/types/battle';
+
+describe('getDiscussionConfig', () => {
+  it('A팀이 공격 턴일 때 이의제기 설정 반환', () => {
+    const config = getDiscussionConfig('A' as Team, 'TEAM_A_ATTACK' as BattlePhase);
+
+    expect(config.placeholderText).toBe('상대 진영에 이의제기...');
+    expect(config.buttonText).toBe('이의제기');
+    expect(config.isAttacking).toBe(true);
+  });
+
+  it('A팀이 방어 턴일 때 반론 설정 반환', () => {
+    const config = getDiscussionConfig('A' as Team, 'TEAM_B_ATTACK' as BattlePhase);
+
+    expect(config.placeholderText).toBe('상대 진영에 반론...');
+    expect(config.buttonText).toBe('반론');
+    expect(config.isAttacking).toBe(false);
+  });
+
+  it('B팀이 공격 턴일 때 이의제기 설정 반환', () => {
+    const config = getDiscussionConfig('B' as Team, 'TEAM_B_ATTACK' as BattlePhase);
+
+    expect(config.placeholderText).toBe('상대 진영에 이의제기...');
+    expect(config.buttonText).toBe('이의제기');
+    expect(config.isAttacking).toBe(true);
+  });
+
+  it('B팀이 방어 턴일 때 반론 설정 반환', () => {
+    const config = getDiscussionConfig('B' as Team, 'TEAM_A_ATTACK' as BattlePhase);
+
+    expect(config.placeholderText).toBe('상대 진영에 반론...');
+    expect(config.buttonText).toBe('반론');
+    expect(config.isAttacking).toBe(false);
+  });
+});

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,9 @@
+import { expect, afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import * as matchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(matchers);
+
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,8 +1,6 @@
-import { expect, afterEach } from 'vitest';
+import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
-import * as matchers from '@testing-library/jest-dom/matchers';
-
-expect.extend(matchers);
+import '@testing-library/jest-dom/vitest';
 
 afterEach(() => {
   cleanup();

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import svgr from 'vite-plugin-svgr';
@@ -22,5 +22,11 @@ export default defineConfig({
         rewrite: (path) => path.replace(/^\/api/, '')
       }
     }
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+    css: true
   }
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       socket.io-client:
         specifier: ^4.8.1
         version: 4.8.1
+      zustand:
+        specifier: ^5.0.9
+        version: 5.0.9(@types/react@19.2.7)(react@19.2.3)
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -4000,6 +4003,24 @@ packages:
 
   zod@4.2.1:
     resolution: {integrity: sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==}
+
+  zustand@5.0.9:
+    resolution: {integrity: sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -8100,3 +8121,8 @@ snapshots:
       zod: 4.2.1
 
   zod@4.2.1: {}
+
+  zustand@5.0.9(@types/react@19.2.7)(react@19.2.3):
+    optionalDependencies:
+      '@types/react': 19.2.7
+      react: 19.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,18 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.1
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/react-hooks':
+        specifier: ^8.0.1
+        version: 8.0.1(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.4
@@ -175,6 +187,9 @@ importers:
       globals:
         specifier: ^16.5.0
         version: 16.5.0
+      jsdom:
+        specifier: ^27.4.0
+        version: 27.4.0
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -193,8 +208,17 @@ importers:
       vite-plugin-svgr:
         specifier: ^4.5.0
         version: 4.5.0(rollup@4.53.5)(typescript@5.9.3)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16(@types/node@24.10.4)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
 
 packages:
+
+  '@acemir/cssom@0.9.30':
+    resolution: {integrity: sha512-9CnlMCI0LmCIq0olalQqdWrJHPzm0/tw3gzOA9zJSgvFX7Xau3D24mAGa4BtwxwY69nsuJW6kQqqCzf/mEcQgg==}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@angular-devkit/core@19.2.17':
     resolution: {integrity: sha512-Ah008x2RJkd0F+NLKqIpA34/vUGwjlprRCkvddjDopAWRzYn6xCkz1Tqwuhn0nR1Dy47wTLKYD999TYl5ONOAQ==}
@@ -226,6 +250,15 @@ packages:
   '@angular-devkit/schematics@19.2.19':
     resolution: {integrity: sha512-J4Jarr0SohdrHcb40gTL4wGPCQ952IMWF1G/MSAQfBAPvA9ZKApYhpxcY7PmehVePve+ujpus1dGsJ7dPxz8Kg==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+
+  '@asamuzakjp/css-color@4.1.1':
+    resolution: {integrity: sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==}
+
+  '@asamuzakjp/dom-selector@6.7.6':
+    resolution: {integrity: sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -389,6 +422,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
@@ -414,6 +451,38 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.22':
+    resolution: {integrity: sha512-qBcx6zYlhleiFfdtzkRgwNC7VVoAwfK76Vmsw5t+PbvtdknO9StgRk7ROvq9so1iqbdW4uLIDAsXRsTfUrIoOw==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
@@ -617,6 +686,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.8.0':
+    resolution: {integrity: sha512-8JPn18Bcp8Uo1T82gR8lh2guEOa5KKU/IEKvvdp0sgmi7coPBWf1Doi1EXsGZb2ehc8ym/StJCjffYV+ne7sXQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@exodus/crypto': ^1.0.0-rc.4
+    peerDependenciesMeta:
+      '@exodus/crypto':
+        optional: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1149,6 +1227,9 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
     engines: {node: '>=14'}
@@ -1307,6 +1388,51 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react-hooks@8.0.1':
+    resolution: {integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@types/react': ^16.9.0 || ^17.0.0
+      react: ^16.9.0 || ^17.0.0
+      react-dom: ^16.9.0 || ^17.0.0
+      react-test-renderer: ^16.9.0 || ^17.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-dom:
+        optional: true
+      react-test-renderer:
+        optional: true
+
+  '@testing-library/react@16.3.1':
+    resolution: {integrity: sha512-gr4KtAWqIOQoucWYD/f6ki+j5chXfcPc74Col/6poTyqTmn7zRmodWahWRCp8tYd+GMqBonw6hstNzqjbs6gjw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tokenizer/inflate@0.3.1':
     resolution: {integrity: sha512-4oeoZEBQdLdt5WmP/hx1KZ6D3/Oid/0cUb2nk4F0pTDAWy+KCH3/EnAkZF/bvckWo8I33EqBm01lIPgmgc8rCA==}
     engines: {node: '>=18'}
@@ -1329,6 +1455,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1344,6 +1473,9 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -1352,6 +1484,9 @@ packages:
 
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -1600,6 +1735,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@4.0.16':
+    resolution: {integrity: sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==}
+
+  '@vitest/mocker@4.0.16':
+    resolution: {integrity: sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.16':
+    resolution: {integrity: sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==}
+
+  '@vitest/runner@4.0.16':
+    resolution: {integrity: sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==}
+
+  '@vitest/snapshot@4.0.16':
+    resolution: {integrity: sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==}
+
+  '@vitest/spy@4.0.16':
+    resolution: {integrity: sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==}
+
+  '@vitest/utils@4.0.16':
+    resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -1678,6 +1842,10 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -1763,11 +1931,22 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -1817,6 +1996,9 @@ packages:
   baseline-browser-mapping@2.9.8:
     resolution: {integrity: sha512-Y1fOuNDowLfgKOypdc9SPABfoWXuZHBOyCS4cD52IeZBhr4Md6CLLs6atcxVrzRmQ06E7hSlm5bHHApPKR/byA==}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -1883,6 +2065,10 @@ packages:
 
   caniuse-lite@1.0.30001760:
     resolution: {integrity: sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2047,8 +2233,23 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@5.3.6:
+    resolution: {integrity: sha512-legscpSpgSAeGEe0TNcai97DKt9Vd9AsAdOL7Uoetb52Ar/8eJm3LIa39qpv8wWzLFlNG4vVvppQM+teaMPj3A==}
+    engines: {node: '>=20'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@6.0.0:
+    resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
+    engines: {node: '>=20'}
 
   debug@4.3.7:
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
@@ -2067,6 +2268,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   dedent@1.7.0:
     resolution: {integrity: sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==}
@@ -2094,6 +2298,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -2108,6 +2316,12 @@ packages:
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -2159,6 +2373,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   environment@1.1.0:
@@ -2292,6 +2510,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2314,6 +2535,10 @@ packages:
   exit-x@0.2.2:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expect@30.2.0:
     resolution: {integrity: sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==}
@@ -2524,12 +2749,24 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -2567,6 +2804,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -2609,6 +2850,9 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -2798,6 +3042,15 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsdom@27.4.0:
+    resolution: {integrity: sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -2971,6 +3224,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -2990,6 +3247,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -3046,6 +3306,10 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
@@ -3143,6 +3407,9 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -3197,6 +3464,9 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -3227,6 +3497,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3280,6 +3553,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@30.2.0:
     resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -3314,6 +3591,15 @@ packages:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
       react: ^19.2.3
+
+  react-error-boundary@3.1.4:
+    resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13.1'
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -3350,6 +3636,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
@@ -3405,6 +3695,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3466,6 +3760,9 @@ packages:
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -3529,9 +3826,15 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -3584,6 +3887,10 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -3614,6 +3921,9 @@ packages:
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   synckit@0.11.11:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
@@ -3651,9 +3961,27 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.19:
+    resolution: {integrity: sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==}
+
+  tldts@7.0.19:
+    resolution: {integrity: sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==}
+    hasBin: true
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -3669,6 +3997,14 @@ packages:
   token-types@6.1.1:
     resolution: {integrity: sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ==}
     engines: {node: '>=14.16'}
+
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -3880,6 +4216,44 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.0.16:
+    resolution: {integrity: sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.16
+      '@vitest/browser-preview': 4.0.16
+      '@vitest/browser-webdriverio': 4.0.16
+      '@vitest/ui': 4.0.16
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -3889,6 +4263,10 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
 
   webpack-node-externals@3.0.0:
     resolution: {integrity: sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==}
@@ -3908,9 +4286,22 @@ packages:
       webpack-cli:
         optional: true
 
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3954,6 +4345,25 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xmlhttprequest-ssl@2.1.2:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
@@ -4024,6 +4434,10 @@ packages:
 
 snapshots:
 
+  '@acemir/cssom@0.9.30': {}
+
+  '@adobe/css-tools@4.4.4': {}
+
   '@angular-devkit/core@19.2.17(chokidar@4.0.3)':
     dependencies:
       ajv: 8.17.1
@@ -4077,6 +4491,24 @@ snapshots:
       rxjs: 7.8.1
     transitivePeerDependencies:
       - chokidar
+
+  '@asamuzakjp/css-color@4.1.1':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 11.2.4
+
+  '@asamuzakjp/dom-selector@6.7.6':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.4
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -4252,6 +4684,8 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/runtime@7.28.4': {}
+
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -4285,6 +4719,28 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.22': {}
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@emnapi/core@1.7.1':
     dependencies:
@@ -4425,6 +4881,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.8.0': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -5033,6 +5491,8 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -5171,6 +5631,49 @@ snapshots:
       tailwindcss: 4.1.18
       vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react-hooks@8.0.1(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      react: 19.2.3
+      react-error-boundary: 3.1.4(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      react-dom: 19.2.3(react@19.2.3)
+
+  '@testing-library/react@16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tokenizer/inflate@0.3.1':
     dependencies:
       debug: 4.4.3
@@ -5193,6 +5696,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -5220,6 +5725,11 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 22.19.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 22.19.3
@@ -5229,6 +5739,8 @@ snapshots:
   '@types/cors@2.8.19':
     dependencies:
       '@types/node': 24.10.4
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -5495,6 +6007,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.0.16':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.16(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.16
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+
+  '@vitest/pretty-format@4.0.16':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.16':
+    dependencies:
+      '@vitest/utils': 4.0.16
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.16':
+    dependencies:
+      '@vitest/pretty-format': 4.0.16
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.16': {}
+
+  '@vitest/utils@4.0.16':
+    dependencies:
+      '@vitest/pretty-format': 4.0.16
+      tinyrainbow: 3.0.3
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -5599,6 +6150,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
@@ -5669,9 +6222,17 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
   array-timsort@1.0.3: {}
 
   asap@2.0.6: {}
+
+  assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
 
@@ -5743,6 +6304,10 @@ snapshots:
   base64id@2.0.0: {}
 
   baseline-browser-mapping@2.9.8: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bl@4.1.0:
     dependencies:
@@ -5823,6 +6388,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001760: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -5961,7 +6528,26 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
+  cssstyle@5.3.6:
+    dependencies:
+      '@asamuzakjp/css-color': 4.1.1
+      '@csstools/css-syntax-patches-for-csstree': 1.0.22
+      css-tree: 3.1.0
+      lru-cache: 11.2.4
+
   csstype@3.2.3: {}
+
+  data-urls@6.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
 
   debug@4.3.7:
     dependencies:
@@ -5970,6 +6556,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   dedent@1.7.0: {}
 
@@ -5985,6 +6573,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
@@ -5995,6 +6585,10 @@ snapshots:
       wrappy: 1.0.2
 
   diff@4.0.2: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dot-case@3.0.4:
     dependencies:
@@ -6059,6 +6653,8 @@ snapshots:
       tapable: 2.3.0
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   environment@1.1.0: {}
 
@@ -6226,6 +6822,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -6247,6 +6847,8 @@ snapshots:
       strip-final-newline: 2.0.0
 
   exit-x@0.2.2: {}
+
+  expect-type@1.3.0: {}
 
   expect@30.2.0:
     dependencies:
@@ -6506,6 +7108,12 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.8.0
+    transitivePeerDependencies:
+      - '@exodus/crypto'
+
   html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
@@ -6515,6 +7123,20 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-signals@2.1.0: {}
 
@@ -6541,6 +7163,8 @@ snapshots:
       resolve-cwd: 3.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -6570,6 +7194,8 @@ snapshots:
   is-interactive@1.0.0: {}
 
   is-number@7.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
 
@@ -6949,6 +7575,34 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdom@27.4.0:
+    dependencies:
+      '@acemir/cssom': 0.9.30
+      '@asamuzakjp/dom-selector': 6.7.6
+      '@exodus/bytes': 1.8.0
+      cssstyle: 5.3.6
+      data-urls: 6.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@exodus/crypto'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -7097,6 +7751,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -7116,6 +7772,8 @@ snapshots:
       tmpl: 1.0.5
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.12.2: {}
 
   media-typer@0.3.0: {}
 
@@ -7153,6 +7811,8 @@ snapshots:
   mimic-fn@2.1.0: {}
 
   mimic-function@5.0.1: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.1.1:
     dependencies:
@@ -7229,6 +7889,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  obug@2.1.1: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -7297,6 +7959,10 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
@@ -7318,6 +7984,8 @@ snapshots:
   path-to-regexp@8.3.0: {}
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -7352,6 +8020,12 @@ snapshots:
       fast-diff: 1.3.0
 
   prettier@3.7.4: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   pretty-format@30.2.0:
     dependencies:
@@ -7390,6 +8064,13 @@ snapshots:
       react: 19.2.3
       scheduler: 0.27.0
 
+  react-error-boundary@3.1.4(react@19.2.3):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      react: 19.2.3
+
+  react-is@17.0.2: {}
+
   react-is@18.3.1: {}
 
   react-refresh@0.18.0: {}
@@ -7417,6 +8098,11 @@ snapshots:
       util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect-metadata@0.2.2: {}
 
@@ -7493,6 +8179,10 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -7580,6 +8270,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -7661,7 +8353,11 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -7713,6 +8409,10 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   strtok3@10.3.4:
@@ -7752,6 +8452,8 @@ snapshots:
 
   symbol-observable@4.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   synckit@0.11.11:
     dependencies:
       '@pkgr/core': 0.2.9
@@ -7782,10 +8484,22 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.2
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
+
+  tldts-core@7.0.19: {}
+
+  tldts@7.0.19:
+    dependencies:
+      tldts-core: 7.0.19
 
   tmpl@1.0.5: {}
 
@@ -7800,6 +8514,14 @@ snapshots:
       '@borewit/text-codec': 0.1.1
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.19
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
@@ -7998,6 +8720,48 @@ snapshots:
       terser: 5.44.1
       yaml: 2.8.2
 
+  vitest@4.0.16(@types/node@24.10.4)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2):
+    dependencies:
+      '@vitest/expect': 4.0.16
+      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.0.16
+      '@vitest/runner': 4.0.16
+      '@vitest/snapshot': 4.0.16
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.4
+      jsdom: 27.4.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
@@ -8010,6 +8774,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  webidl-conversions@8.0.1: {}
 
   webpack-node-externals@3.0.0: {}
 
@@ -8047,9 +8813,21 @@ snapshots:
       - esbuild
       - uglify-js
 
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 
@@ -8087,6 +8865,12 @@ snapshots:
       signal-exit: 4.1.0
 
   ws@8.17.1: {}
+
+  ws@8.18.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
 


### PR DESCRIPTION
## 🔗 관련 이슈
closes #91

## ✅ 작업 내용

### 💡개선 사항

#### 1. 상태 관리 시스템 전면 개편 (Zustand 도입)

기존 배틀 페이지 로직은 게임에 필요한 데이터들 객체로 감싼 것 포함 20개 이상 종류를 배틀 페이지 최상단에서  useState로 상태 관리를 하고 있었습니다

##### 상태 데이터 종류 (20개 이상):
```typescript
- 기본 정보: userId, battleId, selectedTeam, viewMode
- 소켓 관련: socket, isConnected
- 게임 진행: battleProgress, currentStage, battleData
- 토론 관련: objections (이의제기/반론 배열)
- 타임라인: timelines (attacks, defenses 배열)
- 채팅: teamChats, allChats (각각 배열)
- 팀 정보: teamCounts (teamACount, teamBCount)
- 모달: isTeamChangeModalOpen, effectModal
- 타이머: remainingTime, timerInterval
- 기타: discussions, votes 등
```

이로 인해 생긴 문제는 이렇습니다.
* **부모에서 자식으로 5~6단계 깊이로 props 전달하는 Props Drilling 문제가 심각해졌음**
  그로 인해 BattlePage → ChatSection → ChatTabs → ChatMessage까지 props 계속 전달 하는 문제가 생기며 중간 컴포넌트들은 자신이 사용하지 않는 props를 단순히 전달만 하는 역할하는 컴포넌들이 많아졌습니다. 
* **상태 데이터 중 어느 하나가 바뀌는 경우 배틀 페이지 전부가 리렌더링 되는 문제가 발생**
   채팅 메시지 하나 추가되면 → 타임라인, 코드뷰, 헤더까지 모두 리렌더링 되는 불필요한 렌더링 문제 발생.
* **useBattleSocket과 함께 상태 데이터 관리, 이벤트 관리를 같이 관리하다보니 useBattleSocket  200줄, 배틀 메인페이지 250줄이나 되는 결합력 강한 집합체를 만들어버렸음.**
 강한 결합으로 인해 특정 기능 수정 시 전체 영향이 가는 문제가 생겼습니다. (어우... 특히 타임라인 부분 추가할 때 너무 지옥 같더라구요)

##### 그래서 대안책으로..! 
> Zustand를 사용하여 상태 저장로직을 분리했습니다. 

<br/>

#### 왜 Zustand를 선택했는가?
위 문제를 해결하기 위해 전역 상태 관리 라이브러리 도입을 검토했고, Context API, Jotai, Zustand를 비교한 결과 결론적으로는 Zustand를 선택했습니다.

##### Context API를 선택하지 않은 이유
- 상태가 변경되면 Context를 구독하는 모든 컴포넌트가 리렌더링되어 최적화가 어려움 (이 문제가 가장 최악이라 선택지에서 바로 버렸습니다.ㅋㅋ..)
- 프로젝트 특성상 여러 Context를 만들어야 하고, useContext 훅을 각각 만들어야 하는 보일러플레이트 발생 할 것 같습니다. 

##### Jotai를 선택하지 않은 이유
- Atom 기반 접근 방식은 상태를 매우 세분화해야 하는데, 우리 프로젝트는 battleProgress, timelines 등 관련된 상태들을 묶어서 관리하는 게 더 직관적이라고 생각했습니다. 
- Atom을 20개 이상 만들어야 하고, 각 atom 간의 의존성 관리가 복잡해질 거라 생각했습니다.

#####  Zustand를 선택한 이유

- 간단한 API와 낮은 러닝 커브 - Provider 설정 없이 간단하게 스토어를 만들고 사용할 수 있어 빠른 리팩토링이 가능했습니다. create 함수 하나로 스토어를 만들고, 훅처럼 사용하면 되기 쉬운점

- 선택적 구독을 통한 리렌더링 최적화 - 컴포넌트가 필요한 상태만 선택적으로 구독할 수 있어, 해당 상태가 변경될 때만 리렌더링됩니다. 이를 통해 채팅 메시지가 업데이트되어도 채팅 컴포넌트만 리렌더링되고 다른 컴포넌트는 영향을 받지 않는 다는 장점

- 작은 번들 사이즈 - Zustand는 매우 가볍고(약 1KB), 추가 라이브러리 없이 독립적으로 동작할 수 있다는 장점이 있습니다.

- 직관적인 상태 구조 하나의 스토어에 관련된 상태와 액션을 모아서 관리할 수 있어,  battleProgress, timelines, chats 등을 Jotai를 사용했을 때보다 논리적으로 그룹화하기 용이하다고 생각했습니다

<br/>

### 그 결과
>
- 최상단 부모 페이지 컴포넌트 코드량 70% 감소 (240줄 → 72줄)
- 컴포넌트는 필요한 상태만 구독하게 하여 Props drilling 문제를 제거하여 보일러 플레이팅 제거 
- 상태 업데이트 시 해당 상태를 구독하는 컴포넌트만 리렌더링 하게 했습니다. 


<br/>
<br/>

---



#### 2. 거대한 훅을 기능별로 완전 분리

##### 기존 문제점 
<img width="993" height="460" alt="image" src="https://github.com/user-attachments/assets/c79163a4-8b13-475d-bb46-a2e4c606848f" />
 소켓 연결, 이벤트 수신, 상태 업데이트를 useBattleSocket(178줄)과 battlePage(240줄) 에서 다양한 책임들을 가지고.. 관리하고 있었음. 

```typescript
  export function useBattleSocket({ battleId, userId, team, password }) {
    const [battleData, setBattleData] = useState(...);
    const [battleProgress, setBattleProgressState] = useState(...);
    const [currentStage, setCurrentStage] = useState(...);
    const [objections, setObjections] = useState(...);
    
    useEffect(() => {
      // battle:joined 이벤트
      // battle:phase:update 이벤트
      // battle:turn:update 이벤트
      // battle:closed 이벤트
      // battle:objection:created 이벤트
      // battle:objection:voted 이벤트
      // battle:attacked 이벤트
      // battle:defensed 이벤트
      // battle:chat 이벤트
      // battle:team:changed 이벤트
      // ... 10개 이상의 소켓 이벤트를 한 곳에서 처리
    }, []);
    
    return { socket, currentStage, battleProgress, battleData, objections };
  }
```
그로인해 느낀 문제점으로는...
- 단일 책임 원칙 위반 한 훅이 너무 많은 역할 담당 하고 있음을 느꼈습니다.
- 너무 많은 코드에 어떤 이벤트가 어디서 처리되는지 파악 하기 어려웠습니다. 
- 테스트 코드를 작성하려하니 특정 기능만 테스트할 수 없을 정도로 결합 되어있음을 느꼈습니다.
- 배틀 페이지에도 상태 처리, 소켓 처리 로직이 혼재 되어있어서 코드 줄 수가 너무 과대함을 느꼈습니다. 그래서  디자인 / 비지니스 / 상태처리 로직의 분리가 필요하다고 느꼈습니다. 

<br/>

**개선 과정** - (기능별로 완전히 독립된 훅으로 분리)
그렇게 `useBattleSocket`, `useBattleProgress`, `useBattleDiscussions`, `useBattleTimeline`, `useBattleTeam, `useBattleChat`, `useBattle` 총 7개의 훅으로 관심사에 맞는 상태 / 이벤트 끼리 묶어 분리했습니다. 


1. `useBattleSocket.ts` (111줄): 소켓 연결 및 초기 동기화만 담당
   - 소켓 연결 생명주기 관리
   - battle:joined 이벤트로 초기 상태 동기화
   - 팀 인원수, 타임라인, 채팅 초기 데이터 설정

2. `useBattleProgress.ts` (64줄): 게임 진행 상태 전담
   - battle:phase:update 이벤트 처리
   - battle:turn:update 이벤트 처리
   - battle:closed 이벤트 처리

3. `useBattleDiscussions.ts` (106줄): 이의제기/반론 전담
   - battle:objection:created 이벤트 수신
   - battle:objection:voted 이벤트 수신
   - 이의제기/반론 제출 이벤트 송신
   - 투표 이벤트 송신

4. `useBattleTimeline.ts` (93줄): 타임라인 업데이트 전담
   - battle:attacked 이벤트 수신
   - battle:defensed 이벤트 수신
   - 타임라인에 선정된 항목 추가
   - 이펙트 모달 표시

5. `useBattleTeam.ts` (60줄): 팀 관리 전담
   - battle:team:changed 이벤트 수신
   - 팀 변경 요청 송신
   - 팀 변경 모달 제어

6. `useBattleChat.ts` (96줄): 채팅 기능 전담
   - 팀/전체 채팅 메시지 필터링
   - 채팅 전송 이벤트 송신
   - 메시지 데이터 변환

7. `useBattle.ts` (58줄): 모든 훅을 조합하는 통합 훅
   - 각 기능별 훅을 호출하여 조합
   - 페이지 컴포넌트에서는 이 훅 하나만 사용

<br/>

##### 개설 결과 
- BattlePage
  -  코드는 240줄 → 72줄 (70% 감소)
  - 실제 비즈니스 로직은 훅으로 분리, 상태 처리는 스토어에서 처리 하도록하여 페이지는 오직 UI 조합과 렌더링만 담당하게 해서 결합력을 낮추고 가독성,  유지 보수성을 대폭 상향 시켰습니다. 

---

##### 바뀐 구조 
<img width="1087" height="489" alt="image" src="https://github.com/user-attachments/assets/7c4784f4-9583-44d5-9662-c75f077a1cdb" />




#### 3. Props Drilling 완전 제거

기존에는 필요 상태를 부모로부터 prop으로 내려 받는 구조에서 BattleStore에 각 컴포넌트가 필요한 상태만 직접 구독 하는 방식으로 변경했습니다. 

```
BattleHeader.tsx:
  const teamCounts = useBattleStore((state) => state.teamCounts);
  const battleProgress = useBattleStore((state) => state.battleProgress);
  // 필요한 것만 가져옴

ChatSection.tsx:
  const teamChats = useBattleStore(selectTeamChats);
  const allChats = useBattleStore(selectAllChats);
  const selectedTeam = useBattleStore((state) => state.selectedTeam);
  // props 없이 직접 구독

TimelineSection.tsx:
  const timelines = useBattleStore((state) => state.timelines);
  // 필요한 것만 직접 구독

battlePage/index.tsx (리팩토링 후):
  return (
    <div className="text-white flex flex-col items-center">
      <BattleHeader title={battleInfo.title} description={battleInfo.description} />
      <CodeSection ... />
      <ChatSection />  {/* props 없음 */}
      <TimelineSection />  {/* props 없음 */}
      <DiscussionInput ... />
      <DiscussionVote ... />
    </div>
  );
```
---

#### 4. 공용 유틸 추가 및 UX 개선

**자동 스크롤 훅 추가 `commons/useAutoScroll`**:
- ChatSection에서 하드코딩으로 구현되어 있던 자동 스크롤 로직을 재사용 가능한 훅으로 분리
- `commons/hooks/useAutoScroll.ts` 추가
- 새 메시지 도착 시 자동으로 채팅창 하단으로 스크롤
```typescript
useAutoScroll.ts:
  export const useAutoScroll = (deps: unknown[]) => {
    const ref = useRef<HTMLDivElement>(null);
    useEffect(() => {
      if (ref.current) {
        ref.current.scrollTop = ref.current.scrollHeight;
      }
    }, deps);
    return ref;
  };
```

**채팅 컴포넌트 리팩토링**:
- 코드 컨벤션 통일
- 불필요한 중복 코드 제거

---

#### 5. 테스트 환경 구축 및 테스트 코드 작성

**테스트 환경 구축**:
- Vitest 설치 및 설정
- React Testing Library 설치
- frontend/src/test/setup.ts 테스트 환경 파일 추가

**유틸 함수 테스트** (3개):
1. battlePhase.test.ts: 게임 페이즈 판단 로직 테스트
2. convertChatMessage.test.ts: 채팅 메시지 변환 로직 테스트
3. getDiscussionConfig.test.ts: 토론 설정 로직 테스트

**컴포넌트 통합 테스트**:

1. ChatSection.test.tsx:
   - 팀 채팅 필터링 (현재 팀 메시지만 표시)
   - 전체 채팅 표시 (모든 팀 메시지 표시)
   - 탭 전환 (팀 라운지 ↔ 전체 라운지)
   - 메시지 전송 기능

2. DiscussionInput.test.tsx, DiscussionVote.test.tsx:
   - 이의제기/반론 입력 폼 렌더링
   - 투표 항목 렌더링
   - 투표 체크 기능
   - 입력 유효성 검사

3. CodeSection.test.tsx:
   - 코드 뷰 전환 (코드 A <-> 코드 B)
   - 탭 전환 (각 탭 활성화)
   - 코드 내용 렌더링

