### PR TITLE
[Feature] 선정된 이의제기 / 반론 이벤트 수신 결과 타임라인, 채팅창 UI에 반영

### DIFF
--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -7,6 +7,7 @@ export interface BattleChat {
   team: Team;
   text: string;
   createdAt: Date;
+  type?: 'chat' | 'attack' | 'defense';
 }
 
 export interface BattleInfo {

--- a/frontend/src/pages/battlePage/components/chatting/test/ChatSection.test.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/test/ChatSection.test.tsx
@@ -99,4 +99,90 @@ describe('배틀 페이지에 ChatSection 통합 테스트', () => {
     // 이제 B팀 메시지도 보임
     expect(screen.getByText('B팀 메시지')).toBeInTheDocument();
   });
+
+  it('선정된 이의제기 메시지가 DiscussionMessage로 렌더링되는지', () => {
+    mockSelectedTeam = 'NONE';
+    mockAllMessages = [
+      {
+        id: '1',
+        user: 'SYSTEM',
+        team: 'A',
+        content: '이 코드는 성능 문제가 있습니다',
+        timestamp: '2026-01-04 10:00:00',
+        type: 'attack'
+      }
+    ];
+    const { container } = render(<ChatSection />);
+
+    expect(screen.getByText('이 코드는 성능 문제가 있습니다')).toBeInTheDocument();
+    // DiscussionMessage 컴포넌트가 렌더링되었는지 확인
+    const discussionMessage = container.querySelector('[class*="discussion"]') || container.querySelector('div');
+    expect(discussionMessage).toBeInTheDocument();
+  });
+
+  it('선정된 반론 메시지가 DiscussionMessage로 렌더링되는지', () => {
+    mockSelectedTeam = 'NONE';
+    mockAllMessages = [
+      {
+        id: '1',
+        user: 'SYSTEM',
+        team: 'B',
+        content: '캐싱을 사용하면 해결됩니다',
+        timestamp: '2026-01-04 10:05:00',
+        type: 'defense'
+      }
+    ];
+    render(<ChatSection />);
+
+    expect(screen.getByText('캐싱을 사용하면 해결됩니다')).toBeInTheDocument();
+  });
+
+  it('일반 채팅과 특수 메시지(이의제기/반론)가 함께 표시되는지', () => {
+    mockSelectedTeam = 'NONE';
+    mockAllMessages = [
+      { id: '1', user: 'user-123', team: 'A', content: '안녕하세요', timestamp: '2026-01-04 10:00:00', type: 'chat' },
+      {
+        id: '2',
+        user: 'SYSTEM',
+        team: 'A',
+        content: '이 코드는 문제가 있습니다',
+        timestamp: '2026-01-04 10:01:00',
+        type: 'attack'
+      },
+      {
+        id: '3',
+        user: 'SYSTEM',
+        team: 'B',
+        content: '그렇지 않습니다',
+        timestamp: '2026-01-04 10:02:00',
+        type: 'defense'
+      },
+      { id: '4', user: 'user-456', team: 'B', content: '반갑습니다', timestamp: '2026-01-04 10:03:00', type: 'chat' }
+    ];
+    render(<ChatSection />);
+
+    expect(screen.getByText('안녕하세요')).toBeInTheDocument();
+    expect(screen.getByText('이 코드는 문제가 있습니다')).toBeInTheDocument();
+    expect(screen.getByText('그렇지 않습니다')).toBeInTheDocument();
+    expect(screen.getByText('반갑습니다')).toBeInTheDocument();
+  });
+
+  it('팀 라운지에서도 해당 팀의 선정된 이의제기/반론이 표시되는지', () => {
+    mockSelectedTeam = 'A';
+    mockTeamMessages = [
+      { id: '1', user: 'user-123', team: 'A', content: 'A팀 채팅', timestamp: '2026-01-04 10:00:00', type: 'chat' },
+      {
+        id: '2',
+        user: 'SYSTEM',
+        team: 'A',
+        content: 'A팀의 이의제기',
+        timestamp: '2026-01-04 10:01:00',
+        type: 'attack'
+      }
+    ];
+    render(<ChatSection />);
+
+    expect(screen.getByText('A팀 채팅')).toBeInTheDocument();
+    expect(screen.getByText('A팀의 이의제기')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/battlePage/components/chatting/test/ChatSection.test.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/test/ChatSection.test.tsx
@@ -44,19 +44,19 @@ describe('배틀 페이지에 ChatSection 통합 테스트', () => {
     mockTeamCounts = { teamACount: 5, teamBCount: 3 };
 
     mockTeamMessages = [
-      { id: '1', user: 'You', team: 'A', content: 'A팀 메시지', timestamp: '2026-01-04 10:00:00', type: 'normal' }
+      { id: '1', user: 'You', team: 'A', content: 'A팀 메시지', timestamp: '2026-01-04 10:00:00', type: 'chat' }
     ];
 
     mockAllMessages = [
-      { id: '1', user: 'You', team: 'A', content: 'A팀 메시지', timestamp: '2026-01-04 10:00:00', type: 'normal' },
-      { id: '2', user: 'user-789', team: 'B', content: 'B팀 메시지', timestamp: '2026-01-04 10:02:00', type: 'normal' }
+      { id: '1', user: 'You', team: 'A', content: 'A팀 메시지', timestamp: '2026-01-04 10:00:00', type: 'chat' },
+      { id: '2', user: 'user-789', team: 'B', content: 'B팀 메시지', timestamp: '2026-01-04 10:02:00', type: 'chat' }
     ];
   });
 
   it('팀 채팅 활성화시 현재 팀 메시지만 표시되는지', () => {
     mockSelectedTeam = 'A';
     mockTeamMessages = [
-      { id: '1', user: 'You', team: 'A', content: 'A팀 메시지', timestamp: '2026-01-04 10:00:00', type: 'normal' }
+      { id: '1', user: 'You', team: 'A', content: 'A팀 메시지', timestamp: '2026-01-04 10:00:00', type: 'chat' }
     ];
     render(<ChatSection />);
 

--- a/frontend/src/pages/battlePage/hooks/useBattleChat.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleChat.ts
@@ -20,13 +20,26 @@ export function useBattleChat() {
   const allChats = useBattleStore(selectAllChats);
   const addChat = useBattleStore((state) => state.addChat);
 
-  // 팀 채팅: 같은 팀인 것만
-  const teamMessages = useMemo(
-    () => teamChats.filter((chat) => chat.team === team).map((chat) => convertBattleChatToMessage(chat, userId)),
-    [teamChats, team, userId]
-  );
+  // 팀 채팅
+  const teamMessages = useMemo(() => {
+    const teamOnlyMessages = teamChats
+      .filter((chat) => chat.team === team)
+      .map((chat) => convertBattleChatToMessage(chat, userId));
 
-  // 전체 채팅: 그대로
+    const allChatTeamMessages = allChats
+      .filter((chat) => chat.team === team)
+      .map((chat) => convertBattleChatToMessage(chat, userId));
+
+    // 메시지 ID 기준으로 중복 제거하며 병합
+    const messageMap = new Map();
+    [...teamOnlyMessages, ...allChatTeamMessages].forEach((msg) => {
+      messageMap.set(msg.id, msg);
+    });
+
+    return Array.from(messageMap.values());
+  }, [teamChats, allChats, team, userId]);
+
+  // 전체 채팅
   const allMessages = useMemo(
     () => allChats.map((chat) => convertBattleChatToMessage(chat, userId)),
     [allChats, userId]
@@ -59,7 +72,6 @@ export function useBattleChat() {
         text: content.trim()
       };
 
-      // Optimistic update: 즉시 로컬 state에 추가
       const optimisticMessage: BattleChat = {
         messageId: `temp-${Date.now()}`,
         battleId,

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -96,10 +96,10 @@ export function useBattleSocket() {
       newSocket.off('battle:round:update');
       newSocket.off('battle:attacked');
       newSocket.off('battle:defensed');
-      newSocket.off('battle:attackvote:update', handleVoteUpdate);
-      newSocket.off('battle:defensevote:update', handleVoteUpdate);
-      newSocket.off('Battle:NewAttack', handleNewDiscussion);
-      newSocket.off('Battle:NewDefense', handleNewDiscussion);
+      newSocket.off('battle:attackvote:update');
+      newSocket.off('battle:defensevote:update');
+      newSocket.off('Battle:NewAttack');
+      newSocket.off('Battle:NewDefense');
       newSocket.disconnect();
       setSocket(null);
       setIsConnected(false);

--- a/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
@@ -1,5 +1,11 @@
 import { useEffect } from 'react';
-import type { BattleAttackedResult, BattleDefensedResult } from '@/commons/types/battle';
+import type {
+  BattleAttackedResult,
+  BattleDefensedResult,
+  BattleDiscussion,
+  BattleDefense,
+  BattleChat
+} from '@/commons/types/battle';
 import { useBattleStore, selectBattleProgress, selectSocket } from '../stores/battleStore';
 import { useEffectModal } from './useEffectModal';
 
@@ -15,12 +21,63 @@ export function useBattleTimeline() {
       // 턴 상태로 공격하는 팀 판단
       const attackingTeam = battleProgress?.turn?.status === 'A_ATTACK' ? 'A' : 'B';
       showEffect(attackingTeam, data.attack.text, 'attack');
+
+      // 타임라인에 이의제기 추가
+      const attackDiscussion: BattleDiscussion = {
+        discussionId: data.attack.discussionId,
+        authorId: data.attack.authorId,
+        content: data.attack.text,
+        upvotes: data.attack.upvotes,
+        votes: [],
+        status: 'SELECTED',
+        type: 'ATTACK'
+      };
+      useBattleStore.getState().addAttackTimeline(attackDiscussion);
+
+      // 채팅방에 선정된 이의제기 메시지 추가
+      const attackChatMessage: BattleChat = {
+        battleId: data.battleId,
+        scope: 'ALL' as const,
+        messageId: `attack-${data.attack.discussionId}`,
+        sender: 'SYSTEM',
+        team: attackingTeam,
+        text: data.attack.text,
+        createdAt: new Date(),
+        type: 'attack'
+      };
+      useBattleStore.getState().addChat(attackChatMessage);
     };
 
     const handleDefensed = (data: BattleDefensedResult) => {
       // 턴 상태로 방어하는 팀 판단
       const defendingTeam = battleProgress?.turn?.status === 'A_DEFENSE' ? 'A' : 'B';
       showEffect(defendingTeam, data.defense.text, 'defense');
+
+      // 타임라인에 반론 추가
+      const defenseDiscussion: BattleDefense = {
+        discussionId: data.defense.discussionId,
+        authorId: data.defense.authorId,
+        content: data.defense.text,
+        upvotes: data.defense.upvotes,
+        votes: [],
+        status: 'SELECTED',
+        type: 'DEFENSE',
+        attackId: '' // 서버에서 제공하지 않으면 빈 문자열
+      };
+      useBattleStore.getState().addDefenseTimeline(defenseDiscussion);
+
+      // 채팅방에 선정된 반론 메시지 추가
+      const defenseChatMessage: BattleChat = {
+        battleId: data.battleId,
+        scope: 'ALL' as const,
+        messageId: `defense-${data.defense.discussionId}`,
+        sender: 'SYSTEM',
+        team: defendingTeam,
+        text: data.defense.text,
+        createdAt: new Date(),
+        type: 'defense'
+      };
+      useBattleStore.getState().addChat(defenseChatMessage);
     };
 
     socket.on('battle:attacked', handleAttacked);

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -41,6 +41,8 @@ interface BattleStore {
   updateDiscussionVote: (discussionId: string, upvotes: number, votes: string[], userId: string) => void;
   setTeamCounts: (counts: { teamACount: number; teamBCount: number }) => void;
   setTimelines: (timelines: { attacks: BattleDiscussion[]; defenses: BattleDefense[] }) => void;
+  addAttackTimeline: (attack: BattleDiscussion) => void;
+  addDefenseTimeline: (defense: BattleDefense) => void;
   setTeamChats: (chats: BattleChat[]) => void;
   setAllChats: (chats: BattleChat[]) => void;
   addChat: (chat: BattleChat) => void;
@@ -90,6 +92,20 @@ export const useBattleStore = create<BattleStore>((set) => ({
 
   setTeamCounts: (counts) => set({ teamCounts: counts }),
   setTimelines: (timelines) => set({ timelines }),
+  addAttackTimeline: (attack) =>
+    set((state) => ({
+      timelines: {
+        attacks: [...(state.timelines?.attacks || []), attack],
+        defenses: state.timelines?.defenses || []
+      }
+    })),
+  addDefenseTimeline: (defense) =>
+    set((state) => ({
+      timelines: {
+        attacks: state.timelines?.attacks || [],
+        defenses: [...(state.timelines?.defenses || []), defense]
+      }
+    })),
   setTeamChats: (chats) => set({ teamChats: chats }),
   setAllChats: (chats) => set({ allChats: chats }),
   addChat: (chat) =>
@@ -97,7 +113,10 @@ export const useBattleStore = create<BattleStore>((set) => ({
       if (chat.scope === 'TEAM') {
         return { teamChats: [...state.teamChats, chat] };
       } else {
-        return { allChats: [...state.allChats, chat] };
+        return {
+          allChats: [...state.allChats, chat],
+          teamChats: [...state.teamChats, chat]
+        };
       }
     }),
   setSelectedTeam: (team) => set({ selectedTeam: team })

--- a/frontend/src/pages/battlePage/utils/convertChatMessage.ts
+++ b/frontend/src/pages/battlePage/utils/convertChatMessage.ts
@@ -6,7 +6,7 @@ export interface Message {
   team: Team;
   content: string;
   timestamp: string;
-  type?: 'normal' | 'attack' | 'defense';
+  type?: 'chat' | 'attack' | 'defense';
 }
 
 export const convertBattleChatToMessage = (chat: BattleChat, userId: string): Message => ({
@@ -15,5 +15,5 @@ export const convertBattleChatToMessage = (chat: BattleChat, userId: string): Me
   team: chat.team,
   content: chat.text,
   timestamp: new Date(chat.createdAt).toISOString().replace('T', ' ').substring(0, 19),
-  type: 'normal'
+  type: chat.type || 'chat'
 });


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #90 

## ✅ 작업 내용

### 💡개선 사항

#### 1. 선정된 이의제기/반론 타임라인 실시간 업데이트 구현
- `battle:attacked` 이벤트 수신 시 타임라인 UI에 이의제기 카드 추가 로직 구현 
- `battle:defensed` 이벤트 수신 시 타임라인 UI에 반론카드 추가 로직 구현 

#### 2. 채팅 라운지에 선정된 이의제기/반론 표시 기능 구현
- `BattleChat` 타입에 `type` 필드 추가 
  - ```typescript 
      BattleChat {
        ... 
        type?: 'chat' | 'attack' | 'defense'
        ...
     }
      ```
  -  채팅창에 기본 메세지, 이의제기/반론 메세지 조건부 렌더링 로직 구현 할 수 있도록 type 필드 추가 
- 투표로 선정된 이의제기/반론을 전체 라운지 및 팀 라운지에 특수 메시지(`DiscussionMessage`)로 렌더링 하도록 구현
- 일반 채팅과 토론 메시지를 구분하여 UI에 표시

#### 3. 버그 수정
- 페이즈/턴 변경 시 이전에 진행했던 이의제기/반론 투표 리스트가 초기화되지 않던 버그 수정
  - `battle:phase:update` 이벤트 수신 시 discussions 초기화
  - `battle:turn:update` 이벤트 수신 시 discussions 초기화

#### 4. 채팅 관련 테스트 코드 추가
1.  투표로 선정된 공격 메시지가 채팅창에 잘 나타나는지 확인하는 테스트 추가
2. 투표로 선정된 방어 메시지가 채팅창에 잘 나타나는지 확인하는 테스트 추가 
3. 유저들의 일반 채팅과 선정된 이의제기/반론이 모두 시간 순서대로 잘 표시되는지 테스트 추가 
4. 팀 채팅방에서 우리 팀의 선정된 토론이 일반 채팅과 함께 보이는지 테스트 추가


<br />


### 구현 부분
#### 선정된 이의제기/반론이 타임라인 & 채팅방에 실시간으로 추가 되는 기능
![20260105-1233-59 7019515](https://github.com/user-attachments/assets/512552c4-1b10-46f4-84fc-8b7afd5e4165)


## 💬 질문사항 (고민했던 부분)

- **투표 리스트 초기화 시점**: 페이즈/턴 변경 시 `useEffect`로 discussions를 초기화하는 방식이 적절한지, 아니면 서버에서 명시적인 초기화 이벤트를 받는 것이 더 안전할지 고민되네요.