### PR TITLE
[Refactor] FE/BE 프로젝트에서 사용중인 소켓 이벤트명 수정

### DIFF
--- a/backend/src/battles/gateway/battles.gateway.spec.ts
+++ b/backend/src/battles/gateway/battles.gateway.spec.ts
@@ -52,7 +52,7 @@ describe('BattlesGateway - Discussion Events', () => {
     gateway.server = mockServer
   })
 
-  describe('Battle:attack', () => {
+  describe('battle:attack', () => {
     it('공격 이벤트를 처리하고 팀 룸에 브로드캐스트한다', () => {
       const dto: AttackRequestDto = {
         battleId: 'battle-1',
@@ -100,13 +100,13 @@ describe('BattlesGateway - Discussion Events', () => {
 
       gateway.handleAttack(dto, mockClient)
 
-      expect(mockClient.emit).toHaveBeenCalledWith('Battle:Attack:Error', {
+      expect(mockClient.emit).toHaveBeenCalledWith('battle:attack:error', {
         message: 'Phase가 올바르지 않습니다',
       })
     })
   })
 
-  describe('Battle:Defense', () => {
+  describe('battle:defense', () => {
     it('반론 이벤트를 처리하고 팀 룸에 브로드캐스트한다', () => {
       const dto: DefenseRequestDto = {
         battleId: 'battle-1',
@@ -154,7 +154,7 @@ describe('BattlesGateway - Discussion Events', () => {
 
       gateway.handleDefense(dto, mockClient)
 
-      expect(mockClient.emit).toHaveBeenCalledWith('Battle:Defense:Error', {
+      expect(mockClient.emit).toHaveBeenCalledWith('battle:defense:error', {
         message: '현재 반론을 등록할 수 없는 단계입니다.',
       })
     })

--- a/backend/src/battles/gateway/battles.gateway.spec.ts
+++ b/backend/src/battles/gateway/battles.gateway.spec.ts
@@ -224,7 +224,7 @@ describe('BattlesGateway - Discussion Events', () => {
       })
 
       expect(mockServer.to).toHaveBeenCalledWith('battle-1:B')
-      expect(mockServer.emit).toHaveBeenCalledWith('battle:defensevote:update', mockResponse)
+      expect(mockServer.emit).toHaveBeenCalledWith('battle:defense:voted', mockResponse)
     })
   })
 })

--- a/backend/src/battles/gateway/battles.gateway.spec.ts
+++ b/backend/src/battles/gateway/battles.gateway.spec.ts
@@ -52,7 +52,7 @@ describe('BattlesGateway - Discussion Events', () => {
     gateway.server = mockServer
   })
 
-  describe('Battle:Attack', () => {
+  describe('Battle:attack', () => {
     it('공격 이벤트를 처리하고 팀 룸에 브로드캐스트한다', () => {
       const dto: AttackRequestDto = {
         battleId: 'battle-1',
@@ -160,7 +160,7 @@ describe('BattlesGateway - Discussion Events', () => {
     })
   })
 
-  describe('Battle:AttackVote', () => {
+  describe('battle:attack:vote', () => {
     it('공격 투표 이벤트를 처리하고 팀 룸에 브로드캐스트한다', () => {
       const dto: AttackVoteRequestDto = {
         battleId: 'battle-1',
@@ -194,7 +194,7 @@ describe('BattlesGateway - Discussion Events', () => {
     })
   })
 
-  describe('Battle:DefenseVote', () => {
+  describe('battle:defense:vote', () => {
     it('반론 투표 이벤트를 처리하고 팀 룸에 브로드캐스트한다', () => {
       const dto: DefenseVoteRequestDto = {
         battleId: 'battle-1',

--- a/backend/src/battles/gateway/battles.gateway.spec.ts
+++ b/backend/src/battles/gateway/battles.gateway.spec.ts
@@ -190,7 +190,7 @@ describe('BattlesGateway - Discussion Events', () => {
       })
 
       expect(mockServer.to).toHaveBeenCalledWith('battle-1:A')
-      expect(mockServer.emit).toHaveBeenCalledWith('battle:attackvote:update', mockResponse)
+      expect(mockServer.emit).toHaveBeenCalledWith('battle:attack:voted', mockResponse)
     })
   })
 

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -76,7 +76,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     }
   }
 
-  @SubscribeMessage('Battle:Attack')
+  @SubscribeMessage('Battle:attack')
   handleAttack(@MessageBody() dto: AttackRequestDto, @ConnectedSocket() client: Socket) {
     try {
       const { battleId, authorId, content, team } = dto
@@ -86,14 +86,14 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
       this.server.to(teamRoom).emit('Battle:NewAttack', attack)
     } catch (error) {
       if (error instanceof Error) {
-        client.emit('Battle:Attack:Error', {
+        client.emit('battle:attack:Error', {
           message: error.message,
         })
       }
     }
   }
 
-  @SubscribeMessage('Battle:Defense')
+  @SubscribeMessage('battle:defense')
   handleDefense(@MessageBody() dto: DefenseRequestDto, @ConnectedSocket() client: Socket) {
     try {
       const { battleId, authorId, content, team } = dto
@@ -103,7 +103,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
       this.server.to(teamRoom).emit('Battle:NewDefense', defense)
     } catch (error) {
       if (error instanceof Error) {
-        client.emit('Battle:Defense:Error', {
+        client.emit('battle:defense:Error', {
           message: error.message,
         })
       }
@@ -243,13 +243,13 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     }
   }
 
-  @SubscribeMessage('battle:teamVote')
+  @SubscribeMessage('battle:team:vote')
   handleTeamVote(@MessageBody() dto: BattleTeamVoteDto, @ConnectedSocket() client: Socket) {
     try {
       this.battlesService.voteTeam(dto, client.id)
     } catch (error) {
       if (error instanceof Error) {
-        client.emit('battle:teamVote:error', { message: error.message })
+        client.emit('battle:team:vote:error', { message: error.message })
       }
     }
   }

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -234,7 +234,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
           ? this.battlesService.getBattleRoomId(battleChatDto.battleId)
           : this.battlesService.getBattleRoomId(battleChatDto.battleId, battleChatDto.team)
 
-      // this.server.to(roomId).emit('battle:chatUpdate', saved)
+      // this.server.to(roomId).emit('battle:chatted', saved)
       this.server.to(roomId).except(client.id).emit('battle:chatted', saved)
     } catch (error) {
       if (error instanceof Error) {

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -76,7 +76,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     }
   }
 
-  @SubscribeMessage('Battle:attack')
+  @SubscribeMessage('battle:attack')
   handleAttack(@MessageBody() dto: AttackRequestDto, @ConnectedSocket() client: Socket) {
     try {
       const { battleId, authorId, content, team } = dto
@@ -86,7 +86,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
       this.server.to(teamRoom).emit('Battle:NewAttack', attack)
     } catch (error) {
       if (error instanceof Error) {
-        client.emit('battle:attack:Error', {
+        client.emit('battle:attack:error', {
           message: error.message,
         })
       }
@@ -103,7 +103,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
       this.server.to(teamRoom).emit('Battle:NewDefense', defense)
     } catch (error) {
       if (error instanceof Error) {
-        client.emit('battle:defense:Error', {
+        client.emit('battle:defense:error', {
           message: error.message,
         })
       }
@@ -154,21 +154,21 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     const { battleId } = payload
     const battleRoomId = this.battlesService.getBattleRoomId(battleId)
 
-    this.server.to(battleRoomId).emit('battle:turn:update', payload)
+    this.server.to(battleRoomId).emit('battle:turn:updated', payload)
   }
 
   phaseUpdate(payload: BattlePhaseResponseDto) {
     const { battleId } = payload
     const battleRoomId = this.battlesService.getBattleRoomId(battleId)
 
-    this.server.to(battleRoomId).emit('battle:phase:update', payload)
+    this.server.to(battleRoomId).emit('battle:phase:updated', payload)
   }
 
   roundUpdate(payload: BattleRoundResponseDto) {
     const { battleId } = payload
     const battleRoomId = this.battlesService.getBattleRoomId(battleId)
 
-    this.server.to(battleRoomId).emit('battle:round:update', payload)
+    this.server.to(battleRoomId).emit('battle:round:updated', payload)
   }
 
   onAttacked(payload: DiscussionVoteResultDto) {

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -110,7 +110,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     }
   }
 
-  @SubscribeMessage('battle:attackvote')
+  @SubscribeMessage('battle:attack:vote')
   handleAttackVote(@MessageBody() dto: AttackVoteRequestDto, @ConnectedSocket() client: Socket) {
     try {
       const { battleId, discussionId, userId, team } = dto
@@ -123,14 +123,14 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
       })
     } catch (error) {
       if (error instanceof Error) {
-        client.emit('battle:attackvote:error', {
+        client.emit('battle:attack:vote:error', {
           message: error.message,
         })
       }
     }
   }
 
-  @SubscribeMessage('battle:defensevote')
+  @SubscribeMessage('battle:defense:vote')
   handleDefenseVote(@MessageBody() dto: DefenseVoteRequestDto, @ConnectedSocket() client: Socket) {
     try {
       const { battleId, discussionId, userId, team } = dto
@@ -143,7 +143,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
       })
     } catch (error) {
       if (error instanceof Error) {
-        client.emit('battle:defensevote:error', {
+        client.emit('battle:defense:vote:error', {
           message: error.message,
         })
       }

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -139,7 +139,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
       // 모든 변경된 항목(기존 투표 취소 + 새 투표)을 전송
       updates.forEach(update => {
-        this.server.to(teamRoom).emit('battle:defensevote:update', update)
+        this.server.to(teamRoom).emit('battle:defense:voted', update)
       })
     } catch (error) {
       if (error instanceof Error) {
@@ -235,7 +235,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
           : this.battlesService.getBattleRoomId(battleChatDto.battleId, battleChatDto.team)
 
       // this.server.to(roomId).emit('battle:chatUpdate', saved)
-      this.server.to(roomId).except(client.id).emit('battle:chatUpdate', saved)
+      this.server.to(roomId).except(client.id).emit('battle:chatted', saved)
     } catch (error) {
       if (error instanceof Error) {
         client.emit('battle:chat:error', { message: error.message })

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -199,11 +199,11 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
   }
 
   private bindBattleEvents() {
-    this.battlesService.on('battle:phase:update', (payload: BattlePhaseResponseDto) => this.phaseUpdate(payload))
+    this.battlesService.on('battle:phase:updated', (payload: BattlePhaseResponseDto) => this.phaseUpdate(payload))
 
-    this.battlesService.on('battle:turn:update', (payload: BattleTurnResponseDto) => this.turnUpdate(payload))
+    this.battlesService.on('battle:turn:updated', (payload: BattleTurnResponseDto) => this.turnUpdate(payload))
 
-    this.battlesService.on('battle:round:update', (payload: BattleRoundResponseDto) => this.roundUpdate(payload))
+    this.battlesService.on('battle:round:updated', (payload: BattleRoundResponseDto) => this.roundUpdate(payload))
 
     this.battlesService.on('battle:attacked', (payload: DiscussionVoteResultDto) => this.onAttacked(payload))
 

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -119,7 +119,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
       // 모든 변경된 항목(기존 투표 취소 + 새 투표)을 전송
       updates.forEach(update => {
-        this.server.to(teamRoom).emit('battle:attackvote:update', update)
+        this.server.to(teamRoom).emit('battle:attack:voted', update)
       })
     } catch (error) {
       if (error instanceof Error) {

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -370,7 +370,7 @@ export class BattlesService extends EventEmitter {
         expiredAt: state.expiredAt,
       })
 
-      this.emit('battle:turn:update', res)
+      this.emit('battle:turn:updated', res)
     }
 
     if (prevRound !== state.round) {

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -254,7 +254,7 @@ export class BattlesService extends EventEmitter {
       expiredAt: activeBattleState.expiredAt,
     })
 
-    this.emit('battle:phase:update', res)
+    this.emit('battle:phase:updated', res)
     this.scheduleNextTick(battleId)
   }
 
@@ -359,7 +359,7 @@ export class BattlesService extends EventEmitter {
         startedAt: state.startedAt,
         expiredAt: state.expiredAt,
       })
-      this.emit('battle:phase:update', res)
+      this.emit('battle:phase:updated', res)
     }
 
     if (state.turn?.status && prevTurn !== state.turn.status) {
@@ -379,7 +379,7 @@ export class BattlesService extends EventEmitter {
         round: state.round,
       })
 
-      this.emit('battle:round:update', res)
+      this.emit('battle:round:updated', res)
     }
 
     this.scheduleNextTick(battleId)

--- a/frontend/src/pages/battlePage/hooks/useBattleChat.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleChat.ts
@@ -53,10 +53,10 @@ export function useBattleChat() {
       addChat(message);
     };
 
-    socket.on('battle:chatUpdate', handleChatUpdate);
+    socket.on('battle:chatted', handleChatUpdate);
 
     return () => {
-      socket.off('battle:chatUpdate', handleChatUpdate);
+      socket.off('battle:chatted', handleChatUpdate);
     };
   }, [socket, addChat]);
 

--- a/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
@@ -27,7 +27,7 @@ export function useBattleDiscussions() {
       if (targetDiscussion?.hasVoted) return;
 
       const { isAttacking } = getDiscussionConfig(team, battleProgress?.phase);
-      const eventName = isAttacking ? 'battle:attackvote' : 'battle:defensevote';
+      const eventName = isAttacking ? 'battle:attack:vote' : 'battle:defense:vote';
 
       socket.emit(eventName, {
         battleId,

--- a/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
@@ -91,14 +91,14 @@ export function useBattleDiscussions() {
 
     socket.on('battle:attackvote:update', handleVoteUpdate);
     socket.on('battle:defensevote:update', handleVoteUpdate);
-    socket.on('Battle:NewAttack', handleNewDiscussion);
-    socket.on('Battle:NewDefense', handleNewDiscussion);
+    socket.on('battle:attack:created', handleNewDiscussion);
+    socket.on('battle:defense:created', handleNewDiscussion);
 
     return () => {
       socket.off('battle:attackvote:update', handleVoteUpdate);
       socket.off('battle:defensevote:update', handleVoteUpdate);
-      socket.off('Battle:NewAttack', handleNewDiscussion);
-      socket.off('Battle:NewDefense', handleNewDiscussion);
+      socket.off('battle:attack:created', handleNewDiscussion);
+      socket.off('battle:defense:created', handleNewDiscussion);
     };
   }, [socket, userId, team, updateDiscussionVote, addDiscussion]);
 

--- a/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
@@ -90,13 +90,13 @@ export function useBattleDiscussions() {
     };
 
     socket.on('battle:attack:voted', handleVoteUpdate);
-    socket.on('battle:defensevote:update', handleVoteUpdate);
+    socket.on('battle:defense:voted', handleVoteUpdate);
     socket.on('battle:attack:created', handleNewDiscussion);
     socket.on('battle:defense:created', handleNewDiscussion);
 
     return () => {
-      socket.off('battle:attackvote:update', handleVoteUpdate);
-      socket.off('battle:defensevote:update', handleVoteUpdate);
+      socket.off('battle:attack:voted', handleVoteUpdate);
+      socket.off('battle:defense:voted', handleVoteUpdate);
       socket.off('battle:attack:created', handleNewDiscussion);
       socket.off('battle:defense:created', handleNewDiscussion);
     };

--- a/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
@@ -50,7 +50,7 @@ export function useBattleDiscussions() {
         return;
       }
 
-      socket.emit(isAttacking ? 'Battle:Attack' : 'Battle:Defense', {
+      socket.emit(isAttacking ? 'battle:attack' : 'battle:defense', {
         battleId,
         authorId: userId,
         content,

--- a/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
@@ -89,7 +89,7 @@ export function useBattleDiscussions() {
       });
     };
 
-    socket.on('battle:attackvote:update', handleVoteUpdate);
+    socket.on('battle:attack:voted', handleVoteUpdate);
     socket.on('battle:defensevote:update', handleVoteUpdate);
     socket.on('battle:attack:created', handleNewDiscussion);
     socket.on('battle:defense:created', handleNewDiscussion);

--- a/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
@@ -44,9 +44,9 @@ export function useBattleProgress() {
       });
     };
 
-    socket.on('battle:phase:update', handlePhaseUpdate);
-    socket.on('battle:turn:update', handleTurnUpdate);
-    socket.on('battle:round:update', handleRoundUpdate);
+    socket.on('battle:phase:updated', handlePhaseUpdate);
+    socket.on('battle:turn:updated', handleTurnUpdate);
+    socket.on('battle:round:updated', handleRoundUpdate);
 
     // 배틀 종료 이벤트 구독
     const handleBattleClosed = (data: { battleId: string }) => {
@@ -55,9 +55,9 @@ export function useBattleProgress() {
     socket.on('battle:closed', handleBattleClosed);
 
     return () => {
-      socket.off('battle:phase:update', handlePhaseUpdate);
-      socket.off('battle:turn:update', handleTurnUpdate);
-      socket.off('battle:round:update', handleRoundUpdate);
+      socket.off('battle:phase:updated', handlePhaseUpdate);
+      socket.off('battle:turn:updated', handleTurnUpdate);
+      socket.off('battle:round:updated', handleRoundUpdate);
       socket.off('battle:closed', handleBattleClosed);
     };
   }, [socket, setCurrentStage, updateBattleProgress, navigate]);

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -98,8 +98,8 @@ export function useBattleSocket() {
       newSocket.off('battle:defensed');
       newSocket.off('battle:attackvote:update');
       newSocket.off('battle:defensevote:update');
-      newSocket.off('Battle:NewAttack');
-      newSocket.off('Battle:NewDefense');
+      newSocket.off('battle:attack:created');
+      newSocket.off('battle:defense:created');
       newSocket.disconnect();
       setSocket(null);
       setIsConnected(false);

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -97,7 +97,7 @@ export function useBattleSocket() {
       newSocket.off('battle:attacked');
       newSocket.off('battle:defensed');
       newSocket.off('battle:attack:voted');
-      newSocket.off('battle:defensevote:update');
+      newSocket.off('battle:defense:voted');
       newSocket.off('battle:attack:created');
       newSocket.off('battle:defense:created');
       newSocket.disconnect();

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -91,9 +91,9 @@ export function useBattleSocket() {
     return () => {
       newSocket.off('connect');
       newSocket.off('battle:joined');
-      newSocket.off('battle:phase:update');
-      newSocket.off('battle:turn:update');
-      newSocket.off('battle:round:update');
+      newSocket.off('battle:phase:updated');
+      newSocket.off('battle:turn:updated');
+      newSocket.off('battle:round:updated');
       newSocket.off('battle:attacked');
       newSocket.off('battle:defensed');
       newSocket.off('battle:attack:voted');

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -96,7 +96,7 @@ export function useBattleSocket() {
       newSocket.off('battle:round:update');
       newSocket.off('battle:attacked');
       newSocket.off('battle:defensed');
-      newSocket.off('battle:attackvote:update');
+      newSocket.off('battle:attack:voted');
       newSocket.off('battle:defensevote:update');
       newSocket.off('battle:attack:created');
       newSocket.off('battle:defense:created');

--- a/frontend/src/pages/battlePage/hooks/useBattleTeam.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTeam.ts
@@ -49,7 +49,7 @@ export function useBattleTeam({ onOpenTeamChangeModal, onCloseTeamChangeModal }:
   const handleTeamChange = useCallback(
     (team: 'A' | 'B' | 'NONE') => {
       if (!socket) return;
-      socket.emit('battle:teamVote', { battleId, team });
+      socket.emit('battle:team:vote', { battleId, team });
 
       onCloseTeamChangeModal();
     },


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #104

## ✅ 작업 내용

### 💡개선 사항
WebSocket 이벤트명을 도메인:kebab-case 컨벤션으로 전면 통일했습니다.

#### 컨벤션 규칙
- 모든 이벤트명: 소문자 + kebab-case (콜론으로 구분)
- 서버→클라이언트 응답: `battle:action:created` 형식
- 서버→클라이언트 업데이트: `battle:noun:updated` 형식 (과거형)
- 에러 이벤트: `battle:action:error` 형식 (모두 소문자)

#### Backend 변경사항
- **@SubscribeMessage 데코레이터**: `Battle:attack` → `battle:attack`
- **이벤트 응답**: `Battle:NewAttack` → `battle:attack:created`, `Battle:NewDefense` → `battle:defense:created`
- **투표 이벤트**: `battle:attackvote` → `battle:attack:vote`, `battle:defensevote` → `battle:defense:vote`
- **진행 상태**: `battle:turn:update` → `battle:turn:updated`, `battle:phase:update` → `battle:phase:updated`, `battle:round:update` → `battle:round:updated`
- **에러 이벤트**: `Battle:Attack:Error` → `battle:attack:error`, `Battle:Defense:Error` → `battle:defense:error`
- **채팅**: `battle:chatUpdate` → `battle:chatted`
- **팀 투표**: `battle:teamVote` → `battle:team:vote`
- **테스트 코드**: 모든 describe 블록 및 expect 구문을 새 이벤트명으로 업데이트

#### Frontend 변경사항
- **useBattleSocket.ts**: cleanup 배열의 모든 이벤트명 업데이트
- **useBattleDiscussions.ts**: emit 및 listener 이벤트명 통일
- **useBattleProgress.ts**: phase, turn, round 이벤트 리스너 업데이트
- **useBattleChat.ts**: chatted 이벤트로 변경
- **useBattleTeam.ts**: team:vote emit 수정
- **useBattleTimeline.ts**: attacked/defensed 리스너 유지


<br />
