### PR TITLE
[Refactor] 이의제기 & 반박 투표/ 입력창을 재배치  

### DIFF
--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
+import BattleIcon from '@/assets/icon/battle.svg?react';
 import { isInputDisabled, getDiscussionConfig } from '../../utils/battlePhase';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from '../../stores/battleStore';
+import { TEAM_COLORS } from '../../types/teamColors';
 
 interface DiscussionInputProps {
   disabled?: boolean;
@@ -12,10 +14,15 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
   const team = useBattleStore(selectSelectedTeam);
   const [inputValue, setInputValue] = useState('');
 
+  // 중립 진영은 DiscussionInput 표시 안 함
+  if (team === 'NONE') {
+    return null;
+  }
+
   const phase = battleProgress?.phase;
   const turnStatus = battleProgress?.turn?.status;
 
-  const { placeholderText, buttonText, Icon } = getDiscussionConfig(team, phase);
+  const { placeholderText, buttonText, Icon, isAttacking } = getDiscussionConfig(team, phase);
   const disabled_input = isInputDisabled(team, phase, turnStatus, disabled);
 
   const handleSubmit = () => {
@@ -31,27 +38,59 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
     }
   };
 
+  const hintText = isAttacking
+    ? '상대 진영의 코드와 주장의 빈틈을 노려 반론을 던져보세요.'
+    : '아직 이의제기 단계가 아닙니다. 잠시만 기다려주세요.';
+
+  const colors = TEAM_COLORS[team];
+
   return (
-    <section className="w-full bg-[#1E1E2F] rounded-lg overflow-hidden">
-      <div className="p-4 flex gap-1">
-        <input
-          type="text"
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          onKeyPress={handleKeyPress}
-          placeholder={placeholderText}
-          disabled={disabled_input}
-          autoFocus
-          className="w-full bg-[#2D2D3F] border border-[#FF5A5F] rounded-md px-4 py-3 text-[13px] text-white placeholder-[#666] focus:outline-none focus:border-[#FF5A5F] disabled:opacity-50 disabled:cursor-not-allowed"
-        />
-        <button
-          onClick={handleSubmit}
-          disabled={disabled_input}
-          className="w-[140px] py-2 bg-[#4A5568] text-[15px] text-white rounded-md hover:bg-[#5A6578] transition-colors flex items-center justify-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[#4A5568]"
-        >
-          <Icon className="w-[22px] h-[22px]" />
-          {buttonText}
-        </button>
+    <section
+      className={`w-full bg-linear-to-r ${colors.containerGradient} border ${colors.border} rounded-lg overflow-hidden shadow-lg`}
+    >
+      {/* 헤더 */}
+      <div className="px-4 pt-4 pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <BattleIcon className={`w-5 h-5 ${colors.icon}`} />
+            <h3 className="text-white text-[15px] font-semibold">{team}팀 이의제기</h3>
+          </div>
+          {isAttacking && (
+            <div
+              className={`flex items-center gap-1.5 bg-linear-to-r ${colors.badgeGradient} px-3 py-1.5 rounded-full`}
+            >
+              <span className="text-white text-[12px] font-medium">반격 시간</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 입력 영역 */}
+      <div className="px-4 pb-4">
+        <div className="flex gap-2 mb-3">
+          <input
+            type="text"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyPress}
+            placeholder={placeholderText}
+            disabled={disabled_input}
+            autoFocus
+            className={`flex-1 bg-[#2D2D3F] border ${colors.inputBorder} rounded-lg px-4 py-3 text-[14px] text-white placeholder-[#666] focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed transition-all`}
+          />
+          <button
+            onClick={handleSubmit}
+            disabled={disabled_input}
+            className={`px-6 py-3 ${colors.buttonBg} text-white rounded-lg ${colors.buttonHover} ${colors.buttonActive} transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed font-medium text-[14px] shadow-md hover:shadow-lg`}
+          >
+            <Icon className="w-5 h-5" />
+            {buttonText}
+          </button>
+        </div>
+
+        <div className={`flex items-start gap-2 ${colors.hintText} text-[12px]`}>
+          <p className="leading-relaxed">{hintText}</p>
+        </div>
       </div>
     </section>
   );

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -52,7 +52,7 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
       <div className="px-4 pt-4 pb-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <BattleIcon className={`w-5 h-5 ${colors.icon}`} />
+            <BattleIcon className={`w-5 h-5 ${colors.primary}`} />
             <h3 className="text-white text-[15px] font-semibold">{team}팀 이의제기</h3>
           </div>
           {isAttacking && (
@@ -76,19 +76,19 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
             placeholder={placeholderText}
             disabled={disabled_input}
             autoFocus
-            className={`flex-1 bg-[#2D2D3F] border ${colors.inputBorder} rounded-lg px-4 py-3 text-[14px] text-white placeholder-[#666] focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed transition-all`}
+            className={`flex-1 bg-[#2D2D3F] border ${colors.border} rounded-lg px-4 py-3 text-[14px] text-white placeholder-[#666] focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed transition-all`}
           />
           <button
             onClick={handleSubmit}
             disabled={disabled_input}
-            className={`px-6 py-3 ${colors.buttonBg} text-white rounded-lg ${colors.buttonHover} ${colors.buttonActive} transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed font-medium text-[14px] shadow-md hover:shadow-lg`}
+            className={`px-6 py-3 ${colors.primaryBg} text-white rounded-lg ${colors.buttonHover} ${colors.buttonActive} transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed font-medium text-[14px] shadow-md hover:shadow-lg`}
           >
             <Icon className="w-5 h-5" />
             {buttonText}
           </button>
         </div>
 
-        <div className={`flex items-start gap-2 ${colors.hintText} text-[12px]`}>
+        <div className={`flex items-start gap-2 ${colors.primary} text-[12px]`}>
           <p className="leading-relaxed">{hintText}</p>
         </div>
       </div>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -4,7 +4,7 @@ import type { BattleInfo } from '@/commons/types/battle';
 import BattleHeader from './components/header/BattleHeader';
 import CodeSection from './components/codeview/CodeSection';
 import ChatSection from './components/chatting/ChatSection';
-import DiscussionInput from './components/discussion/DiscussionInput';
+// import DiscussionInput from './components/discussion/DiscussionInput';
 import DiscussionVote from './components/discussion/DiscussionVote';
 import TimelineSection from './components/timeline/TimelineSection';
 import { useBattle } from './hooks/useBattle';
@@ -23,7 +23,7 @@ export default function BattlePage() {
     closeModal: handleCloseTeamChangeModal
   } = useModal(false);
 
-  const { handleVote, handleDiscussionSubmit, effectModal, hideEffect, handleTeamChange } = useBattle({
+  const { handleVote, effectModal, hideEffect, handleTeamChange } = useBattle({
     battleId,
     onOpenTeamChangeModal: handleOpenTeamChangeModal,
     onCloseTeamChangeModal: handleCloseTeamChangeModal
@@ -47,9 +47,8 @@ export default function BattlePage() {
             <TimelineSection />
           </div>
           <aside className="flex flex-col gap-4 w-[590px]">
-            <ChatSection />
-            <DiscussionInput onSubmit={handleDiscussionSubmit} />
             <DiscussionVote onVote={handleVote} />
+            <ChatSection />
           </aside>
         </div>
       </main>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -4,7 +4,7 @@ import type { BattleInfo } from '@/commons/types/battle';
 import BattleHeader from './components/header/BattleHeader';
 import CodeSection from './components/codeview/CodeSection';
 import ChatSection from './components/chatting/ChatSection';
-// import DiscussionInput from './components/discussion/DiscussionInput';
+import DiscussionInput from './components/discussion/DiscussionInput';
 import DiscussionVote from './components/discussion/DiscussionVote';
 import TimelineSection from './components/timeline/TimelineSection';
 import { useBattle } from './hooks/useBattle';
@@ -23,18 +23,18 @@ export default function BattlePage() {
     closeModal: handleCloseTeamChangeModal
   } = useModal(false);
 
-  const { handleVote, effectModal, hideEffect, handleTeamChange } = useBattle({
+  const { handleVote, handleDiscussionSubmit, effectModal, hideEffect, handleTeamChange } = useBattle({
     battleId,
     onOpenTeamChangeModal: handleOpenTeamChangeModal,
     onCloseTeamChangeModal: handleCloseTeamChangeModal
   });
 
   return (
-    <div className="text-white flex flex-col items-center">
+    <div className="text-white flex flex-col items-center relative">
       <div className="w-[1800px]">
         <BattleHeader title={battleInfo.title} description={battleInfo.description} />
       </div>
-      <main className="w-[1800px]">
+      <main className="w-[1800px] pb-24">
         <div className="flex gap-2 py-4">
           <div className="flex-1">
             <CodeSection
@@ -52,6 +52,13 @@ export default function BattlePage() {
           </aside>
         </div>
       </main>
+
+      {/* DiscussionInput 항상 중앙 하단에 고정 */}
+      <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-[1800px] px-4 pb-4 z-50">
+        <div className="max-w-[590px] mx-auto">
+          <DiscussionInput onSubmit={handleDiscussionSubmit} />
+        </div>
+      </div>
 
       {isTeamChangeModalOpen && (
         <TeamChangeModal handleTeamChange={handleTeamChange} onClose={handleCloseTeamChangeModal} />

--- a/frontend/src/pages/battlePage/types/teamColors.ts
+++ b/frontend/src/pages/battlePage/types/teamColors.ts
@@ -1,41 +1,49 @@
-export type Team = 'A' | 'B';
+export type Team = 'A' | 'B' | 'NONE';
 
 export interface TeamColors {
-  containerGradient: string;
+  primary: string;
   border: string;
-  icon: string;
-  inputBorder: string;
-  buttonBg: string;
+  primaryBg: string;
+  containerGradient: string;
   buttonHover: string;
   buttonActive: string;
   badgeGradient: string;
-  badgeIcon: string;
-  hintText: string;
+  codeBlock: string;
+  codeText: string;
 }
 
 export const TEAM_COLORS: Record<Team, TeamColors> = {
   A: {
-    containerGradient: 'from-[#1A2B4A] to-[#0F1A2E]',
+    primary: 'text-[#6BA3FF]',
     border: 'border-[#3B6FA8]',
-    icon: 'text-[#6BA3FF]',
-    inputBorder: 'border-[#3B6FA8]',
-    buttonBg: 'bg-[#3B6FA8]',
+    primaryBg: 'bg-[#3B6FA8]',
+    containerGradient: 'from-[#1A2B4A] to-[#0F1A2E]',
     buttonHover: 'hover:bg-[#4B7FB8]',
     buttonActive: 'active:bg-[#2B5F98]',
     badgeGradient: 'from-[#1A2B4A] to-[#2B4A6E]',
-    badgeIcon: 'text-[#6BA3FF]',
-    hintText: 'text-[#6BA3FF]'
+    codeBlock: 'border-[#2B7FFF] bg-[#1C398E]',
+    codeText: 'text-[#BEDBFF]'
   },
   B: {
-    containerGradient: 'from-[#4A1F22] to-[#2F1214]',
+    primary: 'text-[#FF7A7F]',
     border: 'border-[#C85A5F]',
-    icon: 'text-[#FF7A7F]',
-    inputBorder: 'border-[#C85A5F]',
-    buttonBg: 'bg-[#C85A5F]',
+    primaryBg: 'bg-[#C85A5F]',
+    containerGradient: 'from-[#4A1F22] to-[#2F1214]',
     buttonHover: 'hover:bg-[#D86A6F]',
     buttonActive: 'active:bg-[#B84A4F]',
     badgeGradient: 'from-[#4A1F22] to-[#6A2F32]',
-    badgeIcon: 'text-[#FF7A7F]',
-    hintText: 'text-[#FF7A7F]'
+    codeBlock: 'border-[#FB2C36] bg-[#82181A]',
+    codeText: 'text-[#FFC9C9]'
+  },
+  NONE: {
+    primary: 'text-[#FF8533]',
+    border: 'border-[#FF6900]',
+    primaryBg: 'bg-[#F54900]',
+    containerGradient: 'from-[#3A1F0F] to-[#241308]',
+    buttonHover: 'hover:bg-[#FF5A00]',
+    buttonActive: 'active:bg-[#E53900]',
+    badgeGradient: 'from-[#CA3500] to-[#FF5A00]',
+    codeBlock: 'border-[#FF6900] bg-[#CA3500]',
+    codeText: 'text-[#FFB86A]'
   }
 } as const;

--- a/frontend/src/pages/battlePage/types/teamColors.ts
+++ b/frontend/src/pages/battlePage/types/teamColors.ts
@@ -1,0 +1,41 @@
+export type Team = 'A' | 'B';
+
+export interface TeamColors {
+  containerGradient: string;
+  border: string;
+  icon: string;
+  inputBorder: string;
+  buttonBg: string;
+  buttonHover: string;
+  buttonActive: string;
+  badgeGradient: string;
+  badgeIcon: string;
+  hintText: string;
+}
+
+export const TEAM_COLORS: Record<Team, TeamColors> = {
+  A: {
+    containerGradient: 'from-[#1A2B4A] to-[#0F1A2E]',
+    border: 'border-[#3B6FA8]',
+    icon: 'text-[#6BA3FF]',
+    inputBorder: 'border-[#3B6FA8]',
+    buttonBg: 'bg-[#3B6FA8]',
+    buttonHover: 'hover:bg-[#4B7FB8]',
+    buttonActive: 'active:bg-[#2B5F98]',
+    badgeGradient: 'from-[#1A2B4A] to-[#2B4A6E]',
+    badgeIcon: 'text-[#6BA3FF]',
+    hintText: 'text-[#6BA3FF]'
+  },
+  B: {
+    containerGradient: 'from-[#4A1F22] to-[#2F1214]',
+    border: 'border-[#C85A5F]',
+    icon: 'text-[#FF7A7F]',
+    inputBorder: 'border-[#C85A5F]',
+    buttonBg: 'bg-[#C85A5F]',
+    buttonHover: 'hover:bg-[#D86A6F]',
+    buttonActive: 'active:bg-[#B84A4F]',
+    badgeGradient: 'from-[#4A1F22] to-[#6A2F32]',
+    badgeIcon: 'text-[#FF7A7F]',
+    hintText: 'text-[#FF7A7F]'
+  }
+} as const;

--- a/frontend/src/pages/teamSelectPage/components/TeamButton.tsx
+++ b/frontend/src/pages/teamSelectPage/components/TeamButton.tsx
@@ -3,6 +3,7 @@ import EyeIcon from '@/assets/icon/eye.svg?react';
 import Sheild from '@/assets/icon/shield.svg?react';
 import Scale from '@/assets/icon/scale.svg?react';
 import CodeTooltip from './CodeTooltip';
+import { TEAM_COLORS, type Team } from '@/pages/battlePage/types/teamColors';
 
 interface TeamButtonProps {
   team: 'A' | 'B' | 'NONE';
@@ -11,30 +12,6 @@ interface TeamButtonProps {
   description?: string;
   onSelect?: (team: 'A' | 'B' | 'NONE') => void;
 }
-
-const TEAM_STYLES = {
-  A: {
-    button: 'border-[#2B7FFF]',
-    icon: 'bg-[#155DFC]',
-    title: 'text-[#51A2FF]',
-    codeBlock: 'border-[#2B7FFF] bg-[#1C398E]',
-    codeText: 'text-[#BEDBFF]'
-  },
-  B: {
-    button: 'border-[#FB2C36]',
-    icon: 'bg-[#E7000B]',
-    title: 'text-[#FF5A5F]',
-    codeBlock: 'border-[#FB2C36] bg-[#82181A]',
-    codeText: 'text-[#FFC9C9]'
-  },
-  NONE: {
-    button: 'border-[#FF6900]',
-    icon: 'bg-[#F54900]',
-    title: 'text-[#FF8533]',
-    codeBlock: 'border-[#FF6900] bg-[#CA3500]',
-    codeText: 'text-[#FFB86A]'
-  }
-};
 
 const TEAM_CONTENT = {
   A: {
@@ -57,9 +34,10 @@ const TEAM_CONTENT = {
 
 export default function TeamButton({ team, language, code, description, onSelect }: TeamButtonProps) {
   const [isHovered, setIsHovered] = useState(false);
-  const styles = TEAM_STYLES[team];
   const content = TEAM_CONTENT[team];
   const Icon = team === 'NONE' ? Scale : Sheild;
+
+  const colors = TEAM_COLORS[team as Team];
 
   return (
     <div
@@ -69,24 +47,24 @@ export default function TeamButton({ team, language, code, description, onSelect
     >
       <button
         onClick={() => onSelect?.(team)}
-        className={`border-[0.1px] rounded-lg bg-[#1E1E2F] min-h-[437px] w-[18rem] ${styles.button} transition-transform duration-300 hover:scale-110`}
+        className={`border-[0.1px] rounded-lg bg-[#1E1E2F] min-h-[437px] w-[18rem] ${colors.border} transition-transform duration-300 hover:scale-110`}
       >
-        <Icon className={`rounded-full w-[96px] h-[96px] px-6 py-6 mx-auto ${styles.icon}`} />
+        <Icon className={`rounded-full w-[96px] h-[96px] px-6 py-6 mx-auto ${colors.primaryBg}`} />
         <p className="my-4">{content.label}</p>
-        <p className={`text-[16px] my-4 ${styles.title}`}>{content.title}</p>
+        <p className={`text-[16px] my-4 ${colors.primary}`}>{content.title}</p>
         {team === 'NONE' ? (
-          <div className={`border-[1px] rounded-md w-[85%] mx-auto text-left px-4 py-2 ${styles.codeBlock}`}>
-            <p className={`text-[12px] ${styles.codeText} my-2 whitespace-pre-line text-center`}>
+          <div className={`border rounded-md w-[85%] mx-auto text-left px-4 py-2 ${colors.codeBlock}`}>
+            <p className={`text-[12px] ${colors.codeText} my-2 whitespace-pre-line text-center`}>
               {'message' in content && content.message}
             </p>
           </div>
         ) : (
-          <div className={`relative border-[1px] rounded-md w-[85%] mx-auto text-left px-4 py-2 ${styles.codeBlock}`}>
+          <div className={`relative border rounded-md w-[85%] mx-auto text-left px-4 py-2 ${colors.codeBlock}`}>
             <div className="flex justify-between">
               <p className="text-[8px] text-[#8EC5FF]">{language}</p>
               <EyeIcon className="text-blue-400" />
             </div>
-            <p className={`text-[12px] ${styles.codeText} my-2 line-clamp-3`}>{code}</p>
+            <p className={`text-[12px] ${colors.codeText} my-2 line-clamp-3`}>{code}</p>
           </div>
         )}
         <p className="mx-5 text-[12px] text-[#99A1AF] mt-4">
@@ -99,8 +77,8 @@ export default function TeamButton({ team, language, code, description, onSelect
           team={team as 'A' | 'B'}
           language={language}
           code={code}
-          titleColor={styles.title}
-          borderColor={styles.button}
+          titleColor={colors.primary}
+          borderColor={colors.border}
         />
       )}
     </div>


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->
resolve #98 

## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->
- `DicussionInput` sticky 컴포넌트로 변경하여 항상 화면 하단 중앙에 위치하도록 변경
- `DiscuttionInput`  figma make 스타일과 유사하게 개선
  - team 별 색상이 여기저기 사용되어서 `types/teamColors.ts` 파일에 분리하여 재사용할 수 있도록 했습니다.
- `DiscussionVote`가  `ChatSection` 위로 올라오도록 순서 변경
<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

https://github.com/user-attachments/assets/b09d2467-2928-4d4b-8e73-712101da216f


<br/>

