### PR TITLE
[Feature] FE 배틀 진행 방식 변경

### DIFF
--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -18,9 +18,8 @@ export interface BattleInfo {
 }
 
 // 공통 타입들
-export type BattlePhase = 'OPINION_SHARE' | 'TEAM_A_ATTACK' | 'TEAM_B_ATTACK' | 'TEAM_SWITCH';
+export type BattlePhase = 'PENDING' | 'OPINION_SHARE' | 'ATTACK' | 'DEFENSE' | 'TEAM_SWITCH';
 export type Team = 'A' | 'B' | 'NONE';
-export type TurnStatus = 'A_ATTACK' | 'B_ATTACK' | 'A_DEFENSE' | 'B_DEFENSE';
 
 // BattleDiscussion 타입
 export interface BattleDiscussion {
@@ -58,10 +57,6 @@ export interface BattleJoinData {
   // 배틀 상태 정보
   round: number;
   phase: BattlePhase;
-  turn: {
-    status: TurnStatus;
-    count: number;
-  } | null;
   startedAt: number;
   expiredAt: number;
 }
@@ -76,10 +71,6 @@ export interface UseBattleSocketProps {
 export interface BattleProgressState {
   round: number;
   phase: BattlePhase;
-  turn: {
-    status: TurnStatus;
-    count: number;
-  } | null;
   startedAt: number;
   expiredAt: number;
 }

--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -78,14 +78,18 @@ export interface BattleProgressState {
 }
 
 // Battle:Attacked 이벤트 응답 타입
+export interface DiscussionVoteResultItem {
+  id: string | null;
+  text: string | null;
+  ownerId: string | null;
+  count: number | null;
+}
+
 export interface BattleAttackedResult {
   battleId: string;
   attack: {
-    discussionId: string;
-    authorId: string;
-    type: string;
-    text: string;
-    upvotes: number;
+    aTeam: DiscussionVoteResultItem;
+    bTeam: DiscussionVoteResultItem;
   };
 }
 
@@ -93,11 +97,8 @@ export interface BattleAttackedResult {
 export interface BattleDefensedResult {
   battleId: string;
   defense: {
-    discussionId: string;
-    authorId: string;
-    type: string;
-    text: string;
-    upvotes: number;
+    aTeam: DiscussionVoteResultItem;
+    bTeam: DiscussionVoteResultItem;
   };
 }
 

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -13,10 +13,9 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
   const [inputValue, setInputValue] = useState('');
 
   const phase = battleProgress?.phase;
-  const turnStatus = battleProgress?.turn?.status;
 
   const { placeholderText, buttonText, Icon } = getDiscussionConfig(team, phase);
-  const disabled_input = isInputDisabled(team, phase, turnStatus, disabled);
+  const disabled_input = isInputDisabled(team, phase, disabled);
 
   const handleSubmit = () => {
     if (inputValue.trim() && !disabled_input) {

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -21,7 +21,6 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
 
   const phase = battleProgress?.phase;
 
-
   const { placeholderText, buttonText, Icon, isAttacking } = getDiscussionConfig(team, phase);
   const disabled_input = isInputDisabled(team, phase, disabled);
 
@@ -33,7 +32,7 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
   };
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
       handleSubmit();
     }
   };

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionVote.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionVote.tsx
@@ -27,8 +27,8 @@ export default function DiscussionVote({ onVote }: DiscussionVoteProps) {
   const phase = battleProgress?.phase;
   const isAttacking = isMyTeamAttacking(team, phase);
 
-  // OPINION_SHARE 단계에서는 투표 UI를 표시하지 않음
-  if (phase === 'OPINION_SHARE') {
+  // ATTACK/DEFENSE 외 단계에서는 표시하지 않음
+  if (phase !== 'ATTACK' && phase !== 'DEFENSE') {
     return null;
   }
 

--- a/frontend/src/pages/battlePage/components/discussion/test/DiscussionInput.test.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/test/DiscussionInput.test.tsx
@@ -5,10 +5,8 @@ import DiscussionInput from '@/pages/battlePage/components/discussion/Discussion
 
 let mockBattleProgress: {
   phase: string;
-  turn: { status: string } | null;
 } = {
-  phase: 'TEAM_A_ATTACK',
-  turn: { status: 'A_ATTACK' }
+  phase: 'ATTACK'
 };
 let mockSelectedTeam: 'A' | 'B' = 'A';
 
@@ -20,8 +18,7 @@ vi.mock('@/pages/battlePage/stores/battleStore', () => ({
     };
     return selector(state);
   }),
-  selectBattleProgress: (state: { battleProgress: { phase: string; turn: { status: string } | null } }) =>
-    state.battleProgress,
+  selectBattleProgress: (state: { battleProgress: { phase: string } }) => state.battleProgress,
   selectSelectedTeam: (state: { selectedTeam: 'A' | 'B' }) => state.selectedTeam
 }));
 
@@ -31,15 +28,14 @@ describe('DiscussionInput', () => {
   beforeEach(() => {
     mockOnSubmit.mockClear();
     mockBattleProgress = {
-      phase: 'TEAM_A_ATTACK',
-      turn: { status: 'A_ATTACK' }
+      phase: 'ATTACK'
     };
     mockSelectedTeam = 'A';
   });
 
   it('공격 팀일 때 "상대 진영에 이의제기..." placeholder 표시', () => {
     mockSelectedTeam = 'A';
-    mockBattleProgress = { phase: 'TEAM_A_ATTACK', turn: { status: 'A_ATTACK' } };
+    mockBattleProgress = { phase: 'ATTACK' };
 
     render(<DiscussionInput onSubmit={mockOnSubmit} />);
 
@@ -49,7 +45,7 @@ describe('DiscussionInput', () => {
 
   it('방어 팀일 때 "상대 진영에 반론..." placeholder 표시', () => {
     mockSelectedTeam = 'A';
-    mockBattleProgress = { phase: 'TEAM_B_ATTACK', turn: { status: 'B_ATTACK' } };
+    mockBattleProgress = { phase: 'DEFENSE' };
 
     render(<DiscussionInput onSubmit={mockOnSubmit} />);
 
@@ -92,7 +88,7 @@ describe('DiscussionInput', () => {
   });
 
   it('OPINION_SHARE 단계에서 input 비활성화', () => {
-    mockBattleProgress = { phase: 'OPINION_SHARE', turn: null };
+    mockBattleProgress = { phase: 'OPINION_SHARE' };
 
     render(<DiscussionInput onSubmit={mockOnSubmit} />);
 
@@ -100,9 +96,9 @@ describe('DiscussionInput', () => {
     expect(input).toBeDisabled();
   });
 
-  it('잘못된 턴에는 input 비활성화', () => {
+  it('ATTACK/DEFENSE 외 페이즈에서는 input 비활성화', () => {
     mockSelectedTeam = 'A';
-    mockBattleProgress = { phase: 'TEAM_A_ATTACK', turn: { status: 'B_DEFENSE' } };
+    mockBattleProgress = { phase: 'TEAM_SWITCH' };
 
     render(<DiscussionInput onSubmit={mockOnSubmit} />);
 

--- a/frontend/src/pages/battlePage/components/discussion/test/DiscussionVote.test.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/test/DiscussionVote.test.tsx
@@ -6,10 +6,8 @@ import type { Discussion } from '@/pages/battlePage/components/discussion/Discus
 let mockDiscussions: Discussion[] = [];
 let mockBattleProgress: {
   phase: string;
-  turn: { status: string };
 } = {
-  phase: 'TEAM_A_ATTACK',
-  turn: { status: 'A_ATTACK' }
+  phase: 'ATTACK'
 };
 let mockSelectedTeam: 'A' | 'B' = 'A';
 
@@ -23,8 +21,7 @@ vi.mock('@/pages/battlePage/stores/battleStore', () => ({
     return selector(state);
   }),
   selectDiscussions: (state: { discussions: Discussion[] }) => state.discussions,
-  selectBattleProgress: (state: { battleProgress: { phase: string; turn: { status: string } } }) =>
-    state.battleProgress,
+  selectBattleProgress: (state: { battleProgress: { phase: string } }) => state.battleProgress,
   selectSelectedTeam: (state: { selectedTeam: 'A' | 'B' }) => state.selectedTeam
 }));
 
@@ -46,14 +43,13 @@ describe('DiscussionVote', () => {
     mockOnVote.mockClear();
     mockDiscussions = [];
     mockBattleProgress = {
-      phase: 'TEAM_A_ATTACK',
-      turn: { status: 'A_ATTACK' }
+      phase: 'ATTACK'
     };
     mockSelectedTeam = 'A';
   });
 
   it('OPINION_SHARE 단계에서는 렌더링하지 않음', () => {
-    mockBattleProgress = { phase: 'OPINION_SHARE', turn: { status: 'A_ATTACK' } };
+    mockBattleProgress = { phase: 'OPINION_SHARE' };
 
     const { container } = render(<DiscussionVote onVote={mockOnVote} />);
 
@@ -70,7 +66,7 @@ describe('DiscussionVote', () => {
 
   it('공격 팀일 때 "제출된 이의제기 목록" 헤더 표시', () => {
     mockSelectedTeam = 'A';
-    mockBattleProgress = { phase: 'TEAM_A_ATTACK', turn: { status: 'A_ATTACK' } };
+    mockBattleProgress = { phase: 'ATTACK' };
     mockDiscussions = [
       { id: 1, user: 'user1', team: 'A', content: '테스트', votes: 5, totalVotes: 10, hasVoted: false }
     ];
@@ -83,7 +79,7 @@ describe('DiscussionVote', () => {
 
   it('방어 팀일 때 "제출된 반론 목록" 헤더 표시', () => {
     mockSelectedTeam = 'A';
-    mockBattleProgress = { phase: 'TEAM_B_ATTACK', turn: { status: 'B_ATTACK' } };
+    mockBattleProgress = { phase: 'DEFENSE' };
     mockDiscussions = [
       { id: 1, user: 'user1', team: 'B', content: '테스트', votes: 5, totalVotes: 10, hasVoted: false }
     ];

--- a/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
+++ b/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
@@ -27,7 +27,7 @@ export default function BattleHeader({ title, description }: BattleHeaderProps) 
           <p className="text-[#99A1AF] text-[14px]">{description}</p>
         </div>
         <div className="flex items-center gap-4">
-          <StatusCard turn={status} timer={formattedTime} />
+          <StatusCard phase={status} timer={formattedTime} />
           <VoteStatus teamACounts={teamACount} teamBCounts={teamBCount} teamNoneCounts={teamNoneCounts} />
         </div>
       </div>

--- a/frontend/src/pages/battlePage/components/header/StatusCard.tsx
+++ b/frontend/src/pages/battlePage/components/header/StatusCard.tsx
@@ -1,13 +1,13 @@
 import TimerIcon from '@/assets/icon/timer.svg?react';
-import { getTurnInfo } from '../../utils/getTurnInfo';
+import { getPhaseInfo } from '../../utils/getTurnInfo';
 
 interface StatusCardProps {
-  turn: string | null;
+  phase: string | null;
   timer: string;
 }
 
-export default function StatusCard({ turn, timer }: StatusCardProps) {
-  const { title, description } = getTurnInfo(turn);
+export default function StatusCard({ phase, timer }: StatusCardProps) {
+  const { title, description } = getPhaseInfo(phase);
   return (
     <div className="bg-gradient-to-br from-[#3D2A28] to-[#2D1F2B] border-2 border-[#FF8A00] rounded-lg px-4 py-2 min-w-[320px] min-h-[145px]">
       <div className="flex justify-between items-center mb-3">

--- a/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
@@ -44,7 +44,7 @@ export function useBattleDiscussions() {
       if (team === 'NONE' || !socket) return;
 
       const { isAttacking } = getDiscussionConfig(team, battleProgress?.phase);
-      const canSubmit = !isInputDisabled(team, battleProgress?.phase, battleProgress?.turn?.status);
+      const canSubmit = !isInputDisabled(team, battleProgress?.phase);
 
       if (!canSubmit) {
         return;

--- a/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
@@ -24,19 +24,6 @@ export function useBattleProgress() {
       useBattleStore.getState().setDiscussions([]);
     };
 
-    // Turn 변경 이벤트 구독
-    const handleTurnUpdate = (data: BattleProgressState) => {
-      updateBattleProgress({
-        turn: data.turn,
-        startedAt: data.startedAt,
-        expiredAt: data.expiredAt
-      });
-      setCurrentStage(data.turn?.status || null);
-
-      // 턴이 변경되면 투표 리스트 초기화
-      useBattleStore.getState().setDiscussions([]);
-    };
-
     // Round 변경 이벤트 구독
     const handleRoundUpdate = (data: { battleId: string; round: number }) => {
       updateBattleProgress({
@@ -45,7 +32,6 @@ export function useBattleProgress() {
     };
 
     socket.on('battle:phase:updated', handlePhaseUpdate);
-    socket.on('battle:turn:updated', handleTurnUpdate);
     socket.on('battle:round:updated', handleRoundUpdate);
 
     // 배틀 종료 이벤트 구독
@@ -56,7 +42,6 @@ export function useBattleProgress() {
 
     return () => {
       socket.off('battle:phase:updated', handlePhaseUpdate);
-      socket.off('battle:turn:updated', handleTurnUpdate);
       socket.off('battle:round:updated', handleRoundUpdate);
       socket.off('battle:closed', handleBattleClosed);
     };

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -55,17 +55,12 @@ export function useBattleSocket() {
       setTeamChats(data.chats || []);
       setAllChats(data.allChats || []);
 
-      // 초기 투표 리스트 동기화
+      // 초기 투표 리스트 동기화 (ATTACK/DEFENSE 페이즈만)
       const team = useBattleStore.getState().selectedTeam;
-      if (team !== 'NONE' && (data.phase == 'ATTACK' || data.phase == 'DEFENSE')) {
-        const VOTE_MAP: Record<string, typeof data.attacks | typeof data.defenses> = {
-          A_ATTACK_B: data.attacks,
-          B_DEFENSE_A: data.defenses,
-          B_ATTACK_A: data.attacks,
-          A_DEFENSE_B: data.defenses
-        };
+      if (team !== 'NONE') {
+        const currentVoteList =
+          data.phase === 'ATTACK' ? data.attacks : data.phase === 'DEFENSE' ? data.defenses : null;
 
-        const currentVoteList = VOTE_MAP[`${data.phase}_${team}`];
         if (currentVoteList?.length) {
           const totalVotes = currentVoteList.reduce((sum, { upvotes }) => sum + upvotes, 0);
           setDiscussions(

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -43,16 +43,11 @@ export function useBattleSocket() {
       setBattleProgress({
         round: data.round,
         phase: data.phase,
-        turn: data.turn,
         startedAt: data.startedAt,
         expiredAt: data.expiredAt
       });
 
-      if (data.phase === 'OPINION_SHARE' || data.phase === 'TEAM_SWITCH') {
-        setCurrentStage(data.phase);
-      } else {
-        setCurrentStage(data.turn?.status || data.phase);
-      }
+      setCurrentStage(data.phase);
 
       // 팀 인원 수, 타임라인, 채팅 데이터 store에 저장
       setTeamCounts({ teamACount: data.counts.teamA, teamBCount: data.counts.teamB });
@@ -62,7 +57,7 @@ export function useBattleSocket() {
 
       // 초기 투표 리스트 동기화
       const team = useBattleStore.getState().selectedTeam;
-      if (team !== 'NONE' && data.turn?.status) {
+      if (team !== 'NONE' && (data.phase == 'ATTACK' || data.phase == 'DEFENSE')) {
         const VOTE_MAP: Record<string, typeof data.attacks | typeof data.defenses> = {
           A_ATTACK_B: data.attacks,
           B_DEFENSE_A: data.defenses,
@@ -70,7 +65,7 @@ export function useBattleSocket() {
           A_DEFENSE_B: data.defenses
         };
 
-        const currentVoteList = VOTE_MAP[`${data.turn.status}_${team}`];
+        const currentVoteList = VOTE_MAP[`${data.phase}_${team}`];
         if (currentVoteList?.length) {
           const totalVotes = currentVoteList.reduce((sum, { upvotes }) => sum + upvotes, 0);
           setDiscussions(
@@ -92,7 +87,6 @@ export function useBattleSocket() {
       newSocket.off('connect');
       newSocket.off('battle:joined');
       newSocket.off('battle:phase:updated');
-      newSocket.off('battle:turn:updated');
       newSocket.off('battle:round:updated');
       newSocket.off('battle:attacked');
       newSocket.off('battle:defensed');

--- a/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
@@ -25,11 +25,12 @@ export function useBattleTimeline() {
       },
       userTeam: Team
     ) => {
-      const entry = userTeam === 'B' ? payload.aTeam : payload.bTeam;
-      if (entry && entry.id) return { team: userTeam, entry };
-
-      if (payload.aTeam?.id) return { team: 'A' as Team, entry: payload.aTeam };
-      if (payload.bTeam?.id) return { team: 'B' as Team, entry: payload.bTeam };
+      // 상대팀의 결과 표시
+      const opponentEntry = userTeam === 'A' ? payload.bTeam : payload.aTeam;
+      if (opponentEntry?.id) {
+        const opponentTeam: Team = userTeam === 'A' ? 'B' : 'A';
+        return { team: opponentTeam, entry: opponentEntry };
+      }
       return null;
     };
 

--- a/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
@@ -4,22 +4,28 @@ import type {
   BattleDefensedResult,
   BattleDiscussion,
   BattleDefense,
-  BattleChat
+  BattleChat,
+  Team
 } from '@/commons/types/battle';
-import { useBattleStore, selectBattleProgress, selectSocket } from '../stores/battleStore';
+import { useBattleStore, selectSelectedTeam, selectSocket } from '../stores/battleStore';
 import { useEffectModal } from './useEffectModal';
 
 export function useBattleTimeline() {
   const socket = useBattleStore(selectSocket);
-  const battleProgress = useBattleStore(selectBattleProgress);
+  const selectedTeam = useBattleStore(selectSelectedTeam);
   const { effectModal, showEffect, hideEffect } = useEffectModal();
+
+  const resolveTeam = (fallback: Team): Team => {
+    if (selectedTeam !== 'NONE') return selectedTeam;
+    return fallback;
+  };
 
   useEffect(() => {
     if (!socket) return;
 
     const handleAttacked = (data: BattleAttackedResult) => {
-      // 턴 상태로 공격하는 팀 판단
-      const attackingTeam = battleProgress?.turn?.status === 'A_ATTACK' ? 'A' : 'B';
+      // ATTACK 페이즈: 양 팀 모두 공격 가능, 사용자 팀 기준으로 표시
+      const attackingTeam = resolveTeam('A');
       showEffect(attackingTeam, data.attack.text, 'attack');
 
       // 타임라인에 이의제기 추가
@@ -49,8 +55,8 @@ export function useBattleTimeline() {
     };
 
     const handleDefensed = (data: BattleDefensedResult) => {
-      // 턴 상태로 방어하는 팀 판단
-      const defendingTeam = battleProgress?.turn?.status === 'A_DEFENSE' ? 'A' : 'B';
+      // DEFENSE 페이즈: 양 팀 모두 방어 가능, 사용자 팀 기준으로 표시
+      const defendingTeam = resolveTeam('A');
       showEffect(defendingTeam, data.defense.text, 'defense');
 
       // 타임라인에 반론 추가
@@ -87,7 +93,7 @@ export function useBattleTimeline() {
       socket.off('battle:attacked', handleAttacked);
       socket.off('battle:defensed', handleDefensed);
     };
-  }, [socket, battleProgress?.turn?.status, showEffect]);
+  }, [socket, showEffect, selectedTeam]);
 
   return { effectModal, hideEffect };
 }

--- a/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
@@ -25,7 +25,7 @@ export function useBattleTimeline() {
 
     const handleAttacked = (data: BattleAttackedResult) => {
       // ATTACK 페이즈: 양 팀 모두 공격 가능, 사용자 팀 기준으로 표시
-      const attackingTeam = resolveTeam('A');
+      const attackingTeam = resolveTeam('NONE');
       showEffect(attackingTeam, data.attack.text, 'attack');
 
       // 타임라인에 이의제기 추가
@@ -56,7 +56,7 @@ export function useBattleTimeline() {
 
     const handleDefensed = (data: BattleDefensedResult) => {
       // DEFENSE 페이즈: 양 팀 모두 방어 가능, 사용자 팀 기준으로 표시
-      const defendingTeam = resolveTeam('A');
+      const defendingTeam = resolveTeam('NONE');
       showEffect(defendingTeam, data.defense.text, 'defense');
 
       // 타임라인에 반론 추가

--- a/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
@@ -15,75 +15,76 @@ export function useBattleTimeline() {
   const selectedTeam = useBattleStore(selectSelectedTeam);
   const { effectModal, showEffect, hideEffect } = useEffectModal();
 
-  const resolveTeam = (fallback: Team): Team => {
-    if (selectedTeam !== 'NONE') return selectedTeam;
-    return fallback;
-  };
-
   useEffect(() => {
     if (!socket) return;
 
-    const handleAttacked = (data: BattleAttackedResult) => {
-      // ATTACK 페이즈: 양 팀 모두 공격 가능, 사용자 팀 기준으로 표시
-      const attackingTeam = resolveTeam('NONE');
-      showEffect(attackingTeam, data.attack.text, 'attack');
+    const pickEntry = (
+      payload: {
+        aTeam: { id: string | null; text: string | null; ownerId: string | null; count: number | null };
+        bTeam: { id: string | null; text: string | null; ownerId: string | null; count: number | null };
+      },
+      userTeam: Team
+    ) => {
+      const entry = userTeam === 'B' ? payload.aTeam : payload.bTeam;
+      if (entry && entry.id) return { team: userTeam, entry };
 
-      // 타임라인에 이의제기 추가
-      const attackDiscussion: BattleDiscussion = {
-        discussionId: data.attack.discussionId,
-        authorId: data.attack.authorId,
-        content: data.attack.text,
-        upvotes: data.attack.upvotes,
+      if (payload.aTeam?.id) return { team: 'A' as Team, entry: payload.aTeam };
+      if (payload.bTeam?.id) return { team: 'B' as Team, entry: payload.bTeam };
+      return null;
+    };
+
+    const pushTimelineAndChat = (
+      battleId: string,
+      team: Team,
+      entry: { id: string | null; text: string | null; ownerId: string | null; count: number | null },
+      type: 'attack' | 'defense'
+    ) => {
+      if (!entry.id || !entry.text) return;
+
+      const discussion: BattleDiscussion | BattleDefense = {
+        discussionId: entry.id,
+        authorId: entry.ownerId ?? '',
+        content: entry.text,
+        upvotes: entry.count ?? 0,
         votes: [],
         status: 'SELECTED',
-        type: 'ATTACK'
-      };
-      useBattleStore.getState().addAttackTimeline(attackDiscussion);
+        type: type === 'attack' ? 'ATTACK' : 'DEFENSE',
+        ...(type === 'defense' ? { attackId: '' } : {})
+      } as BattleDiscussion | BattleDefense;
 
-      // 채팅방에 선정된 이의제기 메시지 추가
-      const attackChatMessage: BattleChat = {
-        battleId: data.battleId,
-        scope: 'ALL' as const,
-        messageId: `attack-${data.attack.discussionId}`,
+      if (type === 'attack') {
+        useBattleStore.getState().addAttackTimeline(discussion as BattleDiscussion);
+      } else {
+        useBattleStore.getState().addDefenseTimeline(discussion as BattleDefense);
+      }
+
+      const chatMessage: BattleChat = {
+        battleId,
+        scope: 'ALL',
+        messageId: `${type}-${entry.id}`,
         sender: 'SYSTEM',
-        team: attackingTeam,
-        text: data.attack.text,
+        team,
+        text: entry.text,
         createdAt: new Date(),
-        type: 'attack'
+        type
       };
-      useBattleStore.getState().addChat(attackChatMessage);
+      useBattleStore.getState().addChat(chatMessage);
+    };
+
+    const handleAttacked = (data: BattleAttackedResult) => {
+      const target = pickEntry(data.attack, selectedTeam);
+      if (target) {
+        showEffect(target.team, target.entry.text ?? '', 'attack');
+        pushTimelineAndChat(data.battleId, target.team, target.entry, 'attack');
+      }
     };
 
     const handleDefensed = (data: BattleDefensedResult) => {
-      // DEFENSE 페이즈: 양 팀 모두 방어 가능, 사용자 팀 기준으로 표시
-      const defendingTeam = resolveTeam('NONE');
-      showEffect(defendingTeam, data.defense.text, 'defense');
-
-      // 타임라인에 반론 추가
-      const defenseDiscussion: BattleDefense = {
-        discussionId: data.defense.discussionId,
-        authorId: data.defense.authorId,
-        content: data.defense.text,
-        upvotes: data.defense.upvotes,
-        votes: [],
-        status: 'SELECTED',
-        type: 'DEFENSE',
-        attackId: '' // 서버에서 제공하지 않으면 빈 문자열
-      };
-      useBattleStore.getState().addDefenseTimeline(defenseDiscussion);
-
-      // 채팅방에 선정된 반론 메시지 추가
-      const defenseChatMessage: BattleChat = {
-        battleId: data.battleId,
-        scope: 'ALL' as const,
-        messageId: `defense-${data.defense.discussionId}`,
-        sender: 'SYSTEM',
-        team: defendingTeam,
-        text: data.defense.text,
-        createdAt: new Date(),
-        type: 'defense'
-      };
-      useBattleStore.getState().addChat(defenseChatMessage);
+      const target = pickEntry(data.defense, selectedTeam);
+      if (target) {
+        showEffect(target.team, target.entry.text ?? '', 'defense');
+        pushTimelineAndChat(data.battleId, target.team, target.entry, 'defense');
+      }
     };
 
     socket.on('battle:attacked', handleAttacked);

--- a/frontend/src/pages/battlePage/utils/battlePhase.ts
+++ b/frontend/src/pages/battlePage/utils/battlePhase.ts
@@ -1,57 +1,33 @@
-import type { BattlePhase, Team, TurnStatus } from '@/commons/types/battle';
+import type { BattlePhase, Team } from '@/commons/types/battle';
 import BattleIcon from '@/assets/icon/battle.svg?react';
 import ShieldIcon from '@/assets/icon/shield.svg?react';
 
 export const isMyTeamAttacking = (team: Team, phase?: BattlePhase): boolean => {
   if (!phase) return false;
-  return (team === 'A' && phase === 'TEAM_A_ATTACK') || (team === 'B' && phase === 'TEAM_B_ATTACK');
+  return phase === 'ATTACK' && team !== 'NONE';
 };
 
-export const isInputDisabled = (
-  team: Team,
-  phase?: BattlePhase,
-  turnStatus?: TurnStatus | null,
-  disabled = false
-): boolean => {
+export const isInputDisabled = (team: Team, phase?: BattlePhase, disabled = false): boolean => {
   if (disabled) return true;
   if (!phase) return true;
 
-  // OPINION_SHARE, TEAM_SWITCH 단계에서는 무조건 비활성화
-  if (phase === 'OPINION_SHARE' || phase === 'TEAM_SWITCH') return true;
+  // 공격/방어 페이즈가 아니면 입력 불가
+  if (phase !== 'ATTACK' && phase !== 'DEFENSE') return true;
+  if (team === 'NONE') return true;
 
-  // 턴 정보가 없으면 비활성화
-  if (!turnStatus) return true;
-
-  // TEAM_A_ATTACK 페이즈
-  if (phase === 'TEAM_A_ATTACK') {
-    if (team === 'A') {
-      // A팀: A_ATTACK 턴일 때만 이의제기 가능
-      return turnStatus !== 'A_ATTACK';
-    } else if (team === 'B') {
-      // B팀: B_DEFENSE 턴일 때만 반론 가능
-      return turnStatus !== 'B_DEFENSE';
-    }
-  }
-
-  // TEAM_B_ATTACK 페이즈
-  if (phase === 'TEAM_B_ATTACK') {
-    if (team === 'B') {
-      // B팀: B_ATTACK 턴일 때만 이의제기 가능
-      return turnStatus !== 'B_ATTACK';
-    } else if (team === 'A') {
-      // A팀: A_DEFENSE 턴일 때만 반론 가능
-      return turnStatus !== 'A_DEFENSE';
-    }
-  }
-
-  return true;
+  return false;
 };
 
 export const getDiscussionConfig = (team: Team, phase?: BattlePhase) => {
-  const isAttacking = isMyTeamAttacking(team, phase);
+  const isAttacking = isMyTeamAttacking(team, phase) || phase === 'ATTACK';
 
   return {
-    placeholderText: isAttacking ? '상대 진영에 이의제기...' : '상대 진영에 반론...',
+    placeholderText:
+      phase === 'OPINION_SHARE'
+        ? '의견을 공유하세요...'
+        : isAttacking
+          ? '상대 진영에 이의제기...'
+          : '상대 진영에 반론...',
     buttonText: isAttacking ? '이의제기' : '반론',
     Icon: isAttacking ? BattleIcon : ShieldIcon,
     isAttacking

--- a/frontend/src/pages/battlePage/utils/getTurnInfo.ts
+++ b/frontend/src/pages/battlePage/utils/getTurnInfo.ts
@@ -1,66 +1,47 @@
-import type { BattlePhase, TurnStatus } from '@/commons/types/battle';
+import type { BattlePhase } from '@/commons/types/battle';
 
-interface TurnInfo {
+interface PhaseInfo {
   title: string;
   description: string;
 }
 
-export const getTurnInfo = (stage: string | null): TurnInfo => {
-  if (!stage) {
+export const getPhaseInfo = (phase: string | null): PhaseInfo => {
+  if (!phase) {
     return {
       title: '대기 중',
       description: '배틀이 시작되기를 기다리고 있습니다.'
     };
   }
 
-  const PHASE_MAP: Record<BattlePhase, TurnInfo> = {
+  const PHASE_MAP: Record<BattlePhase, PhaseInfo> = {
+    PENDING: {
+      title: '대기 중',
+      description: '배틀이 곧 시작됩니다.'
+    },
     OPINION_SHARE: {
-      title: '의견 공유 시간',
+      title: '의견 공유',
       description: '코드를 분석하고 팀원들과 의견을 나누세요.'
     },
-    TEAM_A_ATTACK: {
-      title: 'A팀 이의제기 시간',
-      description: 'A팀이 코드의 문제점을 지적하세요'
+    ATTACK: {
+      title: '이의제기',
+      description: '상대 코드의 문제점을 지적하세요.'
     },
-    TEAM_B_ATTACK: {
-      title: 'B팀 이의제기 시간',
-      description: 'B팀이 코드의 문제점을 지적하세요'
+    DEFENSE: {
+      title: '반론',
+      description: '이의제기에 대해 반론을 제시하세요.'
     },
     TEAM_SWITCH: {
-      title: '팀 변경 시간',
+      title: '팀 변경',
       description: '팀을 변경할 수 있는 시간입니다.'
     }
   };
 
-  const TURN_MAP: Record<TurnStatus, TurnInfo> = {
-    A_ATTACK: {
-      title: 'A팀 이의제기 시간',
-      description: 'A팀이 코드의 문제점을 지적하세요.'
-    },
-    B_ATTACK: {
-      title: 'B팀 이의제기 시간',
-      description: 'B팀이 코드의 문제점을 지적하세요.'
-    },
-    A_DEFENSE: {
-      title: 'A팀 반론 시간',
-      description: 'B팀의 이의제기에 반론하세요.'
-    },
-    B_DEFENSE: {
-      title: 'B팀 반론 시간',
-      description: 'A팀의 이의제기에 반론하세요.'
-    }
-  };
-
-  if (stage in TURN_MAP) {
-    return TURN_MAP[stage as TurnStatus];
-  }
-
-  if (stage in PHASE_MAP) {
-    return PHASE_MAP[stage as BattlePhase];
+  if (phase in PHASE_MAP) {
+    return PHASE_MAP[phase as BattlePhase];
   }
 
   return {
-    title: stage,
+    title: phase,
     description: '현재 진행 중인 단계입니다.'
   };
 };

--- a/frontend/src/pages/battlePage/utils/test/battlePhase.test.ts
+++ b/frontend/src/pages/battlePage/utils/test/battlePhase.test.ts
@@ -2,15 +2,19 @@ import { describe, it, expect } from 'vitest';
 import { isInputDisabled } from '../battlePhase';
 
 describe('입력 가능 조건 검증', () => {
-  it('A팀 공격 턴에 A팀은 입력 가능', () => {
-    expect(isInputDisabled('A', 'TEAM_A_ATTACK', 'A_ATTACK')).toBe(false);
+  it('ATTACK 페이즈에 팀 선택이 있으면 입력 가능', () => {
+    expect(isInputDisabled('A', 'ATTACK')).toBe(false);
   });
 
-  it('B팀 방어 턴에 B팀은 입력 가능', () => {
-    expect(isInputDisabled('B', 'TEAM_A_ATTACK', 'B_DEFENSE')).toBe(false);
+  it('DEFENSE 페이즈에 팀 선택이 있으면 입력 가능', () => {
+    expect(isInputDisabled('B', 'DEFENSE')).toBe(false);
   });
 
-  it('잘못된 턴에는 입력 불가', () => {
-    expect(isInputDisabled('B', 'TEAM_A_ATTACK', 'A_ATTACK')).toBe(true);
+  it('OPINION_SHARE에서는 입력 불가', () => {
+    expect(isInputDisabled('A', 'OPINION_SHARE')).toBe(true);
+  });
+
+  it('TEAM_SWITCH에서는 입력 불가', () => {
+    expect(isInputDisabled('A', 'TEAM_SWITCH')).toBe(true);
   });
 });

--- a/frontend/src/pages/battlePage/utils/test/getDiscussionConfig.test.ts
+++ b/frontend/src/pages/battlePage/utils/test/getDiscussionConfig.test.ts
@@ -3,32 +3,16 @@ import { getDiscussionConfig } from '../battlePhase';
 import type { Team, BattlePhase } from '@/commons/types/battle';
 
 describe('getDiscussionConfig', () => {
-  it('A팀이 공격 턴일 때 이의제기 설정 반환', () => {
-    const config = getDiscussionConfig('A' as Team, 'TEAM_A_ATTACK' as BattlePhase);
+  it('ATTACK 페이즈에는 이의제기 설정 반환', () => {
+    const config = getDiscussionConfig('A' as Team, 'ATTACK' as BattlePhase);
 
     expect(config.placeholderText).toBe('상대 진영에 이의제기...');
     expect(config.buttonText).toBe('이의제기');
     expect(config.isAttacking).toBe(true);
   });
 
-  it('A팀이 방어 턴일 때 반론 설정 반환', () => {
-    const config = getDiscussionConfig('A' as Team, 'TEAM_B_ATTACK' as BattlePhase);
-
-    expect(config.placeholderText).toBe('상대 진영에 반론...');
-    expect(config.buttonText).toBe('반론');
-    expect(config.isAttacking).toBe(false);
-  });
-
-  it('B팀이 공격 턴일 때 이의제기 설정 반환', () => {
-    const config = getDiscussionConfig('B' as Team, 'TEAM_B_ATTACK' as BattlePhase);
-
-    expect(config.placeholderText).toBe('상대 진영에 이의제기...');
-    expect(config.buttonText).toBe('이의제기');
-    expect(config.isAttacking).toBe(true);
-  });
-
-  it('B팀이 방어 턴일 때 반론 설정 반환', () => {
-    const config = getDiscussionConfig('B' as Team, 'TEAM_A_ATTACK' as BattlePhase);
+  it('DEFENSE 페이즈에는 반론 설정 반환', () => {
+    const config = getDiscussionConfig('A' as Team, 'DEFENSE' as BattlePhase);
 
     expect(config.placeholderText).toBe('상대 진영에 반론...');
     expect(config.buttonText).toBe('반론');


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->
Closes #109 

## ✅ 작업 내용

  - FE  턴 없이 페이즈만 흐름에 맞춰 수정
      - 타입에서 TurnStatus/turn 필드를 제거하고 BattlePhase를 PENDING | OPINION_SHARE | ATTACK | DEFENSE | TEAM_SWITCH로 재정의.
      - 진행 상태/소켓: useBattleSocket·useBattleProgress가 phase/round 업데이트만 구독·반영하도록 단순화, 초기 투표 동기화도 ATTACK/DEFENSE만 대상으로 변경.
      - 입력/투표: isInputDisabled/getDiscussionConfig를 phase 기반으로 변경, Discussion 입력·투표 훅/컴포넌트에서 turn 의존 제거.
      - 상태 표시: getPhaseInfo와 StatusCard/BattleHeader가 phase만 표시하도록 변경.
      - 타임라인/이펙트: turn 제거하고 사용자 팀 기준으로 공격/방어 이펙트를 표시
  - 테스트 수정


### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

이후 BE 배틀 변경 브랜치와 통합 후 merge할 예정입니다.

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
