### PR TITLE
[Feature] BE - 배틀 진행 방식 수정

### DIFF
--- a/backend/src/battles/const/battles.const.ts
+++ b/backend/src/battles/const/battles.const.ts
@@ -1,19 +1,19 @@
 export const BATTLE_PHASE = {
-  // WAITING_FOR_START: {
-  //   name: 'WAITING_FOR_START',
-  //   time: 0,
-  // },
+  PENDING: {
+    name: 'PENDING',
+    time: 0,
+  },
   OPINION_SHARE: {
     name: 'OPINION_SHARE',
     time: 60 * 1000, // 1분
   },
-  TEAM_A_ATTACK: {
-    name: 'TEAM_A_ATTACK',
-    time: 120 * 1000, // 2분
+  ATTACK: {
+    name: 'ATTACK',
+    time: 60 * 1000, // 1분
   },
-  TEAM_B_ATTACK: {
-    name: 'TEAM_B_ATTACK',
-    time: 120 * 1000, // 2분
+  DEFENSE: {
+    name: 'DEFENSE',
+    time: 60 * 1000, // 1분
   },
   TEAM_SWITCH: {
     name: 'TEAM_SWITCH',
@@ -21,12 +21,7 @@ export const BATTLE_PHASE = {
   },
 } as const
 
-export const BATTLE_TURN = {
-  A_ATTACK: { name: 'A_ATTACK', time: 30 * 1000 },
-  B_ATTACK: { name: 'B_ATTACK', time: 30 * 1000 },
-  A_DEFENSE: { name: 'A_DEFENSE', time: 30 * 1000 },
-  B_DEFENSE: { name: 'B_DEFENSE', time: 30 * 1000 },
-} as const
+export const BATTLE_MAX_PHASE_COUNT = 2
 
 export const BATTLE_STATUS = {
   OPEN: 'OPEN',

--- a/backend/src/battles/dto/battleJoinResponse.dto.ts
+++ b/backend/src/battles/dto/battleJoinResponse.dto.ts
@@ -9,12 +9,12 @@ export class BattleJoinResponseDto {
   }
 
   // 배틀 전체 타임라인 & 채팅
-  timelines: { attacks: BattleDiscussion[]; defenses: BattleDefense[] }
+  timelines: { attacks: (BattleDiscussion | null)[]; defenses: (BattleDefense | null)[] }
   allChats: BattleChat[]
 
   // 해당 진영 이의제기 & 반박 & 채팅
-  attacks: BattleDiscussion[]
-  defenses: BattleDefense[]
+  attacks: (BattleDiscussion | null)[]
+  defenses: (BattleDefense | null)[]
   chats: BattleChat[]
 
   // 현재 진행 중인 배틀 정보

--- a/backend/src/battles/dto/battleJoinResponse.dto.ts
+++ b/backend/src/battles/dto/battleJoinResponse.dto.ts
@@ -1,5 +1,5 @@
 import { BATTLE_TEAM } from '../const/battles.const'
-import { ActiveBattleState, Battle, BattleChat, BattleDefense, BattleDiscussion, BattlePhaseName, BattleTurn } from '../types/battles.types'
+import { ActiveBattleState, Battle, BattleChat, BattleDefense, BattleDiscussion, BattlePhaseName } from '../types/battles.types'
 
 export class BattleJoinResponseDto {
   battleId: string
@@ -20,16 +20,14 @@ export class BattleJoinResponseDto {
   // 현재 진행 중인 배틀 정보
   round: number
   phase: BattlePhaseName
-  turn: {
-    status: BattleTurn
-    count: number
-  } | null
-  startedAt: number
-  expiredAt: number
+  phaseCount: number
+
+  startedAt: number | null
+  expiredAt: number | null
 
   static fromEntity(payload: ActiveBattleState, team: string): BattleJoinResponseDto {
     const res = new BattleJoinResponseDto()
-    const { all, teamA, teamB, round, phase, turn, startedAt, expiredAt } = payload
+    const { all, teamA, teamB, round, phase, phaseCount, startedAt, expiredAt } = payload
     const myTeam = team === BATTLE_TEAM.A ? teamA : team === BATTLE_TEAM.B ? teamB : all
 
     res.battleId = payload.battleId
@@ -49,7 +47,7 @@ export class BattleJoinResponseDto {
 
     res.round = round
     res.phase = phase
-    res.turn = turn
+    res.phaseCount = phaseCount
     res.startedAt = startedAt
     res.expiredAt = expiredAt
 

--- a/backend/src/battles/dto/battleJoinResponse.dto.ts
+++ b/backend/src/battles/dto/battleJoinResponse.dto.ts
@@ -64,6 +64,8 @@ export class BattleJoinInfoResponseDto {
   description: string
   aCode: string
   bCode: string
+  language: string
+  category: string
 
   static fromEntity(battle: Battle): BattleJoinInfoResponseDto {
     const res = new BattleJoinInfoResponseDto()
@@ -71,6 +73,8 @@ export class BattleJoinInfoResponseDto {
     res.description = battle.description
     res.aCode = battle.aCode
     res.bCode = battle.bCode
+    res.language = battle.language
+    res.category = battle.category
     return res
   }
 

--- a/backend/src/battles/dto/battleResponse.dto.ts
+++ b/backend/src/battles/dto/battleResponse.dto.ts
@@ -1,9 +1,10 @@
-import { Battle, BattleStatus, BattleCategory } from '../types/battles.types'
+import { Battle, BattleStatus, BattleCategory, BattleLanguage } from '../types/battles.types'
 
 export class BattleResponseDto {
   id: string
   title: string
   description: string
+  language: BattleLanguage
   category: BattleCategory
   status: BattleStatus
   createdAt: Date
@@ -17,6 +18,8 @@ export class BattleResponseDto {
     res.id = battle.id
     res.title = battle.title
     res.description = battle.description
+    res.language = battle.language
+
     res.category = battle.category
     res.status = battle.status
     res.createdAt = battle.createdAt

--- a/backend/src/battles/dto/battleTurnResponse.dto.ts
+++ b/backend/src/battles/dto/battleTurnResponse.dto.ts
@@ -1,43 +1,20 @@
-import { BattlePhaseName, BattleTurn } from '../types/battles.types'
-
-export class BattleTurnResponseDto {
-  battleId: string
-  turn: {
-    status: BattleTurn
-    count: number
-  } | null
-  startedAt: number
-  expiredAt: number
-
-  static fromEntity(payload: BattleTurnResponseDto): BattleTurnResponseDto {
-    const res = new BattleTurnResponseDto()
-    const { battleId, turn, startedAt, expiredAt } = payload
-
-    res.battleId = battleId
-    res.turn = turn ? { ...turn } : null
-    res.startedAt = startedAt
-    res.expiredAt = expiredAt
-
-    return res
-  }
-
-  static of(payload: BattleTurnResponseDto): BattleTurnResponseDto {
-    return BattleTurnResponseDto.fromEntity(payload)
-  }
-}
+import { BattlePhaseName } from '../types/battles.types'
 
 export class BattlePhaseResponseDto {
   battleId: string
   phase: BattlePhaseName
+  phaseCount: number
+
   startedAt: number
   expiredAt: number
 
   static fromEntity(payload: BattlePhaseResponseDto): BattlePhaseResponseDto {
     const res = new BattlePhaseResponseDto()
-    const { battleId, phase, startedAt, expiredAt } = payload
+    const { battleId, phase, phaseCount, startedAt, expiredAt } = payload
 
     res.battleId = battleId
     res.phase = phase
+    res.phaseCount = phaseCount
     res.startedAt = startedAt
     res.expiredAt = expiredAt
 

--- a/backend/src/battles/dto/discussionVoteResult.dto.ts
+++ b/backend/src/battles/dto/discussionVoteResult.dto.ts
@@ -1,18 +1,18 @@
-import { BattleDiscussion } from '../types/battles.types'
+import { BattleDiscussion, BattleTopOpinions } from '../types/battles.types'
 
 export class DiscussionVoteResultItemDto {
-  id: string
-  text: string
-  ownerId: string
-  count: number
+  id: string | null
+  text: string | null
+  ownerId: string | null
+  count: number | null
 
   static fromEntity(discussion: BattleDiscussion): DiscussionVoteResultItemDto {
     const dto = new DiscussionVoteResultItemDto()
 
-    dto.id = discussion.discussionId
-    dto.text = discussion.content
-    dto.ownerId = discussion.authorId
-    dto.count = discussion.upvotes
+    dto.id = discussion?.discussionId || null
+    dto.text = discussion?.content || null
+    dto.ownerId = discussion?.authorId || null
+    dto.count = discussion?.upvotes || null
 
     return dto
   }
@@ -24,24 +24,31 @@ export class DiscussionVoteResultItemDto {
 
 export class DiscussionVoteResultDto {
   battleId: string
-  attack?: DiscussionVoteResultItemDto
-  defense?: DiscussionVoteResultItemDto
+  attack?: {
+    aTeam: DiscussionVoteResultItemDto
+    bTeam: DiscussionVoteResultItemDto
+  }
+  defense?: {
+    aTeam: DiscussionVoteResultItemDto
+    bTeam: DiscussionVoteResultItemDto
+  }
 
-  static attacked(battleId: string, discussion: BattleDiscussion): DiscussionVoteResultDto {
+  static attacked(battleId: string, discussion: BattleTopOpinions): DiscussionVoteResultDto {
     const dto = new DiscussionVoteResultDto()
     dto.battleId = battleId
-    dto.attack = DiscussionVoteResultItemDto.of(discussion)
+    dto.attack = { aTeam: DiscussionVoteResultItemDto.of(discussion.aTeam!), bTeam: DiscussionVoteResultItemDto.of(discussion.bTeam!) }
     return dto
   }
 
-  static defensed(battleId: string, discussion: BattleDiscussion): DiscussionVoteResultDto {
+  static defensed(battleId: string, discussion: BattleTopOpinions): DiscussionVoteResultDto {
     const dto = new DiscussionVoteResultDto()
     dto.battleId = battleId
-    dto.defense = DiscussionVoteResultItemDto.of(discussion)
+    dto.defense = { aTeam: DiscussionVoteResultItemDto.of(discussion.aTeam!), bTeam: DiscussionVoteResultItemDto.of(discussion.bTeam!) }
     return dto
   }
 
-  static of(battleId: string, discussion: BattleDiscussion): DiscussionVoteResultDto {
-    return discussion.type === 'ATTACK' ? this.attacked(battleId, discussion) : this.defensed(battleId, discussion)
+  static of(battleId: string, discussion: BattleTopOpinions): DiscussionVoteResultDto {
+    const type = discussion.aTeam?.type || 'ATTACK'
+    return type === 'ATTACK' ? this.attacked(battleId, discussion) : this.defensed(battleId, discussion)
   }
 }

--- a/backend/src/battles/gateway/battles.gateway.spec.ts
+++ b/backend/src/battles/gateway/battles.gateway.spec.ts
@@ -179,7 +179,7 @@ describe('BattlesGateway - Discussion Events', () => {
         status: 'PENDING',
       })
 
-      jest.spyOn(service, 'handleAttackVote').mockReturnValue(mockResponse)
+      jest.spyOn(service, 'handleAttackVote').mockReturnValue([mockResponse])
       jest.spyOn(service, 'getBattleRoomId').mockReturnValue('battle-1:A')
 
       gateway.handleAttackVote(dto, mockClient)
@@ -213,7 +213,7 @@ describe('BattlesGateway - Discussion Events', () => {
         status: 'PENDING',
       })
 
-      jest.spyOn(service, 'handleDefenseVote').mockReturnValue(mockResponse)
+      jest.spyOn(service, 'handleDefenseVote').mockReturnValue([mockResponse])
       jest.spyOn(service, 'getBattleRoomId').mockReturnValue('battle-1:B')
 
       gateway.handleDefenseVote(dto, mockClient)

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -194,7 +194,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
   private bindBattleEvents() {
     this.battlesService.on('battle:phase:updated', (payload: BattlePhaseResponseDto) => this.phaseUpdate(payload))
 
-    this.battlesService.on('battle:round:update', (payload: BattleRoundResponseDto) => this.roundUpdate(payload))
+    this.battlesService.on('battle:round:updated', (payload: BattleRoundResponseDto) => this.roundUpdate(payload))
 
     this.battlesService.on('battle:attacked', (payload: DiscussionVoteResultDto) => this.onAttacked(payload))
 

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -14,7 +14,7 @@ import { BattlesService } from '../service/battles.service'
 import { BattleJoinRequestDto } from '../dto/battleJoinRequest.dto'
 import { BattleJoinResponseDto } from '../dto/battleJoinResponse.dto'
 import { AttackRequestDto, DefenseRequestDto, AttackVoteRequestDto, DefenseVoteRequestDto } from '../dto/discussion.dto'
-import { BattlePhaseResponseDto, BattleRoundResponseDto, BattleTurnResponseDto } from '../dto/battleTurnResponse.dto'
+import { BattlePhaseResponseDto, BattleRoundResponseDto } from '../dto/battleTurnResponse.dto'
 import { BattleChatDto } from '../dto/battleChat.dto'
 import { BATTLE_CHAT_SCOPE } from '../const/battles.const'
 import { DiscussionVoteResultDto } from '../dto/discussionVoteResult.dto'
@@ -150,13 +150,6 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     }
   }
 
-  turnUpdate(payload: BattleTurnResponseDto) {
-    const { battleId } = payload
-    const battleRoomId = this.battlesService.getBattleRoomId(battleId)
-
-    this.server.to(battleRoomId).emit('battle:turn:updated', payload)
-  }
-
   phaseUpdate(payload: BattlePhaseResponseDto) {
     const { battleId } = payload
     const battleRoomId = this.battlesService.getBattleRoomId(battleId)
@@ -201,9 +194,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
   private bindBattleEvents() {
     this.battlesService.on('battle:phase:updated', (payload: BattlePhaseResponseDto) => this.phaseUpdate(payload))
 
-    this.battlesService.on('battle:turn:updated', (payload: BattleTurnResponseDto) => this.turnUpdate(payload))
-
-    this.battlesService.on('battle:round:updated', (payload: BattleRoundResponseDto) => this.roundUpdate(payload))
+    this.battlesService.on('battle:round:update', (payload: BattleRoundResponseDto) => this.roundUpdate(payload))
 
     this.battlesService.on('battle:attacked', (payload: DiscussionVoteResultDto) => this.onAttacked(payload))
 

--- a/backend/src/battles/mock/battles.mock.ts
+++ b/backend/src/battles/mock/battles.mock.ts
@@ -62,7 +62,7 @@ export const MOCK_BATTLES: Battle[] = [
     participantCount: 0,
     initialState: {
       round: 3,
-      phase: 'TEAM_B_ATTACK',
+      phase: 'ATTACK',
       timeRemainingSeconds: 0,
     },
   },
@@ -83,7 +83,7 @@ export const MOCK_BATTLES: Battle[] = [
     participantCount: 0,
     initialState: {
       round: 5,
-      phase: 'TEAM_A_ATTACK',
+      phase: 'ATTACK',
       timeRemainingSeconds: 0,
     },
   },
@@ -127,7 +127,7 @@ export const MOCK_BATTLES: Battle[] = [
     participantCount: 0,
     initialState: {
       round: 2,
-      phase: 'TEAM_A_ATTACK',
+      phase: 'ATTACK',
       timeRemainingSeconds: 0,
     },
   },
@@ -148,7 +148,7 @@ export const MOCK_BATTLES: Battle[] = [
     participantCount: 0,
     initialState: {
       round: 2,
-      phase: 'TEAM_B_ATTACK',
+      phase: 'ATTACK',
       timeRemainingSeconds: 0,
     },
   },

--- a/backend/src/battles/service/battles.service.spec.ts
+++ b/backend/src/battles/service/battles.service.spec.ts
@@ -1,16 +1,7 @@
 import { NotFoundException, BadRequestException, ForbiddenException, UnauthorizedException } from '@nestjs/common'
 import { Battle } from '../types/battles.types'
 import { BattlesService } from './battles.service'
-import {
-  BATTLE_TYPE,
-  BATTLE_CATEGORY,
-  BATTLE_PLAYTIME,
-  BATTLE_LANGUAGE,
-  BATTLE_STATUS,
-  BATTLE_PHASE,
-  BATTLE_TEAM,
-  BATTLE_TURN,
-} from '../const/battles.const'
+import { BATTLE_TYPE, BATTLE_CATEGORY, BATTLE_PLAYTIME, BATTLE_LANGUAGE, BATTLE_STATUS, BATTLE_PHASE, BATTLE_TEAM } from '../const/battles.const'
 
 const createBattle = (overrides: Partial<Battle>): Battle => ({
   id: 'battle-id',
@@ -256,55 +247,39 @@ describe('BattlesService', () => {
       service['initBattleState']('battle-1')
     })
 
-    it('OPINION_SHARE → TEAM_A_ATTACK 로 전환된다', () => {
+    it('OPINION_SHARE → ATTACK 으로 전환된다', () => {
       const state = service['activeBattles'].get('battle-1')!
+
+      service['updatePhase']('battle-1')
 
       expect(state.phase).toBe(BATTLE_PHASE.OPINION_SHARE.name)
-      expect(state.turn).toBeNull()
 
       service['updatePhase']('battle-1')
 
-      expect(state.phase).toBe(BATTLE_PHASE.TEAM_A_ATTACK.name)
-      expect(state.turn).toEqual({
-        status: BATTLE_TURN.A_ATTACK.name,
-        count: 1,
-      })
+      expect(state.phase).toBe(BATTLE_PHASE.ATTACK.name)
+      expect(state.phaseCount).toBe(1)
     })
 
-    it('A_ATTACK → B_DEFENSE 로 턴이 변경된다', () => {
+    it('ATTACK → DEFENSE 로 턴이 변경된다', () => {
       const state = service['activeBattles'].get('battle-1')!
 
       service['updatePhase']('battle-1')
       service['updatePhase']('battle-1')
+      service['updatePhase']('battle-1')
 
-      expect(state.turn?.status).toBe(BATTLE_TURN.B_DEFENSE.name)
-      expect(state.phase).toBe(BATTLE_PHASE.TEAM_A_ATTACK.name)
+      expect(state.phase).toBe(BATTLE_PHASE.DEFENSE.name)
+      expect(state.phaseCount).toBe(1)
     })
-    it('A_ATTACK ↔ B_DEFENSE 가 2회 반복된다', () => {
+    it('ATTACK ↔ DEFENSE 가 2회 반복된다', () => {
       const state = service['activeBattles'].get('battle-1')!
 
-      service['updatePhase']('battle-1') // OPINION → A_ATTACK
-      service['updatePhase']('battle-1') // A_ATTACK → B_DEFENSE
-      service['updatePhase']('battle-1') // B_DEFENSE → A_ATTACK (count 2)
+      service['updatePhase']('battle-1') // PENDING → OPINION
+      service['updatePhase']('battle-1') // OPINION → ATTACK
+      service['updatePhase']('battle-1') // ATTACK → DEFENSE
+      service['updatePhase']('battle-1') // DEFENSE → ATTACK (count 2)
 
-      expect(state.turn).toEqual({
-        status: BATTLE_TURN.A_ATTACK.name,
-        count: 2,
-      })
-    })
-
-    it('TEAM_A_ATTACK → TEAM_B_ATTACK 로 넘어간다', () => {
-      const state = service['activeBattles'].get('battle-1')!
-
-      // A 공격/방어 2회 소진
-      service['updatePhase']('battle-1') // opinion → A_ATTACK
-      service['updatePhase']('battle-1') // A_ATTACK → B_DEF
-      service['updatePhase']('battle-1') // B_DEF → A_ATTACK (2)
-      service['updatePhase']('battle-1') // A_ATTACK → B_DEF
-      service['updatePhase']('battle-1') // B_DEF → B_ATTACK
-
-      expect(state.phase).toBe(BATTLE_PHASE.TEAM_B_ATTACK.name)
-      expect(state.turn?.status).toBe(BATTLE_TURN.B_ATTACK.name)
+      expect(state.phase).toBe(BATTLE_PHASE.ATTACK.name)
+      expect(state.phaseCount).toBe(2)
     })
 
     it('TEAM_SWITCH 이후 round가 증가한다', () => {
@@ -599,6 +574,7 @@ describe('BattlesService', () => {
           battleId: 'battle-1',
           scope: 'ALL',
           text: 'hello all',
+          team: 'A',
         },
         'user-1',
       )
@@ -626,11 +602,7 @@ describe('BattlesService', () => {
       service['initBattleState']('battle-1')
 
       const state = service['activeBattles'].get('battle-1')!
-      state.phase = BATTLE_PHASE.TEAM_A_ATTACK.name
-      state.turn = {
-        status: BATTLE_TURN.A_ATTACK.name,
-        count: 1,
-      }
+      state.phase = BATTLE_PHASE.ATTACK.name
 
       service.handleAttack('battle-1', {
         authorId: 'user-a',
@@ -646,12 +618,12 @@ describe('BattlesService', () => {
         userId: 'voter-1',
         team: BATTLE_TEAM.A,
       })
-
-      expect(result).toEqual(
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual(
         expect.objectContaining({
-          battleId: 'battle-1',
-          attackId: attack.discussionId,
-          count: 1,
+          discussionId: attack.discussionId,
+          upvotes: 1,
+          votes: ['voter-1'],
         }),
       )
     })
@@ -683,14 +655,13 @@ describe('BattlesService', () => {
       ).toThrow(ForbiddenException)
     })
 
-    it('현재 공격 턴이 아니면 BadRequestException', () => {
+    it('현재 수비 페이즈가 아니면 공격 페이즈에 관해 BadRequestException', () => {
       const state = service['activeBattles'].get('battle-1')!
-      state.turn!.status = BATTLE_TURN.B_ATTACK.name
 
       const attack = state.teamA.attacks[0]
 
       expect(() =>
-        service.handleAttackVote('battle-1', attack.discussionId, {
+        service.handleDefenseVote('battle-1', attack.discussionId, {
           userId: 'user',
           team: BATTLE_TEAM.A,
         }),

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -20,11 +20,11 @@ import {
   BATTLE_PLAYTIME,
   BATTLE_STATUS,
   BATTLE_TEAM,
-  BATTLE_TURN,
   BATTLE_TYPE,
   BATTLE_DISCUSSION_TYPE,
+  BATTLE_MAX_PHASE_COUNT,
 } from '../const/battles.const'
-import { BattlePhaseResponseDto, BattleRoundResponseDto, BattleTurnResponseDto } from '../dto/battleTurnResponse.dto'
+import { BattlePhaseResponseDto, BattleRoundResponseDto } from '../dto/battleTurnResponse.dto'
 import { DiscussionVoteResponseDto } from '../dto/discussionVoteResponse.dto'
 import { DiscussionVoteResultDto } from '../dto/discussionVoteResult.dto'
 import { BattleClosedResponseDto } from '../dto/battleClosedResponse.dto'
@@ -211,7 +211,8 @@ export class BattlesService extends EventEmitter {
     if (this.activeBattles.has(battleId)) return
 
     const startedAt = Date.now()
-    const expiredAt = startedAt + BATTLE_PHASE.OPINION_SHARE.time
+    // const expiredAt = startedAt + BATTLE_PHASE.OPINION_SHARE.time
+    const expiredAt = startedAt + BATTLE_PHASE.PENDING.time
 
     const activeBattleState: ActiveBattleState = {
       battleId,
@@ -237,9 +238,10 @@ export class BattlesService extends EventEmitter {
       },
       participants: new Map(),
       teamVotes: new Map(),
-      phase: BATTLE_PHASE.OPINION_SHARE.name,
+
+      phase: BATTLE_PHASE.PENDING.name,
       round: 1,
-      turn: null,
+      phaseCount: 1,
 
       startedAt,
       expiredAt,
@@ -247,11 +249,13 @@ export class BattlesService extends EventEmitter {
 
     this.activeBattles.set(battleId, activeBattleState)
 
+    // 시작 버튼으로 분류될 예정
     const res = BattlePhaseResponseDto.of({
       battleId,
       phase: activeBattleState.phase,
-      startedAt: activeBattleState.startedAt,
-      expiredAt: activeBattleState.expiredAt,
+      phaseCount: activeBattleState.phaseCount,
+      startedAt,
+      expiredAt,
     })
 
     this.emit('battle:phase:updated', res)
@@ -331,13 +335,11 @@ export class BattlesService extends EventEmitter {
 
   private updatePhase(battleId: string): void {
     const state = this.getBattleState(battleId)
-    if (!state) return
 
     const battle = this.battles.find(battle => battle.id === battleId)
     if (battle?.status === BATTLE_STATUS.CLOSED) return
 
     const prevPhase = state.phase
-    const prevTurn = state.turn?.status ?? null
     const prevRound = state.round
 
     const now = Date.now()
@@ -347,31 +349,7 @@ export class BattlesService extends EventEmitter {
 
     state.phase = nextPhase.name
     state.startedAt = now
-
-    if (!state.turn && nextPhase.time) {
-      state.expiredAt = now + nextPhase.time
-    }
-
-    if (prevPhase !== state.phase) {
-      const res = BattlePhaseResponseDto.of({
-        battleId,
-        phase: state.phase,
-        startedAt: state.startedAt,
-        expiredAt: state.expiredAt,
-      })
-      this.emit('battle:phase:updated', res)
-    }
-
-    if (state.turn?.status && prevTurn !== state.turn.status) {
-      const res = BattleTurnResponseDto.of({
-        battleId,
-        turn: state.turn,
-        startedAt: state.startedAt,
-        expiredAt: state.expiredAt,
-      })
-
-      this.emit('battle:turn:updated', res)
-    }
+    state.expiredAt = now + nextPhase.time
 
     if (prevRound !== state.round) {
       const res = BattleRoundResponseDto.of({
@@ -382,26 +360,46 @@ export class BattlesService extends EventEmitter {
       this.emit('battle:round:updated', res)
     }
 
+    if (prevPhase !== state.phase) {
+      const res = BattlePhaseResponseDto.of({
+        battleId,
+        phase: state.phase,
+        phaseCount: state.phaseCount,
+        startedAt: state.startedAt,
+        expiredAt: state.expiredAt,
+      })
+
+      this.emit('battle:phase:update', res)
+    }
+
     this.scheduleNextTick(battleId)
   }
 
   private getNextPhase(state: ActiveBattleState): BattlePhase | null {
     switch (state.phase) {
+      case BATTLE_PHASE.PENDING.name:
+        return BATTLE_PHASE.OPINION_SHARE
       case BATTLE_PHASE.OPINION_SHARE.name:
-        state.turn = {
-          status: BATTLE_TURN.A_ATTACK.name,
-          count: 1,
-        }
-        state.expiredAt = Date.now() + BATTLE_TURN.A_ATTACK.time
-        return BATTLE_PHASE.TEAM_A_ATTACK
+        state.expiredAt = Date.now() + BATTLE_PHASE.ATTACK.time
+        return BATTLE_PHASE.ATTACK
 
-      case BATTLE_PHASE.TEAM_A_ATTACK.name:
-      case BATTLE_PHASE.TEAM_B_ATTACK.name:
-        return this.updateTurn(state)
+      case BATTLE_PHASE.ATTACK.name:
+        return BATTLE_PHASE.DEFENSE
+
+      case BATTLE_PHASE.DEFENSE.name:
+        state.phaseCount++
+
+        if (state.phaseCount <= BATTLE_MAX_PHASE_COUNT) {
+          return BATTLE_PHASE.ATTACK
+        }
+
+        state.phaseCount = 1
+        return BATTLE_PHASE.TEAM_SWITCH
 
       case BATTLE_PHASE.TEAM_SWITCH.name: {
         this.applyTeamVotes(state)
         const isNextRound = this.updateRound(state)
+
         return isNextRound ? BATTLE_PHASE.OPINION_SHARE : null
       }
 
@@ -435,71 +433,6 @@ export class BattlesService extends EventEmitter {
           none: [...state.participants.values()].filter(t => t === BATTLE_TEAM.NONE).length,
         },
       })
-    }
-  }
-
-  private updateTurn(state: ActiveBattleState): BattlePhase {
-    const now = Date.now()
-
-    if (!state.turn) {
-      state.turn = {
-        status: BATTLE_TURN.A_ATTACK.name,
-        count: 1,
-      }
-      state.expiredAt = now + BATTLE_TURN.A_ATTACK.time
-      return BATTLE_PHASE.TEAM_A_ATTACK
-    }
-
-    switch (state.turn.status) {
-      case BATTLE_TURN.A_ATTACK.name: {
-        this.emitAttackedResult(state.battleId, BATTLE_TEAM.A)
-        this.resetDiscussionsByTurn(state.battleId)
-
-        state.turn.status = BATTLE_TURN.B_DEFENSE.name
-        state.expiredAt = now + BATTLE_TURN.B_DEFENSE.time
-        return BATTLE_PHASE.TEAM_A_ATTACK
-      }
-
-      case BATTLE_TURN.B_DEFENSE.name: {
-        this.emitDefensedResult(state.battleId, BATTLE_TEAM.B)
-        this.resetDiscussionsByTurn(state.battleId)
-
-        if (state.turn.count < 2) {
-          state.turn.status = BATTLE_TURN.A_ATTACK.name
-          state.turn.count += 1
-          state.expiredAt = now + BATTLE_TURN.A_ATTACK.time
-          return BATTLE_PHASE.TEAM_A_ATTACK
-        } else {
-          state.turn.status = BATTLE_TURN.B_ATTACK.name
-          state.turn.count = 1
-          state.expiredAt = now + BATTLE_TURN.B_ATTACK.time
-          return BATTLE_PHASE.TEAM_B_ATTACK
-        }
-      }
-
-      case BATTLE_TURN.B_ATTACK.name: {
-        this.emitAttackedResult(state.battleId, BATTLE_TEAM.B)
-        this.resetDiscussionsByTurn(state.battleId)
-
-        state.turn.status = BATTLE_TURN.A_DEFENSE.name
-        state.expiredAt = now + BATTLE_TURN.A_DEFENSE.time
-        return BATTLE_PHASE.TEAM_B_ATTACK
-      }
-
-      case BATTLE_TURN.A_DEFENSE.name: {
-        this.emitDefensedResult(state.battleId, BATTLE_TEAM.A)
-        this.resetDiscussionsByTurn(state.battleId)
-
-        if (state.turn.count < 2) {
-          state.turn.status = BATTLE_TURN.B_ATTACK.name
-          state.turn.count += 1
-          state.expiredAt = now + BATTLE_TURN.B_ATTACK.time
-          return BATTLE_PHASE.TEAM_B_ATTACK
-        } else {
-          state.turn = null
-          return BATTLE_PHASE.TEAM_SWITCH
-        }
-      }
     }
   }
 
@@ -607,20 +540,12 @@ export class BattlesService extends EventEmitter {
   }
 
   private canUserSubmitAttack(battleState: ActiveBattleState, userTeam: BattleTeam): boolean {
-    const { phase, turn } = battleState
+    const { phase } = battleState
 
     if (userTeam === BATTLE_TEAM.NONE) return false
 
     // OPINION_SHARE 단계에서는 모든 팀이 의견 제출 가능
-    if (phase === 'OPINION_SHARE') {
-      return true
-    }
-
-    if (phase === 'TEAM_A_ATTACK' && turn?.status === 'A_ATTACK' && userTeam === BATTLE_TEAM.A) {
-      return true
-    }
-
-    if (phase === 'TEAM_B_ATTACK' && turn?.status === 'B_ATTACK' && userTeam === BATTLE_TEAM.B) {
+    if (phase === BATTLE_PHASE.OPINION_SHARE.name || phase === BATTLE_PHASE.ATTACK.name) {
       return true
     }
 
@@ -628,15 +553,11 @@ export class BattlesService extends EventEmitter {
   }
 
   private canUserSubmitDefense(battleState: ActiveBattleState, userTeam: BattleTeam): boolean {
-    const { phase, turn } = battleState
+    const { phase } = battleState
 
     if (userTeam === BATTLE_TEAM.NONE) return false
 
-    if (phase === 'TEAM_A_ATTACK' && turn?.status === 'B_DEFENSE' && userTeam === BATTLE_TEAM.B) {
-      return true
-    }
-
-    if (phase === 'TEAM_B_ATTACK' && turn?.status === 'A_DEFENSE' && userTeam === BATTLE_TEAM.A) {
+    if (phase === BATTLE_PHASE.DEFENSE.name) {
       return true
     }
 
@@ -652,7 +573,7 @@ export class BattlesService extends EventEmitter {
     }
     const battleState = this.getBattleState(battleId)
 
-    if (!this.canUserVoteAttack(battleState, team)) {
+    if (!this.canUserVoteAttack(battleState)) {
       throw new BadRequestException('현재 투표할 수 있는 공격 턴이 아닙니다.')
     }
 
@@ -696,7 +617,7 @@ export class BattlesService extends EventEmitter {
     }
 
     const battleState = this.getBattleState(battleId)
-    if (!this.canUserVoteDefense(battleState, team)) {
+    if (!this.canUserVoteDefense(battleState)) {
       throw new BadRequestException('현재 투표할 수 있는 반론 턴이 아닙니다.')
     }
 
@@ -736,34 +657,12 @@ export class BattlesService extends EventEmitter {
   //battle:defensed
   //battle:attacked
 
-  private canUserVoteAttack(battleState: ActiveBattleState, team: BattleTeam): boolean {
-    const { phase, turn } = battleState
-    if (!turn) return false
-
-    if (phase === BATTLE_PHASE.TEAM_A_ATTACK.name && turn.status === BATTLE_TURN.A_ATTACK.name && team === BATTLE_TEAM.A) {
-      return true
-    }
-
-    if (phase === BATTLE_PHASE.TEAM_B_ATTACK.name && turn.status === BATTLE_TURN.B_ATTACK.name && team === BATTLE_TEAM.B) {
-      return true
-    }
-
-    return false
+  private canUserVoteAttack(battleState: ActiveBattleState): boolean {
+    return battleState.phase === BATTLE_PHASE.ATTACK.name ? true : false
   }
 
-  private canUserVoteDefense(battleState: ActiveBattleState, team: BattleTeam): boolean {
-    const { phase, turn } = battleState
-    if (!turn) return false
-
-    if (phase === BATTLE_PHASE.TEAM_A_ATTACK.name && turn.status === BATTLE_TURN.B_DEFENSE.name && team === BATTLE_TEAM.B) {
-      return true
-    }
-
-    if (phase === BATTLE_PHASE.TEAM_B_ATTACK.name && turn.status === BATTLE_TURN.A_DEFENSE.name && team === BATTLE_TEAM.A) {
-      return true
-    }
-
-    return false
+  private canUserVoteDefense(battleState: ActiveBattleState): boolean {
+    return battleState.phase === BATTLE_PHASE.DEFENSE.name ? true : false
   }
 
   private pickTopVotedAttackByTeam(battleId: string, team: BattleTeam): BattleDiscussion | null {
@@ -832,7 +731,7 @@ export class BattlesService extends EventEmitter {
     if (battle?.status === BATTLE_STATUS.CLOSED) return
 
     const state = this.getBattleState(battleId)
-    if (!state) return
+    if (!state.expiredAt) return
 
     const prevTimer = this.battleTimers.get(battleId)
     if (prevTimer) clearTimeout(prevTimer)

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -5,7 +5,16 @@ import { Injectable, NotFoundException, BadRequestException, UnauthorizedExcepti
 import { MOCK_BATTLES } from '../mock/battles.mock'
 import { mockBattleResults } from '../mock/battleResults.mock'
 import { TimelineItem, Mvp } from '../types/battleResult.types'
-import { ActiveBattleState, Battle, BattlePhase, BattleTeam, BattleDiscussion, BattleDefense, BattlePlayTime } from '../types/battles.types'
+import {
+  ActiveBattleState,
+  Battle,
+  BattlePhase,
+  BattleTeam,
+  BattleDiscussion,
+  BattleDefense,
+  BattlePlayTime,
+  BattleTopOpinions,
+} from '../types/battles.types'
 import { BattleChatDto } from '../dto/battleChat.dto'
 import type { BattleTeamVoteDto } from '../dto/battleTeamVote.dto'
 import { BattleResponseDto } from '../dto/battleResponse.dto'
@@ -384,9 +393,15 @@ export class BattlesService extends EventEmitter {
         return BATTLE_PHASE.ATTACK
 
       case BATTLE_PHASE.ATTACK.name:
+        this.emitAttackedResult(state.battleId)
+        this.resetDiscussions(state.battleId)
+
         return BATTLE_PHASE.DEFENSE
 
       case BATTLE_PHASE.DEFENSE.name:
+        this.emitDefensedResult(state.battleId)
+        this.resetDiscussions(state.battleId)
+
         state.phaseCount++
 
         if (state.phaseCount <= BATTLE_MAX_PHASE_COUNT) {
@@ -394,6 +409,7 @@ export class BattlesService extends EventEmitter {
         }
 
         state.phaseCount = 1
+
         return BATTLE_PHASE.TEAM_SWITCH
 
       case BATTLE_PHASE.TEAM_SWITCH.name: {
@@ -486,6 +502,7 @@ export class BattlesService extends EventEmitter {
 
     const battleState = this.getBattleState(battleId)
 
+    console.log(battleState.phase)
     if (!this.canUserSubmitAttack(battleState, team)) {
       throw new BadRequestException('현재 공격을 등록할 수 없는 단계입니다.')
     }
@@ -665,33 +682,39 @@ export class BattlesService extends EventEmitter {
     return battleState.phase === BATTLE_PHASE.DEFENSE.name ? true : false
   }
 
-  private pickTopVotedAttackByTeam(battleId: string, team: BattleTeam): BattleDiscussion | null {
-    const battleState = this.getBattleState(battleId)
-    const attacks = team === BATTLE_TEAM.A ? battleState.teamA.attacks : battleState.teamB.attacks
+  private getTopOpinion = (opinions: BattleDiscussion[]) => {
+    if (opinions.length === 0) return null
 
-    if (attacks.length === 0) return null
-
-    return attacks.slice().sort((a, b) => b.upvotes - a.upvotes)[0]
+    return opinions.reduce((top, cur) => (cur.upvotes > top.upvotes ? cur : top))
   }
 
-  private pickTopVotedDefenseByTeam(battleId: string, team: BattleTeam): BattleDiscussion | null {
+  private pickTopVotedAttack(battleId: string): BattleTopOpinions {
     const battleState = this.getBattleState(battleId)
-    const defenses = team === BATTLE_TEAM.A ? battleState.teamA.defenses : battleState.teamB.defenses
 
-    if (defenses.length === 0) return null
-
-    return defenses.slice().sort((a, b) => b.upvotes - a.upvotes)[0]
+    return {
+      aTeam: this.getTopOpinion(battleState.teamA.attacks),
+      bTeam: this.getTopOpinion(battleState.teamB.attacks),
+    }
   }
 
-  private emitAttackedResult(battleId: string, team: BattleTeam) {
-    const top = this.pickTopVotedAttackByTeam(battleId, team)
+  private pickTopVotedDefense(battleId: string): BattleTopOpinions {
+    const battleState = this.getBattleState(battleId)
+
+    return {
+      aTeam: this.getTopOpinion(battleState.teamA.defenses),
+      bTeam: this.getTopOpinion(battleState.teamB.defenses),
+    }
+  }
+
+  private emitAttackedResult(battleId: string) {
+    const top = this.pickTopVotedAttack(battleId)
     if (!top) return
 
     this.emit('battle:attacked', DiscussionVoteResultDto.of(battleId, top))
   }
 
-  private emitDefensedResult(battleId: string, team: BattleTeam) {
-    const top = this.pickTopVotedDefenseByTeam(battleId, team)
+  private emitDefensedResult(battleId: string) {
+    const top = this.pickTopVotedDefense(battleId)
     if (!top) return
 
     this.emit('battle:defensed', DiscussionVoteResultDto.of(battleId, top))
@@ -717,7 +740,7 @@ export class BattlesService extends EventEmitter {
     }
   }
 
-  private resetDiscussionsByTurn(battleId: string) {
+  private resetDiscussions(battleId: string) {
     const battleState = this.getBattleState(battleId)
 
     battleState.teamA.attacks = []

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -595,12 +595,13 @@ export class BattlesService extends EventEmitter {
 
     const discussions = team === BATTLE_TEAM.A ? battleState.teamA.attacks : battleState.teamB.attacks
 
-    const idx = discussions.findIndex(d => d.discussionId === discussionId)
+    const idx = discussions.findIndex(d => d?.discussionId === discussionId)
     if (idx === -1) {
       throw new NotFoundException('해당 진영의 이의제기 항목이 없습니다.')
     }
 
     const target = discussions[idx]
+    if (!target) throw new NotFoundException('해당 항목이 존재하지 않습니다.')
 
     if (this.hasAlreadyVoted(target.votes, userId)) {
       throw new BadRequestException('이미 투표한 항목입니다.')
@@ -610,7 +611,7 @@ export class BattlesService extends EventEmitter {
 
     // 다른 항목에 투표한 기록이 있으면 취소
     discussions.forEach((discussion, i) => {
-      if (i !== idx && this.hasAlreadyVoted(discussion.votes, userId)) {
+      if (i !== idx && discussion && this.hasAlreadyVoted(discussion.votes, userId)) {
         const canceled = this.removeVote(discussion, userId)
         discussions[i] = canceled
         updatedDiscussions.push(DiscussionVoteResponseDto.of(battleId, canceled))
@@ -639,12 +640,13 @@ export class BattlesService extends EventEmitter {
 
     const discussions = team === BATTLE_TEAM.A ? battleState.teamA.defenses : battleState.teamB.defenses
 
-    const idx = discussions.findIndex(d => d.discussionId === discussionId)
+    const idx = discussions.findIndex(d => d?.discussionId === discussionId)
     if (idx === -1) {
       throw new NotFoundException('해당 진영의 이의제기 항목이 없습니다.')
     }
 
     const target = discussions[idx]
+    if (!target) throw new NotFoundException('해당 항목이 존재하지 않습니다.')
 
     if (this.hasAlreadyVoted(target.votes, userId)) {
       throw new BadRequestException('이미 투표한 항목입니다.')
@@ -654,7 +656,7 @@ export class BattlesService extends EventEmitter {
 
     // 다른 항목에 투표한 기록이 있으면 취소
     discussions.forEach((discussion, i) => {
-      if (i !== idx && this.hasAlreadyVoted(discussion.votes, userId)) {
+      if (i !== idx && discussion && this.hasAlreadyVoted(discussion.votes, userId)) {
         const canceled = this.removeVote(discussion, userId)
         discussions[i] = canceled
         updatedDiscussions.push(DiscussionVoteResponseDto.of(battleId, canceled))
@@ -681,10 +683,12 @@ export class BattlesService extends EventEmitter {
     return battleState.phase === BATTLE_PHASE.DEFENSE.name ? true : false
   }
 
-  private getTopOpinion = (opinions: BattleDiscussion[]) => {
-    if (opinions.length === 0) return null
+  private getTopOpinion = (opinions: (BattleDiscussion | null)[]): BattleDiscussion | null => {
+    const filteredOpinion = opinions.filter((opinion): opinion is BattleDiscussion => opinion !== null)
 
-    return opinions.reduce((top, cur) => (cur.upvotes > top.upvotes ? cur : top))
+    if (filteredOpinion.length === 0) return null
+
+    return filteredOpinion.reduce((top, cur) => (cur.upvotes > top.upvotes ? cur : top))
   }
 
   private pickTopVotedAttack(battleId: string): BattleTopOpinions {
@@ -712,8 +716,8 @@ export class BattlesService extends EventEmitter {
     const battleState = this.activeBattles.get(battleId)
 
     const { aTeam, bTeam } = top
-    if (aTeam) battleState?.all.attacks.push(aTeam)
-    if (bTeam) battleState?.all.attacks.push(bTeam)
+    battleState?.all.attacks.push(aTeam ? aTeam : null)
+    battleState?.all.attacks.push(bTeam ? bTeam : null)
 
     this.emit('battle:attacked', DiscussionVoteResultDto.of(battleId, top))
   }
@@ -725,8 +729,8 @@ export class BattlesService extends EventEmitter {
     const battleState = this.activeBattles.get(battleId)
 
     const { aTeam, bTeam } = top
-    if (aTeam) battleState?.all.defenses.push(aTeam)
-    if (bTeam) battleState?.all.defenses.push(bTeam)
+    battleState?.all.defenses.push(aTeam ? aTeam : null)
+    battleState?.all.defenses.push(bTeam ? bTeam : null)
 
     this.emit('battle:defensed', DiscussionVoteResultDto.of(battleId, top))
   }

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -378,7 +378,7 @@ export class BattlesService extends EventEmitter {
         expiredAt: state.expiredAt,
       })
 
-      this.emit('battle:phase:update', res)
+      this.emit('battle:phase:updated', res)
     }
 
     this.scheduleNextTick(battleId)
@@ -516,7 +516,7 @@ export class BattlesService extends EventEmitter {
       status: 'PENDING',
     }
 
-    battleState.all.attacks.push(attack)
+    // battleState.all.attacks.push(attack)
     if (team === BATTLE_TEAM.A) {
       battleState.teamA.attacks.push(attack)
     } else {
@@ -545,7 +545,7 @@ export class BattlesService extends EventEmitter {
       status: 'PENDING',
     }
 
-    battleState.all.defenses.push(defense)
+    // battleState.all.defenses.push(defense)
     if (team === BATTLE_TEAM.A) {
       battleState.teamA.defenses.push(defense)
     } else {
@@ -709,12 +709,24 @@ export class BattlesService extends EventEmitter {
     const top = this.pickTopVotedAttack(battleId)
     if (!top) return
 
+    const battleState = this.activeBattles.get(battleId)
+
+    const { aTeam, bTeam } = top
+    if (aTeam) battleState?.all.attacks.push(aTeam)
+    if (bTeam) battleState?.all.attacks.push(bTeam)
+
     this.emit('battle:attacked', DiscussionVoteResultDto.of(battleId, top))
   }
 
   private emitDefensedResult(battleId: string) {
     const top = this.pickTopVotedDefense(battleId)
     if (!top) return
+
+    const battleState = this.activeBattles.get(battleId)
+
+    const { aTeam, bTeam } = top
+    if (aTeam) battleState?.all.defenses.push(aTeam)
+    if (bTeam) battleState?.all.defenses.push(bTeam)
 
     this.emit('battle:defensed', DiscussionVoteResultDto.of(battleId, top))
   }

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -502,7 +502,6 @@ export class BattlesService extends EventEmitter {
 
     const battleState = this.getBattleState(battleId)
 
-    console.log(battleState.phase)
     if (!this.canUserSubmitAttack(battleState, team)) {
       throw new BadRequestException('현재 공격을 등록할 수 없는 단계입니다.')
     }

--- a/backend/src/battles/types/battles.types.ts
+++ b/backend/src/battles/types/battles.types.ts
@@ -64,6 +64,11 @@ export interface BattleDiscussion {
   status: BattleDiscussionStatus
 }
 
+export interface BattleTopOpinions {
+  aTeam: BattleDiscussion | null
+  bTeam: BattleDiscussion | null
+}
+
 export type BattleDefense = BattleDiscussion
 
 export interface BattleData {

--- a/backend/src/battles/types/battles.types.ts
+++ b/backend/src/battles/types/battles.types.ts
@@ -7,7 +7,6 @@ import {
   BATTLE_STATUS,
   BATTLE_TEAM,
   BATTLE_DISCUSSION_TYPE,
-  BATTLE_TURN,
 } from '../const/battles.const'
 
 export type BattlePhaseName = (typeof BATTLE_PHASE)[keyof typeof BATTLE_PHASE]['name']
@@ -20,7 +19,6 @@ export type BattleCategory = (typeof BATTLE_CATEGORY)[keyof typeof BATTLE_CATEGO
 export type BattlePlayTimeName = (typeof BATTLE_PLAYTIME)[keyof typeof BATTLE_PLAYTIME]['name']
 export type BattlePlayTime = (typeof BATTLE_PLAYTIME)[keyof typeof BATTLE_PLAYTIME]
 export type BattleTeam = (typeof BATTLE_TEAM)[keyof typeof BATTLE_TEAM]
-export type BattleTurn = (typeof BATTLE_TURN)[keyof typeof BATTLE_TURN]['name']
 export type BattleDiscussionStatus = 'PENDING' | 'SELECTED' | 'REJECTED'
 
 export interface Battle {
@@ -91,10 +89,8 @@ export interface ActiveBattleState {
 
   round: number
   phase: BattlePhaseName
-  turn: {
-    status: BattleTurn
-    count: number
-  } | null
-  startedAt: number
-  expiredAt: number
+  phaseCount: number
+
+  startedAt: number | null
+  expiredAt: number | null
 }

--- a/backend/src/battles/types/battles.types.ts
+++ b/backend/src/battles/types/battles.types.ts
@@ -74,8 +74,8 @@ export type BattleDefense = BattleDiscussion
 export interface BattleData {
   roomId: string
   chats: BattleChat[]
-  attacks: BattleDiscussion[]
-  defenses: BattleDefense[]
+  attacks: (BattleDiscussion | null)[]
+  defenses: (BattleDefense | null)[]
 }
 
 export interface BattleTeamData extends BattleData {

--- a/frontend/src/assets/icon/close.svg
+++ b/frontend/src/assets/icon/close.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M24 8L8 24" stroke="currentColor" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 8L24 24" stroke="currentColor" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -15,6 +15,8 @@ export interface BattleInfo {
   description: string;
   aCode: string;
   bCode: string;
+  language: string;
+  category: string;
 }
 
 // 공통 타입들

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,6 +3,51 @@
 /* Custom styles */
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  min-width: 1440px;
+
+  /* 배틀 페이지 레이아웃 크기 */
+  --sidebar-width: 320px;
+  --main-closed: 1440px;
+  --main-open: 1120px;
+  --lounge-closed: 472px;
+  --lounge-open: 360px;
+}
+
+/* FHD 모니터 */
+@media (min-width: 1920px) {
+  :root {
+    --sidebar-width: 400px;
+    --main-closed: 1800px;
+    --main-open: 1400px;
+    --lounge-closed: 590px;
+    --lounge-open: 450px;
+  }
+}
+
+@layer components {
+  .sidebar-width {
+    width: var(--sidebar-width);
+  }
+
+  .main-width-closed {
+    width: var(--main-closed);
+  }
+
+  .main-width-open {
+    width: var(--main-open);
+  }
+
+  .lounge-width-closed {
+    width: var(--lounge-closed);
+  }
+
+  .lounge-width-open {
+    width: var(--lounge-open);
+  }
+
+  .ml-sidebar {
+    margin-left: var(--sidebar-width);
+  }
 }
 
 body {
@@ -26,15 +71,15 @@ body {
 }
 
 .scrollbar-thin::-webkit-scrollbar-track {
-  background: #2D2D3F;
+  background: #2d2d3f;
   border-radius: 5px;
 }
 
 .scrollbar-thin::-webkit-scrollbar-thumb {
-  background: #FF6900;
+  background: #ff6900;
   border-radius: 5px;
 }
 
 .scrollbar-thin::-webkit-scrollbar-thumb:hover {
-  background: #FF8533;
+  background: #ff8533;
 }

--- a/frontend/src/pages/battlePage/components/codeview/CodeSection.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/CodeSection.tsx
@@ -14,7 +14,7 @@ export default function CodeSection({ onViewChange, currentView, codeA, codeB, l
   const [currentTab, setCurrentTab] = useState<'A' | 'B'>('A');
 
   return (
-    <section className="w-[1194px] h-fit flex-1 flex flex-col bg-[#1E1E2F]  rounded-lg overflow-hidden">
+    <section className="w-full h-fit flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden">
       <CodeHeader
         onViewChange={onViewChange}
         currentView={currentView}

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
+import BattleIcon from '@/assets/icon/battle.svg?react';
 import { isInputDisabled, getDiscussionConfig } from '../../utils/battlePhase';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from '../../stores/battleStore';
+import { TEAM_COLORS } from '../../types/teamColors';
 
 interface DiscussionInputProps {
   disabled?: boolean;
@@ -12,10 +14,15 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
   const team = useBattleStore(selectSelectedTeam);
   const [inputValue, setInputValue] = useState('');
 
+  // 중립 진영은 DiscussionInput 표시 안 함
+  if (team === 'NONE') {
+    return null;
+  }
+
   const phase = battleProgress?.phase;
   const turnStatus = battleProgress?.turn?.status;
 
-  const { placeholderText, buttonText, Icon } = getDiscussionConfig(team, phase);
+  const { placeholderText, buttonText, Icon, isAttacking } = getDiscussionConfig(team, phase);
   const disabled_input = isInputDisabled(team, phase, turnStatus, disabled);
 
   const handleSubmit = () => {
@@ -31,27 +38,59 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
     }
   };
 
+  const hintText = isAttacking
+    ? '상대 진영의 코드와 주장의 빈틈을 노려 반론을 던져보세요.'
+    : '아직 이의제기 단계가 아닙니다. 잠시만 기다려주세요.';
+
+  const colors = TEAM_COLORS[team];
+
   return (
-    <section className="w-full bg-[#1E1E2F] rounded-lg overflow-hidden">
-      <div className="p-4 flex gap-1">
-        <input
-          type="text"
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          onKeyPress={handleKeyPress}
-          placeholder={placeholderText}
-          disabled={disabled_input}
-          autoFocus
-          className="w-full bg-[#2D2D3F] border border-[#FF5A5F] rounded-md px-4 py-3 text-[13px] text-white placeholder-[#666] focus:outline-none focus:border-[#FF5A5F] disabled:opacity-50 disabled:cursor-not-allowed"
-        />
-        <button
-          onClick={handleSubmit}
-          disabled={disabled_input}
-          className="w-[140px] py-2 bg-[#4A5568] text-[15px] text-white rounded-md hover:bg-[#5A6578] transition-colors flex items-center justify-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[#4A5568]"
-        >
-          <Icon className="w-[22px] h-[22px]" />
-          {buttonText}
-        </button>
+    <section
+      className={`w-full bg-linear-to-r ${colors.containerGradient} border ${colors.border} rounded-lg overflow-hidden shadow-lg`}
+    >
+      {/* 헤더 */}
+      <div className="px-4 pt-4 pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <BattleIcon className={`w-5 h-5 ${colors.primary}`} />
+            <h3 className="text-white text-[15px] font-semibold">{team}팀 이의제기</h3>
+          </div>
+          {isAttacking && (
+            <div
+              className={`flex items-center gap-1.5 bg-linear-to-r ${colors.badgeGradient} px-3 py-1.5 rounded-full`}
+            >
+              <span className="text-white text-[12px] font-medium">반격 시간</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 입력 영역 */}
+      <div className="px-4 pb-4">
+        <div className="flex gap-2 mb-3">
+          <input
+            type="text"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyPress}
+            placeholder={placeholderText}
+            disabled={disabled_input}
+            autoFocus
+            className={`flex-1 bg-[#2D2D3F] border ${colors.border} rounded-lg px-4 py-3 text-[14px] text-white placeholder-[#666] focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed transition-all`}
+          />
+          <button
+            onClick={handleSubmit}
+            disabled={disabled_input}
+            className={`px-6 py-3 ${colors.primaryBg} text-white rounded-lg ${colors.buttonHover} ${colors.buttonActive} transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed font-medium text-[14px] shadow-md hover:shadow-lg`}
+          >
+            <Icon className="w-5 h-5" />
+            {buttonText}
+          </button>
+        </div>
+
+        <div className={`flex items-start gap-2 ${colors.primary} text-[12px]`}>
+          <p className="leading-relaxed">{hintText}</p>
+        </div>
       </div>
     </section>
   );

--- a/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
+++ b/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
@@ -3,12 +3,7 @@ import VoteStatus from './VoteStatus';
 import { useBattleStore, selectCurrentStage, selectBattleProgress, selectTeamCounts } from '../../stores/battleStore';
 import { useBattleTimer } from '../../hooks/useBattleTimer';
 
-interface BattleHeaderProps {
-  title: string;
-  description: string;
-}
-
-export default function BattleHeader({ title, description }: BattleHeaderProps) {
+export default function BattleHeader() {
   const currentStage = useBattleStore(selectCurrentStage);
   const battleProgress = useBattleStore(selectBattleProgress);
   const { teamACount, teamBCount } = useBattleStore(selectTeamCounts);
@@ -22,10 +17,6 @@ export default function BattleHeader({ title, description }: BattleHeaderProps) 
   return (
     <header className="bg-[#1E1E2F] px-8 py-6 rounded-lg mb-2">
       <div className="flex justify-between">
-        <div>
-          <h1 className="text-[20px] text-left font-bold mb-2">{title}</h1>
-          <p className="text-[#99A1AF] text-[14px]">{description}</p>
-        </div>
         <div className="flex items-center gap-4">
           <StatusCard turn={status} timer={formattedTime} />
           <VoteStatus teamACounts={teamACount} teamBCounts={teamBCount} teamNoneCounts={teamNoneCounts} />

--- a/frontend/src/pages/battlePage/components/sidebar/BattleSidebar.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/BattleSidebar.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import ClockIcon from '@/assets/icon/clock.svg?react';
+import MessageIcon from '@/assets/icon/message.svg?react';
+import CloseIcon from '@/assets/icon/close.svg?react';
+import TimelineSection from '../timeline/TimelineSection';
+
+interface BattleSidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  description: string;
+  language: string;
+  category: string;
+}
+
+type Tab = 'info' | 'timeline';
+
+export default function BattleSidebar({ isOpen, onClose, title, description, language, category }: BattleSidebarProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('info');
+
+  return (
+    <aside
+      className={`fixed top-0 left-0 h-full sidebar-width bg-[#0a0a1a] border-r border-[#1A1A2E] z-100 transform transition-transform duration-300 ease-in-out shadow-2xl ${
+        isOpen ? 'translate-x-0' : '-translate-x-full'
+      }`}
+    >
+      {/* 헤더 */}
+      <div>
+        <div className="flex items-center justify-between px-6 pt-5 pb-4">
+          <div className="flex gap-6 flex-1">
+            <button
+              onClick={() => setActiveTab('info')}
+              className={`flex items-center gap-2 px-2 py-2 text-[15px] font-bold transition-colors ${
+                activeTab === 'info' ? 'text-white' : 'text-gray-400 hover:text-white'
+              }`}
+            >
+              <MessageIcon className="w-5 h-5" />
+              문제 설명
+            </button>
+            <button
+              onClick={() => setActiveTab('timeline')}
+              className={`flex items-center gap-2 px-2 py-2 text-[15px] font-bold transition-colors ${
+                activeTab === 'timeline' ? 'text-white' : 'text-gray-400 hover:text-white'
+              }`}
+            >
+              <ClockIcon className="w-5 h-5" />
+              타임라인
+            </button>
+          </div>
+          <button onClick={onClose} className="text-gray-400 hover:text-white transition-colors" aria-label=" 닫기">
+            <CloseIcon className="w-5 h-5 " />
+          </button>
+        </div>
+        {/* 활성 탭 밑줄 */}
+        <div
+          className={`h-[2px] transition-all duration-300 ${
+            activeTab === 'info'
+              ? 'bg-linear-to-r from-[#FF6900] to-[#FF8533]'
+              : 'bg-linear-to-r from-[#AD46FF] to-[#6BA3FF]'
+          }`}
+        />
+      </div>
+
+      {/* 컨텐츠 영역 */}
+      <div className="h-[calc(100vh-65px)] overflow-y-auto overflow-x-hidden">
+        {activeTab === 'info' ? (
+          <div className="p-6 space-y-8">
+            {/* 제목 */}
+            <div className="text-left">
+              <p className="text-orange-500  font-semibold  mb-3">제목</p>
+              <h3 className=" text-xl   leading-relaxed">{title}</h3>
+            </div>
+
+            {/* 설명 */}
+            <div className="text-left">
+              <p className="text-orange-500  font-semibold  mb-3">설명</p>
+              <p className="leading-relaxed">{description}</p>
+            </div>
+
+            <div className="flex gap-4">
+              {/* 언어 */}
+              <div className="bg-[#1E1E2F] rounded-lg px-4 py-3 shadow w-1/2 flex flex-col  gap-2 items-start">
+                <h3 className="text-gray-400  text-sm">언어</h3>
+                <p className="text-white text-[14px] font-semibold">{language}</p>
+              </div>
+              {/* 카테고리 */}
+              <div className="bg-[#1E1E2F] rounded-lg px-4 py-3 shadow w-1/2 flex flex-col  gap-2 items-start">
+                <h3 className="text-gray-400  text-sm">카테고리</h3>
+                <p className="text-white text-[14px] font-semibold">{category}</p>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="px-4 py-2">
+            <div className="w-full [&_section]:w-full [&_section]:mt-0">
+              <TimelineSection />
+            </div>
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
@@ -1,0 +1,35 @@
+import ClockIcon from '@/assets/icon/clock.svg?react';
+import MessageIcon from '@/assets/icon/message.svg?react';
+
+interface BookmarkButtonProps {
+  onOpen: () => void;
+  isOpen: boolean;
+}
+
+export default function BookmarkButton({ onOpen, isOpen }: BookmarkButtonProps) {
+  if (isOpen) return null;
+
+  return (
+    <div className="fixed left-0 top-1/2 -translate-y-1/2 z-30 flex flex-col gap-2">
+      {/* 문제 설명 */}
+      <button
+        onClick={onOpen}
+        className="group relative bg-linear-to-r from-[#FF6900] to-[#FF8533] px-3 py-2 rounded-r-md shadow-md hover:shadow-lg transition-all duration-200 hover:translate-x-1 flex items-center gap-1"
+        aria-label="문제 설명 보기"
+      >
+        <MessageIcon className="w-3.5 h-3.5" />
+        <span className="text-sm">문제 설명</span>
+      </button>
+
+      {/* 타임라인 */}
+      <button
+        onClick={onOpen}
+        className="group relative bg-linear-to-r from-[#AD46FF] to-[#6BA3FF] px-3 py-2 rounded-r-md shadow-md hover:shadow-lg transition-all duration-200 hover:translate-x-1 flex items-center gap-1"
+        aria-label="타임라인 보기"
+      >
+        <ClockIcon className="w-3.5 h-3.5" />
+        <span className="text-sm">타임라인</span>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -6,7 +6,8 @@ import CodeSection from './components/codeview/CodeSection';
 import ChatSection from './components/chatting/ChatSection';
 import DiscussionInput from './components/discussion/DiscussionInput';
 import DiscussionVote from './components/discussion/DiscussionVote';
-import TimelineSection from './components/timeline/TimelineSection';
+import BattleSidebar from './components/sidebar/BattleSidebar';
+import BookmarkButton from './components/sidebar/BookmarkButton';
 import { useBattle } from './hooks/useBattle';
 import useModal from '@/commons/hooks/useModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
@@ -16,6 +17,7 @@ export default function BattlePage() {
   const { id: battleId } = useParams<{ id: string }>();
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
+  const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
 
   const {
     isOpen: isTeamChangeModalOpen,
@@ -30,49 +32,68 @@ export default function BattlePage() {
   });
 
   return (
-    <div className="text-white flex flex-col items-center relative">
-      <div className="w-[1800px]">
-        <BattleHeader title={battleInfo.title} description={battleInfo.description} />
-      </div>
-      <main className="w-[1800px] pb-24">
-        <div className="flex gap-2 py-4">
-          <div className="flex-1">
-            <CodeSection
-              onViewChange={setViewMode}
-              currentView={viewMode}
-              language="javascript"
-              codeA={battleInfo.aCode}
-              codeB={battleInfo.bCode}
-            />
-            <TimelineSection />
+    <div className="text-white relative min-h-screen">
+      {/* 책갈피 버튼 */}
+      <BookmarkButton onOpen={handleOpenSidebar} isOpen={isSidebarOpen} />
+
+      {/* 사이드바 */}
+      <BattleSidebar
+        isOpen={isSidebarOpen}
+        onClose={handleCloseSidebar}
+        title={battleInfo.title}
+        description={battleInfo.description}
+        language={battleInfo.language}
+        category={battleInfo.category}
+      />
+
+      {/* 메인 콘텐츠 */}
+      <div
+        className={`flex flex-col items-center transition-all duration-300 ease-in-out ${
+          isSidebarOpen ? 'ml-sidebar' : 'ml-0'
+        }`}
+      >
+        <div className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'}`}>
+          <BattleHeader />
+        </div>
+        <main className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'}`}>
+          <div className="flex gap-2 py-4">
+            <div className="flex-1">
+              <CodeSection
+                onViewChange={setViewMode}
+                currentView={viewMode}
+                language={battleInfo.language}
+                codeA={battleInfo.aCode}
+                codeB={battleInfo.bCode}
+              />
+            </div>
+            <aside className="flex flex-col gap-4 w-[590px]">
+              <DiscussionVote onVote={handleVote} />
+              <ChatSection />
+            </aside>
           </div>
-          <aside className="flex flex-col gap-4 w-[590px]">
-            <DiscussionVote onVote={handleVote} />
-            <ChatSection />
-          </aside>
-        </div>
-      </main>
+        </main>
 
-      {/* DiscussionInput 항상 중앙 하단에 고정 */}
-      <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-[1800px] px-4 pb-4 z-50">
-        <div className="max-w-[590px] mx-auto">
-          <DiscussionInput onSubmit={handleDiscussionSubmit} />
+        {/* DiscussionInput 항상 중앙 하단에 고정 */}
+        <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-[1800px] px-4 pb-4 z-50">
+          <div className="max-w-[590px] mx-auto">
+            <DiscussionInput onSubmit={handleDiscussionSubmit} />
+          </div>
         </div>
+
+        {isTeamChangeModalOpen && (
+          <TeamChangeModal handleTeamChange={handleTeamChange} onClose={handleCloseTeamChangeModal} />
+        )}
+
+        {effectModal.isOpen && effectModal.team !== 'NONE' && (
+          <DiscussionModal
+            isOpen={effectModal.isOpen}
+            team={effectModal.team}
+            content={effectModal.content}
+            type={effectModal.type}
+            onClose={hideEffect}
+          />
+        )}
       </div>
-
-      {isTeamChangeModalOpen && (
-        <TeamChangeModal handleTeamChange={handleTeamChange} onClose={handleCloseTeamChangeModal} />
-      )}
-
-      {effectModal.isOpen && effectModal.team !== 'NONE' && (
-        <DiscussionModal
-          isOpen={effectModal.isOpen}
-          team={effectModal.team}
-          content={effectModal.content}
-          type={effectModal.type}
-          onClose={hideEffect}
-        />
-      )}
     </div>
   );
 }

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -30,11 +30,11 @@ export default function BattlePage() {
   });
 
   return (
-    <div className="text-white flex flex-col items-center">
+    <div className="text-white flex flex-col items-center relative">
       <div className="w-[1800px]">
         <BattleHeader title={battleInfo.title} description={battleInfo.description} />
       </div>
-      <main className="w-[1800px]">
+      <main className="w-[1800px] pb-24">
         <div className="flex gap-2 py-4">
           <div className="flex-1">
             <CodeSection
@@ -47,12 +47,18 @@ export default function BattlePage() {
             <TimelineSection />
           </div>
           <aside className="flex flex-col gap-4 w-[590px]">
-            <ChatSection />
-            <DiscussionInput onSubmit={handleDiscussionSubmit} />
             <DiscussionVote onVote={handleVote} />
+            <ChatSection />
           </aside>
         </div>
       </main>
+
+      {/* DiscussionInput 항상 중앙 하단에 고정 */}
+      <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-[1800px] px-4 pb-4 z-50">
+        <div className="max-w-[590px] mx-auto">
+          <DiscussionInput onSubmit={handleDiscussionSubmit} />
+        </div>
+      </div>
 
       {isTeamChangeModalOpen && (
         <TeamChangeModal handleTeamChange={handleTeamChange} onClose={handleCloseTeamChangeModal} />

--- a/frontend/src/pages/battlePage/types/teamColors.ts
+++ b/frontend/src/pages/battlePage/types/teamColors.ts
@@ -1,0 +1,49 @@
+export type Team = 'A' | 'B' | 'NONE';
+
+export interface TeamColors {
+  primary: string;
+  border: string;
+  primaryBg: string;
+  containerGradient: string;
+  buttonHover: string;
+  buttonActive: string;
+  badgeGradient: string;
+  codeBlock: string;
+  codeText: string;
+}
+
+export const TEAM_COLORS: Record<Team, TeamColors> = {
+  A: {
+    primary: 'text-[#6BA3FF]',
+    border: 'border-[#3B6FA8]',
+    primaryBg: 'bg-[#3B6FA8]',
+    containerGradient: 'from-[#1A2B4A] to-[#0F1A2E]',
+    buttonHover: 'hover:bg-[#4B7FB8]',
+    buttonActive: 'active:bg-[#2B5F98]',
+    badgeGradient: 'from-[#1A2B4A] to-[#2B4A6E]',
+    codeBlock: 'border-[#2B7FFF] bg-[#1C398E]',
+    codeText: 'text-[#BEDBFF]'
+  },
+  B: {
+    primary: 'text-[#FF7A7F]',
+    border: 'border-[#C85A5F]',
+    primaryBg: 'bg-[#C85A5F]',
+    containerGradient: 'from-[#4A1F22] to-[#2F1214]',
+    buttonHover: 'hover:bg-[#D86A6F]',
+    buttonActive: 'active:bg-[#B84A4F]',
+    badgeGradient: 'from-[#4A1F22] to-[#6A2F32]',
+    codeBlock: 'border-[#FB2C36] bg-[#82181A]',
+    codeText: 'text-[#FFC9C9]'
+  },
+  NONE: {
+    primary: 'text-[#FF8533]',
+    border: 'border-[#FF6900]',
+    primaryBg: 'bg-[#F54900]',
+    containerGradient: 'from-[#3A1F0F] to-[#241308]',
+    buttonHover: 'hover:bg-[#FF5A00]',
+    buttonActive: 'active:bg-[#E53900]',
+    badgeGradient: 'from-[#CA3500] to-[#FF5A00]',
+    codeBlock: 'border-[#FF6900] bg-[#CA3500]',
+    codeText: 'text-[#FFB86A]'
+  }
+} as const;

--- a/frontend/src/pages/teamSelectPage/components/TeamButton.tsx
+++ b/frontend/src/pages/teamSelectPage/components/TeamButton.tsx
@@ -3,6 +3,7 @@ import EyeIcon from '@/assets/icon/eye.svg?react';
 import Sheild from '@/assets/icon/shield.svg?react';
 import Scale from '@/assets/icon/scale.svg?react';
 import CodeTooltip from './CodeTooltip';
+import { TEAM_COLORS, type Team } from '@/pages/battlePage/types/teamColors';
 
 interface TeamButtonProps {
   team: 'A' | 'B' | 'NONE';
@@ -11,30 +12,6 @@ interface TeamButtonProps {
   description?: string;
   onSelect?: (team: 'A' | 'B' | 'NONE') => void;
 }
-
-const TEAM_STYLES = {
-  A: {
-    button: 'border-[#2B7FFF]',
-    icon: 'bg-[#155DFC]',
-    title: 'text-[#51A2FF]',
-    codeBlock: 'border-[#2B7FFF] bg-[#1C398E]',
-    codeText: 'text-[#BEDBFF]'
-  },
-  B: {
-    button: 'border-[#FB2C36]',
-    icon: 'bg-[#E7000B]',
-    title: 'text-[#FF5A5F]',
-    codeBlock: 'border-[#FB2C36] bg-[#82181A]',
-    codeText: 'text-[#FFC9C9]'
-  },
-  NONE: {
-    button: 'border-[#FF6900]',
-    icon: 'bg-[#F54900]',
-    title: 'text-[#FF8533]',
-    codeBlock: 'border-[#FF6900] bg-[#CA3500]',
-    codeText: 'text-[#FFB86A]'
-  }
-};
 
 const TEAM_CONTENT = {
   A: {
@@ -57,9 +34,10 @@ const TEAM_CONTENT = {
 
 export default function TeamButton({ team, language, code, description, onSelect }: TeamButtonProps) {
   const [isHovered, setIsHovered] = useState(false);
-  const styles = TEAM_STYLES[team];
   const content = TEAM_CONTENT[team];
   const Icon = team === 'NONE' ? Scale : Sheild;
+
+  const colors = TEAM_COLORS[team as Team];
 
   return (
     <div
@@ -69,24 +47,24 @@ export default function TeamButton({ team, language, code, description, onSelect
     >
       <button
         onClick={() => onSelect?.(team)}
-        className={`border-[0.1px] rounded-lg bg-[#1E1E2F] min-h-[437px] w-[18rem] ${styles.button} transition-transform duration-300 hover:scale-110`}
+        className={`border-[0.1px] rounded-lg bg-[#1E1E2F] min-h-[437px] w-[18rem] ${colors.border} transition-transform duration-300 hover:scale-110`}
       >
-        <Icon className={`rounded-full w-[96px] h-[96px] px-6 py-6 mx-auto ${styles.icon}`} />
+        <Icon className={`rounded-full w-[96px] h-[96px] px-6 py-6 mx-auto ${colors.primaryBg}`} />
         <p className="my-4">{content.label}</p>
-        <p className={`text-[16px] my-4 ${styles.title}`}>{content.title}</p>
+        <p className={`text-[16px] my-4 ${colors.primary}`}>{content.title}</p>
         {team === 'NONE' ? (
-          <div className={`border-[1px] rounded-md w-[85%] mx-auto text-left px-4 py-2 ${styles.codeBlock}`}>
-            <p className={`text-[12px] ${styles.codeText} my-2 whitespace-pre-line text-center`}>
+          <div className={`border rounded-md w-[85%] mx-auto text-left px-4 py-2 ${colors.codeBlock}`}>
+            <p className={`text-[12px] ${colors.codeText} my-2 whitespace-pre-line text-center`}>
               {'message' in content && content.message}
             </p>
           </div>
         ) : (
-          <div className={`relative border-[1px] rounded-md w-[85%] mx-auto text-left px-4 py-2 ${styles.codeBlock}`}>
+          <div className={`relative border rounded-md w-[85%] mx-auto text-left px-4 py-2 ${colors.codeBlock}`}>
             <div className="flex justify-between">
               <p className="text-[8px] text-[#8EC5FF]">{language}</p>
               <EyeIcon className="text-blue-400" />
             </div>
-            <p className={`text-[12px] ${styles.codeText} my-2 line-clamp-3`}>{code}</p>
+            <p className={`text-[12px] ${colors.codeText} my-2 line-clamp-3`}>{code}</p>
           </div>
         )}
         <p className="mx-5 text-[12px] text-[#99A1AF] mt-4">
@@ -99,8 +77,8 @@ export default function TeamButton({ team, language, code, description, onSelect
           team={team as 'A' | 'B'}
           language={language}
           code={code}
-          titleColor={styles.title}
-          borderColor={styles.button}
+          titleColor={colors.primary}
+          borderColor={colors.border}
         />
       )}
     </div>

--- a/frontend/src/pages/teamSelectPage/index.tsx
+++ b/frontend/src/pages/teamSelectPage/index.tsx
@@ -19,7 +19,7 @@ export default function TeamSelectPage() {
           <BattleIcon className="w-[48px] h-[48px] text-[#FF6900]" />
           <h1 className="ml-2 text-[16px] my-auto">진영을 선택해주세요</h1>
         </div>
-        <div className="w-[768px] h-[113px] bg-[#1E1E2F] border-[1px] border-[#2D2D3F] rounded-lg mx-auto text-center py-6 mt-6 mb-10">
+        <div className="w-full max-w-[768px] px-4 h-[113px] bg-[#1E1E2F] border border-[#2D2D3F] rounded-lg mx-auto text-center py-6 mt-6 mb-10">
           <p className="font-bold text-[20px]">{battleInfo.title}</p>
           <p className="mt-2 text-[#99A1AF] text-[16px]">{battleInfo.description}</p>
         </div>


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 예: Closes #123, Relates to #456 -->

closes #108

## ✅ 작업 내용

- Turn 관련 로직 제거
  1. `BATTLE_TURN` 상태값 제거
  2. `BattleTurnResponseDto` DTO 제거
  3. `battle:turn:updated` 이벤트 제거
- Phase 관련 로직 수정
  1.  PENDING -> OPINION_SHARE -> ATTACK -> DEFENSE -> TEAM_SWITCH
  2.  아직 게임 시작 버튼 로직이 추가되지 않아, PENDING은 0초로 설정
  3.  `phaseCount` 변수 추가 -> ATTACK - DEFENSE가 2회 반복되니, 한 사이클을 기록하기 위해 선언
- 이의제기, 반박, 투표 관련 유효성 검사 메서드 수정
  - `canUserSubmitAttack`, `canUserSubmitDefense`, `canUserVoteAttack`, `canUserVoteDefense`
  - 턴이 제거되고 Phase에 따라 가능하도록 수정
- 테스트 코드 수정 및 추가

### 💡개선 사항

- 테스트 코드 수정 사항
  - A_ATTACK, B_ATTACK... 상태값 모두 ATTACK, DEFNESE로 수정
  - 턴 관련 로직 제거
  - `battles.gateway.spec.ts`에서 `mockResponse` 타입 배열로 반환

<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항

<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->
![be-change](https://github.com/user-attachments/assets/23ef0d95-6dc6-4d1e-86b6-a703704ab911)


<br />

## 💬 질문사항 (고민했던 부분)

1. 아직 BE에서만 수정된거라 FE랑 같이 연동하면서 맞춰봐야할 듯 합니다.
2. 작업하면서 Notion에 적힌 이벤트 명세서와 다르게 구현되었던 점이 많았던 것 같아요.
    다른 사람들이 작업하기 편하도록 구현 후에 명세서 업데이트 부탁드립니다! 🙌 물론 나부터
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
