### PR TITLE
[Feature] 배틀페이지 사이드바 구현

### DIFF
--- a/backend/src/battles/dto/battleJoinResponse.dto.ts
+++ b/backend/src/battles/dto/battleJoinResponse.dto.ts
@@ -66,6 +66,8 @@ export class BattleJoinInfoResponseDto {
   description: string
   aCode: string
   bCode: string
+  language: string
+  category: string
 
   static fromEntity(battle: Battle): BattleJoinInfoResponseDto {
     const res = new BattleJoinInfoResponseDto()
@@ -73,6 +75,8 @@ export class BattleJoinInfoResponseDto {
     res.description = battle.description
     res.aCode = battle.aCode
     res.bCode = battle.bCode
+    res.language = battle.language
+    res.category = battle.category
     return res
   }
 

--- a/backend/src/battles/dto/battleResponse.dto.ts
+++ b/backend/src/battles/dto/battleResponse.dto.ts
@@ -1,9 +1,10 @@
-import { Battle, BattleStatus, BattleCategory } from '../types/battles.types'
+import { Battle, BattleStatus, BattleCategory, BattleLanguage } from '../types/battles.types'
 
 export class BattleResponseDto {
   id: string
   title: string
   description: string
+  language: BattleLanguage
   category: BattleCategory
   status: BattleStatus
   createdAt: Date
@@ -17,6 +18,8 @@ export class BattleResponseDto {
     res.id = battle.id
     res.title = battle.title
     res.description = battle.description
+    res.language = battle.language
+
     res.category = battle.category
     res.status = battle.status
     res.createdAt = battle.createdAt

--- a/frontend/src/assets/icon/close.svg
+++ b/frontend/src/assets/icon/close.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M24 8L8 24" stroke="currentColor" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 8L24 24" stroke="currentColor" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -15,6 +15,8 @@ export interface BattleInfo {
   description: string;
   aCode: string;
   bCode: string;
+  language: string;
+  category: string;
 }
 
 // 공통 타입들

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,6 +3,51 @@
 /* Custom styles */
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  min-width: 1440px;
+
+  /* 배틀 페이지 레이아웃 크기 */
+  --sidebar-width: 320px;
+  --main-closed: 1440px;
+  --main-open: 1120px;
+  --lounge-closed: 472px;
+  --lounge-open: 360px;
+}
+
+/* FHD 모니터 */
+@media (min-width: 1920px) {
+  :root {
+    --sidebar-width: 400px;
+    --main-closed: 1800px;
+    --main-open: 1400px;
+    --lounge-closed: 590px;
+    --lounge-open: 450px;
+  }
+}
+
+@layer components {
+  .sidebar-width {
+    width: var(--sidebar-width);
+  }
+
+  .main-width-closed {
+    width: var(--main-closed);
+  }
+
+  .main-width-open {
+    width: var(--main-open);
+  }
+
+  .lounge-width-closed {
+    width: var(--lounge-closed);
+  }
+
+  .lounge-width-open {
+    width: var(--lounge-open);
+  }
+
+  .ml-sidebar {
+    margin-left: var(--sidebar-width);
+  }
 }
 
 body {
@@ -26,15 +71,15 @@ body {
 }
 
 .scrollbar-thin::-webkit-scrollbar-track {
-  background: #2D2D3F;
+  background: #2d2d3f;
   border-radius: 5px;
 }
 
 .scrollbar-thin::-webkit-scrollbar-thumb {
-  background: #FF6900;
+  background: #ff6900;
   border-radius: 5px;
 }
 
 .scrollbar-thin::-webkit-scrollbar-thumb:hover {
-  background: #FF8533;
+  background: #ff8533;
 }

--- a/frontend/src/pages/battlePage/components/codeview/CodeSection.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/CodeSection.tsx
@@ -14,7 +14,7 @@ export default function CodeSection({ onViewChange, currentView, codeA, codeB, l
   const [currentTab, setCurrentTab] = useState<'A' | 'B'>('A');
 
   return (
-    <section className="w-[1194px] h-fit flex-1 flex flex-col bg-[#1E1E2F]  rounded-lg overflow-hidden">
+    <section className="w-full h-fit flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden">
       <CodeHeader
         onViewChange={onViewChange}
         currentView={currentView}

--- a/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
+++ b/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
@@ -3,12 +3,7 @@ import VoteStatus from './VoteStatus';
 import { useBattleStore, selectCurrentStage, selectBattleProgress, selectTeamCounts } from '../../stores/battleStore';
 import { useBattleTimer } from '../../hooks/useBattleTimer';
 
-interface BattleHeaderProps {
-  title: string;
-  description: string;
-}
-
-export default function BattleHeader({ title, description }: BattleHeaderProps) {
+export default function BattleHeader() {
   const currentStage = useBattleStore(selectCurrentStage);
   const battleProgress = useBattleStore(selectBattleProgress);
   const { teamACount, teamBCount } = useBattleStore(selectTeamCounts);
@@ -22,10 +17,6 @@ export default function BattleHeader({ title, description }: BattleHeaderProps) 
   return (
     <header className="bg-[#1E1E2F] px-8 py-6 rounded-lg mb-2">
       <div className="flex justify-between">
-        <div>
-          <h1 className="text-[20px] text-left font-bold mb-2">{title}</h1>
-          <p className="text-[#99A1AF] text-[14px]">{description}</p>
-        </div>
         <div className="flex items-center gap-4">
           <StatusCard turn={status} timer={formattedTime} />
           <VoteStatus teamACounts={teamACount} teamBCounts={teamBCount} teamNoneCounts={teamNoneCounts} />

--- a/frontend/src/pages/battlePage/components/sidebar/BattleSidebar.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/BattleSidebar.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import ClockIcon from '@/assets/icon/clock.svg?react';
+import MessageIcon from '@/assets/icon/message.svg?react';
+import CloseIcon from '@/assets/icon/close.svg?react';
+import TimelineSection from '../timeline/TimelineSection';
+
+interface BattleSidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  description: string;
+  language: string;
+  category: string;
+}
+
+type Tab = 'info' | 'timeline';
+
+export default function BattleSidebar({ isOpen, onClose, title, description, language, category }: BattleSidebarProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('info');
+
+  return (
+    <aside
+      className={`fixed top-0 left-0 h-full w-[400px]  bg-[#0a0a1a] border-r border-[#1A1A2E] z-100 transform transition-transform duration-300 ease-in-out shadow-2xl ${
+        isOpen ? 'translate-x-0' : '-translate-x-full'
+      }`}
+    >
+      {/* 헤더 */}
+      <div>
+        <div className="flex items-center justify-between px-6 pt-5 pb-4">
+          <div className="flex gap-6 flex-1">
+            <button
+              onClick={() => setActiveTab('info')}
+              className={`flex items-center gap-2 px-2 py-2 text-[15px] font-bold transition-colors ${
+                activeTab === 'info' ? 'text-white' : 'text-gray-400 hover:text-white'
+              }`}
+            >
+              <MessageIcon className="w-5 h-5" />
+              문제 설명
+            </button>
+            <button
+              onClick={() => setActiveTab('timeline')}
+              className={`flex items-center gap-2 px-2 py-2 text-[15px] font-bold transition-colors ${
+                activeTab === 'timeline' ? 'text-white' : 'text-gray-400 hover:text-white'
+              }`}
+            >
+              <ClockIcon className="w-5 h-5" />
+              타임라인
+            </button>
+          </div>
+          <button onClick={onClose} className="text-gray-400 hover:text-white transition-colors" aria-label=" 닫기">
+            <CloseIcon className="w-5 h-5 " />
+          </button>
+        </div>
+        {/* 활성 탭 밑줄 */}
+        <div
+          className={`h-[2px] transition-all duration-300 ${
+            activeTab === 'info'
+              ? 'bg-linear-to-r from-[#FF6900] to-[#FF8533]'
+              : 'bg-linear-to-r from-[#AD46FF] to-[#6BA3FF]'
+          }`}
+        />
+      </div>
+
+      {/* 컨텐츠 영역 */}
+      <div className="h-[calc(100vh-65px)] overflow-y-auto overflow-x-hidden">
+        {activeTab === 'info' ? (
+          <div className="p-6 space-y-8">
+            {/* 제목 */}
+            <div className="text-left">
+              <p className="text-orange-500  font-semibold  mb-3">제목</p>
+              <h3 className=" text-xl   leading-relaxed">{title}</h3>
+            </div>
+
+            {/* 설명 */}
+            <div className="text-left">
+              <p className="text-orange-500  font-semibold  mb-3">설명</p>
+              <p className="leading-relaxed">{description}</p>
+            </div>
+
+            <div className="flex gap-4">
+              {/* 언어 */}
+              <div className="bg-[#1E1E2F] rounded-lg px-4 py-3 shadow w-1/2 flex flex-col  gap-2 items-start">
+                <h3 className="text-gray-400  text-sm">언어</h3>
+                <p className="text-white text-[14px] font-semibold">{language}</p>
+              </div>
+              {/* 카테고리 */}
+              <div className="bg-[#1E1E2F] rounded-lg px-4 py-3 shadow w-1/2 flex flex-col  gap-2 items-start">
+                <h3 className="text-gray-400  text-sm">카테고리</h3>
+                <p className="text-white text-[14px] font-semibold">{category}</p>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="px-4 py-2">
+            <div className="w-full [&_section]:w-full [&_section]:mt-0">
+              <TimelineSection />
+            </div>
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/pages/battlePage/components/sidebar/BattleSidebar.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/BattleSidebar.tsx
@@ -20,7 +20,7 @@ export default function BattleSidebar({ isOpen, onClose, title, description, lan
 
   return (
     <aside
-      className={`fixed top-0 left-0 h-full w-[400px]  bg-[#0a0a1a] border-r border-[#1A1A2E] z-100 transform transition-transform duration-300 ease-in-out shadow-2xl ${
+      className={`fixed top-0 left-0 h-full sidebar-width bg-[#0a0a1a] border-r border-[#1A1A2E] z-100 transform transition-transform duration-300 ease-in-out shadow-2xl ${
         isOpen ? 'translate-x-0' : '-translate-x-full'
       }`}
     >

--- a/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
@@ -1,0 +1,35 @@
+import ClockIcon from '@/assets/icon/clock.svg?react';
+import MessageIcon from '@/assets/icon/message.svg?react';
+
+interface BookmarkButtonProps {
+  onOpen: () => void;
+  isOpen: boolean;
+}
+
+export default function BookmarkButton({ onOpen, isOpen }: BookmarkButtonProps) {
+  if (isOpen) return null;
+
+  return (
+    <div className="fixed left-0 top-1/2 -translate-y-1/2 z-30 flex flex-col gap-2">
+      {/* 문제 설명 */}
+      <button
+        onClick={onOpen}
+        className="group relative bg-linear-to-r from-[#FF6900] to-[#FF8533] px-3 py-2 rounded-r-md shadow-md hover:shadow-lg transition-all duration-200 hover:translate-x-1 flex items-center gap-1"
+        aria-label="문제 설명 보기"
+      >
+        <MessageIcon className="w-3.5 h-3.5" />
+        <span className="text-sm">문제 설명</span>
+      </button>
+
+      {/* 타임라인 */}
+      <button
+        onClick={onOpen}
+        className="group relative bg-linear-to-r from-[#AD46FF] to-[#6BA3FF] px-3 py-2 rounded-r-md shadow-md hover:shadow-lg transition-all duration-200 hover:translate-x-1 flex items-center gap-1"
+        aria-label="타임라인 보기"
+      >
+        <ClockIcon className="w-3.5 h-3.5" />
+        <span className="text-sm">타임라인</span>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -6,7 +6,8 @@ import CodeSection from './components/codeview/CodeSection';
 import ChatSection from './components/chatting/ChatSection';
 import DiscussionInput from './components/discussion/DiscussionInput';
 import DiscussionVote from './components/discussion/DiscussionVote';
-import TimelineSection from './components/timeline/TimelineSection';
+import BattleSidebar from './components/sidebar/BattleSidebar';
+import BookmarkButton from './components/sidebar/BookmarkButton';
 import { useBattle } from './hooks/useBattle';
 import useModal from '@/commons/hooks/useModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
@@ -16,6 +17,7 @@ export default function BattlePage() {
   const { id: battleId } = useParams<{ id: string }>();
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
+  const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
 
   const {
     isOpen: isTeamChangeModalOpen,
@@ -30,43 +32,64 @@ export default function BattlePage() {
   });
 
   return (
-    <div className="text-white flex flex-col items-center">
-      <div className="w-[1800px]">
-        <BattleHeader title={battleInfo.title} description={battleInfo.description} />
-      </div>
-      <main className="w-[1800px]">
-        <div className="flex gap-2 py-4">
-          <div className="flex-1">
-            <CodeSection
-              onViewChange={setViewMode}
-              currentView={viewMode}
-              language="javascript"
-              codeA={battleInfo.aCode}
-              codeB={battleInfo.bCode}
-            />
-            <TimelineSection />
-          </div>
-          <aside className="flex flex-col gap-4 w-[590px]">
-            <ChatSection />
-            <DiscussionInput onSubmit={handleDiscussionSubmit} />
-            <DiscussionVote onVote={handleVote} />
-          </aside>
+    <div className="text-white relative min-h-screen">
+      {/* 책갈피 버튼 */}
+      <BookmarkButton onOpen={handleOpenSidebar} isOpen={isSidebarOpen} />
+
+      {/* 사이드바 */}
+      <BattleSidebar
+        isOpen={isSidebarOpen}
+        onClose={handleCloseSidebar}
+        title={battleInfo.title}
+        description={battleInfo.description}
+        language={battleInfo.language}
+        category={battleInfo.category}
+      />
+
+      {/* 메인 콘텐츠 */}
+      <div
+        className={`flex flex-col items-center transition-all duration-300 ease-in-out ${
+          isSidebarOpen ? 'ml-[400px]' : 'ml-0'
+        }`}
+      >
+        <div className={`transition-all duration-300 ${isSidebarOpen ? 'w-[1400px]' : 'w-[1800px]'}`}>
+          <BattleHeader />
         </div>
-      </main>
+        <main className={`transition-all duration-300 ${isSidebarOpen ? 'w-[1400px]' : 'w-[1800px]'}`}>
+          <div className="flex gap-2 py-4">
+            <div className="flex-1 min-w-0">
+              <CodeSection
+                onViewChange={setViewMode}
+                currentView={viewMode}
+                language="javascript"
+                codeA={battleInfo.aCode}
+                codeB={battleInfo.bCode}
+              />
+            </div>
+            <aside
+              className={`flex flex-col gap-4 transition-all duration-300 ${isSidebarOpen ? 'w-[450px]' : 'w-[590px]'}`}
+            >
+              <ChatSection />
+              <DiscussionInput onSubmit={handleDiscussionSubmit} />
+              <DiscussionVote onVote={handleVote} />
+            </aside>
+          </div>
+        </main>
 
-      {isTeamChangeModalOpen && (
-        <TeamChangeModal handleTeamChange={handleTeamChange} onClose={handleCloseTeamChangeModal} />
-      )}
+        {isTeamChangeModalOpen && (
+          <TeamChangeModal handleTeamChange={handleTeamChange} onClose={handleCloseTeamChangeModal} />
+        )}
 
-      {effectModal.isOpen && effectModal.team !== 'NONE' && (
-        <DiscussionModal
-          isOpen={effectModal.isOpen}
-          team={effectModal.team}
-          content={effectModal.content}
-          type={effectModal.type}
-          onClose={hideEffect}
-        />
-      )}
+        {effectModal.isOpen && effectModal.team !== 'NONE' && (
+          <DiscussionModal
+            isOpen={effectModal.isOpen}
+            team={effectModal.team}
+            content={effectModal.content}
+            type={effectModal.type}
+            onClose={hideEffect}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -57,34 +57,32 @@ export default function BattlePage() {
         </div>
         <main className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'}`}>
           <div className="flex gap-2 py-4">
-            <div className="flex gap-2 py-4">
-              <div className="flex-1">
-                <CodeSection
-                  onViewChange={setViewMode}
-                  currentView={viewMode}
-                  language="javascript"
-                  codeA={battleInfo.aCode}
-                  codeB={battleInfo.bCode}
-                />
-                <TimelineSection />
-              </div>
-              <aside className="flex flex-col gap-4 w-[590px]">
-                <DiscussionVote onVote={handleVote} />
-                <ChatSection />
-              </aside>
+            <div className="flex-1">
+              <CodeSection
+                onViewChange={setViewMode}
+                currentView={viewMode}
+                language={battleInfo.language}
+                codeA={battleInfo.aCode}
+                codeB={battleInfo.bCode}
+              />
+            </div>
+            <aside className="flex flex-col gap-4 w-[590px]">
+              <DiscussionVote onVote={handleVote} />
+              <ChatSection />
+            </aside>
           </div>
         </main>
 
-      {/* DiscussionInput 항상 중앙 하단에 고정 */}
-      <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-[1800px] px-4 pb-4 z-50">
-        <div className="max-w-[590px] mx-auto">
-          <DiscussionInput onSubmit={handleDiscussionSubmit} />
+        {/* DiscussionInput 항상 중앙 하단에 고정 */}
+        <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-[1800px] px-4 pb-4 z-50">
+          <div className="max-w-[590px] mx-auto">
+            <DiscussionInput onSubmit={handleDiscussionSubmit} />
+          </div>
         </div>
-      </div>
 
-      {isTeamChangeModalOpen && (
-        <TeamChangeModal handleTeamChange={handleTeamChange} onClose={handleCloseTeamChangeModal} />
-      )}
+        {isTeamChangeModalOpen && (
+          <TeamChangeModal handleTeamChange={handleTeamChange} onClose={handleCloseTeamChangeModal} />
+        )}
 
         {effectModal.isOpen && effectModal.team !== 'NONE' && (
           <DiscussionModal

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -49,25 +49,27 @@ export default function BattlePage() {
       {/* 메인 콘텐츠 */}
       <div
         className={`flex flex-col items-center transition-all duration-300 ease-in-out ${
-          isSidebarOpen ? 'ml-[400px]' : 'ml-0'
+          isSidebarOpen ? 'ml-sidebar' : 'ml-0'
         }`}
       >
-        <div className={`transition-all duration-300 ${isSidebarOpen ? 'w-[1400px]' : 'w-[1800px]'}`}>
+        <div className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'}`}>
           <BattleHeader />
         </div>
-        <main className={`transition-all duration-300 ${isSidebarOpen ? 'w-[1400px]' : 'w-[1800px]'}`}>
+        <main className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'}`}>
           <div className="flex gap-2 py-4">
             <div className="flex-1 min-w-0">
               <CodeSection
                 onViewChange={setViewMode}
                 currentView={viewMode}
-                language="javascript"
+                language={battleInfo.language}
                 codeA={battleInfo.aCode}
                 codeB={battleInfo.bCode}
               />
             </div>
             <aside
-              className={`flex flex-col gap-4 transition-all duration-300 ${isSidebarOpen ? 'w-[450px]' : 'w-[590px]'}`}
+              className={`flex flex-col gap-4 transition-all duration-300 ${
+                isSidebarOpen ? 'lounge-width-open' : 'lounge-width-closed'
+              }`}
             >
               <ChatSection />
               <DiscussionInput onSubmit={handleDiscussionSubmit} />

--- a/frontend/src/pages/teamSelectPage/index.tsx
+++ b/frontend/src/pages/teamSelectPage/index.tsx
@@ -19,7 +19,7 @@ export default function TeamSelectPage() {
           <BattleIcon className="w-[48px] h-[48px] text-[#FF6900]" />
           <h1 className="ml-2 text-[16px] my-auto">진영을 선택해주세요</h1>
         </div>
-        <div className="w-[768px] h-[113px] bg-[#1E1E2F] border-[1px] border-[#2D2D3F] rounded-lg mx-auto text-center py-6 mt-6 mb-10">
+        <div className="w-full max-w-[768px] px-4 h-[113px] bg-[#1E1E2F] border border-[#2D2D3F] rounded-lg mx-auto text-center py-6 mt-6 mb-10">
           <p className="font-bold text-[20px]">{battleInfo.title}</p>
           <p className="mt-2 text-[#99A1AF] text-[16px]">{battleInfo.description}</p>
         </div>


### PR DESCRIPTION
## 🔗 관련 이슈
resolve #100


## ✅ 작업 내용

### 💡 주요 개선 사항

#### UI/UX 개선

- `BattleSidebar` 컴포넌트 생성 (문제 설명/타임라인 탭)
- `BookmarkButton` 컴포넌트 생성 (사이드바 열기 버튼)
- `BattleHeader`에서 title, description 제거
- `TimelineSection`을 사이드바로 이동
- 사이드바 열림 시 메인 콘텐츠 너비 자동 조정 
- 사이드바 열림, 닫힘 애니메이션 추가

####  동적 레이아웃
- CSS 변수와 미디어 쿼리로 화면 크기별 레이아웃 조정
- 기본값: 1440px (일반 노트북)
- FHD 모니터(1920px+): 1800px로 확장

| 화면 크기 | 사이드바 | 메인(닫힘) | 메인(열림) | 라운지(닫힘) | 라운지(열림) |
|----------|---------|-----------|-----------|------------|------------|
| 기본 (1440px+) | 320px | 1440px | 1120px | 472px | 360px |
| FHD (1920px+) | 400px | 1800px | 1400px | 590px | 450px |

>  **🏷️ 크기 지정 기준**
> 사이드바가 열리면 전체 레이아웃이 약 22% 감소하도록 비율 유지
>  - 메인 콘텐츠: 1440px → 1120px (약 22% 감소)
>   - 라운지: 472px → 360px (약 24% 감소)
>
> 코드 영역과 라운지가 균등하게 줄어들게 설정
  
<br />

## 📸 참고 사항

https://github.com/user-attachments/assets/1bf4331a-fc08-4e2e-a53e-5866cc380f10



<br />

## 💬 질문사항
윈도우 노트북 크기에 맞춰 조정했더니 멀티모니터 환경에서 레이아웃이 작게 보여 미디어 쿼리로 반응형(?)을 구현했습니다. 
이 방식이 적절한지 확인 부탁드립니다.!
