### PR TITLE
[Fix] join 이벤트 발생 시 중립 진영 수 반환

### DIFF
--- a/backend/src/battles/dto/battleJoinResponse.dto.ts
+++ b/backend/src/battles/dto/battleJoinResponse.dto.ts
@@ -6,6 +6,7 @@ export class BattleJoinResponseDto {
   counts: {
     teamA: number
     teamB: number
+    teamNone: number
   }
 
   // 배틀 전체 타임라인 & 채팅
@@ -29,13 +30,14 @@ export class BattleJoinResponseDto {
 
   static fromEntity(payload: ActiveBattleState, team: string): BattleJoinResponseDto {
     const res = new BattleJoinResponseDto()
-    const { all, teamA, teamB, round, phase, turn, startedAt, expiredAt } = payload
+    const { all, teamA, teamB, participants, round, phase, turn, startedAt, expiredAt } = payload
     const myTeam = team === BATTLE_TEAM.A ? teamA : team === BATTLE_TEAM.B ? teamB : all
 
     res.battleId = payload.battleId
     res.counts = {
       teamA: teamA.users.length,
       teamB: teamB.users.length,
+      teamNone: participants.size - (teamA.users.length + teamB.users.length),
     }
     res.timelines = {
       attacks: all.attacks,

--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -46,6 +46,7 @@ export interface BattleJoinData {
   counts: {
     teamA: number;
     teamB: number;
+    teamNone: number;
   };
   timelines: {
     attacks: BattleDiscussion[];

--- a/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
+++ b/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
@@ -6,20 +6,19 @@ import { useBattleTimer } from '../../hooks/useBattleTimer';
 export default function BattleHeader() {
   const currentStage = useBattleStore(selectCurrentStage);
   const battleProgress = useBattleStore(selectBattleProgress);
-  const { teamACount, teamBCount } = useBattleStore(selectTeamCounts);
+  const { teamACount, teamBCount, teamNoneCount } = useBattleStore(selectTeamCounts);
 
   const { formattedTime } = useBattleTimer({
     expiredAt: battleProgress?.expiredAt
   });
 
   const status = currentStage || 'END';
-  const teamNoneCounts = 0;
   return (
     <header className="bg-[#1E1E2F] px-8 py-6 rounded-lg mb-2">
       <div className="flex justify-between">
         <div className="flex items-center gap-4">
           <StatusCard turn={status} timer={formattedTime} />
-          <VoteStatus teamACounts={teamACount} teamBCounts={teamBCount} teamNoneCounts={teamNoneCounts} />
+          <VoteStatus teamACounts={teamACount} teamBCounts={teamBCount} teamNoneCounts={teamNoneCount} />
         </div>
       </div>
     </header>

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -55,7 +55,11 @@ export function useBattleSocket() {
       }
 
       // 팀 인원 수, 타임라인, 채팅 데이터 store에 저장
-      setTeamCounts({ teamACount: data.counts.teamA, teamBCount: data.counts.teamB });
+      setTeamCounts({
+        teamACount: data.counts.teamA,
+        teamBCount: data.counts.teamB,
+        teamNoneCount: data.counts.teamNone
+      });
       setTimelines(data.timelines);
       setTeamChats(data.chats || []);
       setAllChats(data.allChats || []);

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -21,6 +21,7 @@ interface BattleStore {
   teamCounts: {
     teamACount: number;
     teamBCount: number;
+    teamNoneCount: number;
   };
   timelines: {
     attacks: BattleDiscussion[];
@@ -39,7 +40,7 @@ interface BattleStore {
   setDiscussions: (discussions: BattleStore['discussions']) => void;
   addDiscussion: (discussion: BattleStore['discussions'][0]) => void;
   updateDiscussionVote: (discussionId: string, upvotes: number, votes: string[], userId: string) => void;
-  setTeamCounts: (counts: { teamACount: number; teamBCount: number }) => void;
+  setTeamCounts: (counts: { teamACount: number; teamBCount: number; teamNoneCount: number }) => void;
   setTimelines: (timelines: { attacks: BattleDiscussion[]; defenses: BattleDefense[] }) => void;
   addAttackTimeline: (attack: BattleDiscussion) => void;
   addDefenseTimeline: (defense: BattleDefense) => void;
@@ -57,7 +58,7 @@ export const useBattleStore = create<BattleStore>((set) => ({
   currentStage: null,
   battleProgress: null,
   discussions: [],
-  teamCounts: { teamACount: 0, teamBCount: 0 },
+  teamCounts: { teamACount: 0, teamBCount: 0, teamNoneCount: 0 },
   timelines: null,
   teamChats: [],
   allChats: [],


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

resolve #8

## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->
- `BattleJoinResponseDto`에 teamNone 숫자 반환
- frontend에서 중립 진영 수 연동

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->
<img width="50%" alt="스크린샷 2026-01-08 131940" src="https://github.com/user-attachments/assets/7f18967b-2317-4096-b4c0-65d8f823ba27" />

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
