### PR TITLE
[Feature] 배틀 참여자 및 진영 인원 업데이트 이벤트 추가

### DIFF
--- a/backend/src/battles/dto/battleTeamUpdateAllResponse.dto.ts
+++ b/backend/src/battles/dto/battleTeamUpdateAllResponse.dto.ts
@@ -1,0 +1,65 @@
+import { BATTLE_TEAM } from '../const/battles.const'
+import type { BattleTeam } from '../types/battles.types'
+
+export interface TeamCounts {
+  teamA: number
+  teamB: number
+  teamNone: number
+}
+
+export interface TeamChange {
+  clientId: string
+  from: BattleTeam
+  to: BattleTeam
+}
+
+export class BattleTeamUpdateAllResponseDto {
+  battleId: string
+  round: number
+
+  // 변경 전 인원 수
+  before: TeamCounts
+
+  // 변경 후 인원 수
+  after: TeamCounts
+
+  // 각 클라이언트의 팀 변경 정보 (소켓 룸 이동용)
+  changes: TeamChange[]
+
+  // 변화량 (after - before)
+  difference: {
+    teamA: number
+    teamB: number
+    teamNone: number
+  }
+
+  // 우세한 팀
+  dominantTeam: BattleTeam | null
+
+  static of(battleId: string, round: number, before: TeamCounts, after: TeamCounts, changes: TeamChange[]): BattleTeamUpdateAllResponseDto {
+    const res = new BattleTeamUpdateAllResponseDto()
+    res.battleId = battleId
+    res.round = round
+    res.before = before
+    res.after = after
+    res.changes = changes
+
+    // 변화량 계산
+    res.difference = {
+      teamA: after.teamA - before.teamA,
+      teamB: after.teamB - before.teamB,
+      teamNone: after.teamNone - before.teamNone,
+    }
+
+    // 우세한 팀 판단
+    if (after.teamA > after.teamB) {
+      res.dominantTeam = BATTLE_TEAM.A
+    } else if (after.teamB > after.teamA) {
+      res.dominantTeam = BATTLE_TEAM.B
+    } else {
+      res.dominantTeam = null //동점
+    }
+
+    return res
+  }
+}

--- a/backend/src/battles/dto/battleUserUpdateResponse.dto.ts
+++ b/backend/src/battles/dto/battleUserUpdateResponse.dto.ts
@@ -1,0 +1,20 @@
+export interface TeamCounts {
+  teamA: number
+  teamB: number
+  teamNone: number
+}
+
+export class BattleUserUpdateResponseDto {
+  battleId: string
+
+  totalCount: number
+  counts: TeamCounts
+
+  static of(battleId: string, counts: TeamCounts) {
+    const res = new BattleUserUpdateResponseDto()
+    res.battleId = battleId
+    res.counts = counts
+    res.totalCount = counts.teamA + counts.teamB + counts.teamNone
+    return res
+  }
+}

--- a/backend/src/battles/gateway/battles.gateway.spec.ts
+++ b/backend/src/battles/gateway/battles.gateway.spec.ts
@@ -11,6 +11,8 @@ import { BATTLE_TEAM, BATTLE_DISCUSSION_TYPE } from '../const/battles.const'
 import { BattleDiscussion, BattleDefense } from '../types/battles.types'
 
 import { DiscussionVoteResponseDto } from '../dto/discussionVoteResponse.dto'
+import { BattleUserUpdateResponseDto } from '../dto/battleUserUpdateResponse.dto'
+import { BattleTeamUpdateAllResponseDto } from '../dto/battleTeamUpdateAllResponse.dto'
 
 describe('BattlesGateway - Discussion Events', () => {
   let gateway: BattlesGateway
@@ -30,6 +32,8 @@ describe('BattlesGateway - Discussion Events', () => {
             handleAttackVote: jest.fn(),
             handleDefenseVote: jest.fn(),
             getBattleRoomId: jest.fn(),
+            on: jest.fn(),
+            emit: jest.fn(),
           },
         },
       ],
@@ -225,6 +229,77 @@ describe('BattlesGateway - Discussion Events', () => {
 
       expect(mockServer.to).toHaveBeenCalledWith('battle-1:B')
       expect(mockServer.emit).toHaveBeenCalledWith('battle:defense:voted', mockResponse)
+    })
+  })
+
+  describe('battle:user:updated', () => {
+    it('사용자 업데이트 이벤트를 배틀 룸에 브로드캐스트한다', () => {
+      const payload = BattleUserUpdateResponseDto.of('battle-1', {
+        teamA: 5,
+        teamB: 3,
+        teamNone: 2,
+      })
+
+      jest.spyOn(service, 'getBattleRoomId').mockReturnValue('battle:battle-1')
+
+      gateway.userUpdate(payload)
+
+      expect(service.getBattleRoomId).toHaveBeenCalledWith('battle-1')
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockServer.emit).toHaveBeenCalledWith('battle:user:updated', payload)
+    })
+  })
+
+  describe('battle:all:updated', () => {
+    it('팀 변경 이벤트를 배틀 룸에 브로드캐스트한다', () => {
+      const mockSocket1 = {
+        id: 'socket-1',
+        leave: jest.fn(),
+        join: jest.fn(),
+        emit: jest.fn(),
+      }
+      const mockSocket2 = {
+        id: 'socket-2',
+        leave: jest.fn(),
+        join: jest.fn(),
+        emit: jest.fn(),
+      }
+
+      mockServer.sockets = {
+        sockets: new Map([
+          ['client-1', mockSocket1],
+          ['client-2', mockSocket2],
+        ]),
+      }
+
+      const payload = BattleTeamUpdateAllResponseDto.of('battle-1', 1, { teamA: 5, teamB: 3, teamNone: 2 }, { teamA: 4, teamB: 4, teamNone: 2 }, [
+        { clientId: 'client-1', from: BATTLE_TEAM.A, to: BATTLE_TEAM.B },
+        { clientId: 'client-2', from: BATTLE_TEAM.B, to: BATTLE_TEAM.A },
+      ])
+
+      jest.spyOn(service, 'getBattleRoomId').mockImplementation((battleId, team) => {
+        if (!team) return `battle:${battleId}`
+        return `battle:${battleId}:${team}`
+      })
+
+      gateway.teamUpdate(payload)
+
+      expect(mockSocket1.leave).toHaveBeenCalledWith('battle:battle-1:A')
+      expect(mockSocket1.join).toHaveBeenCalledWith('battle:battle-1:B')
+      expect(mockSocket1.emit).toHaveBeenCalledWith('battle:team:updated', {
+        battleId: 'battle-1',
+        team: BATTLE_TEAM.B,
+      })
+
+      expect(mockSocket2.leave).toHaveBeenCalledWith('battle:battle-1:B')
+      expect(mockSocket2.join).toHaveBeenCalledWith('battle:battle-1:A')
+      expect(mockSocket2.emit).toHaveBeenCalledWith('battle:team:updated', {
+        battleId: 'battle-1',
+        team: BATTLE_TEAM.A,
+      })
+
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockServer.emit).toHaveBeenCalledWith('battle:all:updated', payload)
     })
   })
 })

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -248,7 +248,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     }
   }
 
-  private teamUpdate(payload: BattleTeamUpdateAllResponseDto) {
+  teamUpdate(payload: BattleTeamUpdateAllResponseDto) {
     const battleRoomId = this.battlesService.getBattleRoomId(payload.battleId)
 
     // 각 클라이언트의 소켓 룸 이동 및 개별 알림

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -21,6 +21,7 @@ import { DiscussionVoteResultDto } from '../dto/discussionVoteResult.dto'
 import { BattleTeamVoteDto } from '../dto/battleTeamVote.dto'
 import { BattleClosedResponseDto } from '../dto/battleClosedResponse.dto'
 import { BattleTeamUpdateAllResponseDto } from '../dto/battleTeamUpdateAllResponse.dto'
+import { BattleUserUpdateResponseDto } from '../dto/battleUserUpdateResponse.dto'
 
 @WebSocketGateway()
 export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect, OnModuleInit {
@@ -191,6 +192,13 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     rooms.forEach(room => this.server.in(room).disconnectSockets(true))
   }
 
+  userUpdate(payload: BattleUserUpdateResponseDto) {
+    const { battleId } = payload
+    const battleRoomId = this.battlesService.getBattleRoomId(battleId)
+
+    this.server.to(battleRoomId).emit('battle:user:update', payload)
+  }
+
   private bindBattleEvents() {
     this.battlesService.on('battle:phase:updated', (payload: BattlePhaseResponseDto) => this.phaseUpdate(payload))
 
@@ -202,6 +210,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
     this.battlesService.on('battle:team:update', (payload: BattleTeamUpdateAllResponseDto) => this.teamUpdate(payload))
 
+    this.battlesService.on('battle:user:update', (payload: BattleUserUpdateResponseDto) => this.userUpdate(payload))
     // this.battlesService.on('battle:ended', payload => {
     //   const { battleId } = payload
     //   this.server.to(`battle:${battleId}`).emit('battle:ended', payload)

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -19,8 +19,8 @@ import { BattleChatDto } from '../dto/battleChat.dto'
 import { BATTLE_CHAT_SCOPE } from '../const/battles.const'
 import { DiscussionVoteResultDto } from '../dto/discussionVoteResult.dto'
 import { BattleTeamVoteDto } from '../dto/battleTeamVote.dto'
-import type { BattleTeam } from '../types/battles.types'
 import { BattleClosedResponseDto } from '../dto/battleClosedResponse.dto'
+import { BattleTeamUpdateAllResponseDto } from '../dto/battleTeamUpdateAllResponse.dto'
 
 @WebSocketGateway()
 export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect, OnModuleInit {
@@ -199,14 +199,8 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     this.battlesService.on('battle:attacked', (payload: DiscussionVoteResultDto) => this.onAttacked(payload))
 
     this.battlesService.on('battle:defensed', (payload: DiscussionVoteResultDto) => this.onDefensed(payload))
-    this.battlesService.on(
-      'battle:team:update',
-      (payload: {
-        battleId: string
-        changes: Array<{ clientId: string; from: BattleTeam; to: BattleTeam }>
-        counts: { teamA: number; teamB: number; none: number }
-      }) => this.teamUpdate(payload),
-    )
+
+    this.battlesService.on('battle:team:update', (payload: BattleTeamUpdateAllResponseDto) => this.teamUpdate(payload))
 
     // this.battlesService.on('battle:ended', payload => {
     //   const { battleId } = payload
@@ -245,13 +239,10 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     }
   }
 
-  private teamUpdate(payload: {
-    battleId: string
-    changes: Array<{ clientId: string; from: BattleTeam; to: BattleTeam }>
-    counts: { teamA: number; teamB: number; none: number }
-  }) {
+  private teamUpdate(payload: BattleTeamUpdateAllResponseDto) {
     const battleRoomId = this.battlesService.getBattleRoomId(payload.battleId)
 
+    // 각 클라이언트의 소켓 룸 이동 및 개별 알림
     for (const change of payload.changes) {
       const socket = this.server.sockets.sockets.get(change.clientId)
       if (!socket) continue

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -196,7 +196,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     const { battleId } = payload
     const battleRoomId = this.battlesService.getBattleRoomId(battleId)
 
-    this.server.to(battleRoomId).emit('battle:user:update', payload)
+    this.server.to(battleRoomId).emit('battle:user:updated', payload)
   }
 
   private bindBattleEvents() {
@@ -208,9 +208,9 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
     this.battlesService.on('battle:defensed', (payload: DiscussionVoteResultDto) => this.onDefensed(payload))
 
-    this.battlesService.on('battle:team:update', (payload: BattleTeamUpdateAllResponseDto) => this.teamUpdate(payload))
+    this.battlesService.on('battle:team:updated', (payload: BattleTeamUpdateAllResponseDto) => this.teamUpdate(payload))
 
-    this.battlesService.on('battle:user:update', (payload: BattleUserUpdateResponseDto) => this.userUpdate(payload))
+    this.battlesService.on('battle:user:updated', (payload: BattleUserUpdateResponseDto) => this.userUpdate(payload))
     // this.battlesService.on('battle:ended', payload => {
     //   const { battleId } = payload
     //   this.server.to(`battle:${battleId}`).emit('battle:ended', payload)
@@ -261,9 +261,9 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
       void socket.leave(fromRoom)
       void socket.join(toRoom)
-      socket.emit('battle:team:update', { battleId: payload.battleId, team: change.to })
+      socket.emit('battle:team:updated', { battleId: payload.battleId, team: change.to })
     }
 
-    this.server.to(battleRoomId).emit('battle:team:update:all', payload)
+    this.server.to(battleRoomId).emit('battle:all:updated', payload)
   }
 }

--- a/backend/src/battles/service/battles.service.spec.ts
+++ b/backend/src/battles/service/battles.service.spec.ts
@@ -105,6 +105,31 @@ describe('BattlesService', () => {
       expect(state.teamB.users).toContain('client-2')
       expect(state.teamA.users).not.toContain('client-2')
     })
+
+    it('중립 팀에 참가자를 추가한다', () => {
+      service['addParticipant']('battle-1', 'client-3', BATTLE_TEAM.NONE)
+
+      const state = service['activeBattles'].get('battle-1')!
+      expect(state.teamA.users).not.toContain('client-3')
+      expect(state.teamB.users).not.toContain('client-3')
+      expect(state.participants.get('client-3')).toBe(BATTLE_TEAM.NONE)
+    })
+
+    it('참가자 추가 시 teamNoneCount가 올바르게 계산된다', () => {
+      service['addParticipant']('battle-1', 'client-a1', BATTLE_TEAM.A)
+      service['addParticipant']('battle-1', 'client-b1', BATTLE_TEAM.B)
+      service['addParticipant']('battle-1', 'client-none1', BATTLE_TEAM.NONE)
+      service['addParticipant']('battle-1', 'client-none2', BATTLE_TEAM.NONE)
+
+      const state = service['activeBattles'].get('battle-1')!
+      const totalParticipants = state.participants.size
+      const teamA = state.teamA.users.length
+      const teamB = state.teamB.users.length
+      const teamNone = totalParticipants - teamA - teamB
+
+      expect(teamNone).toBe(2)
+      expect(state.participants.size).toBe(4)
+    })
   })
 
   describe('getBattleRoomId', () => {
@@ -367,6 +392,47 @@ describe('BattlesService', () => {
       expect(state.teamA.users).not.toContain('client-1')
       expect(state.teamB.users).toContain('client-1')
     })
+
+    it('TEAM_SWITCH 종료 시 팀 변경 후 teamCount가 올바르게 계산된다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.TEAM_SWITCH.name
+
+      expect(state.teamA.users.length).toBe(1)
+      expect(state.teamB.users.length).toBe(0)
+      expect(state.participants.size).toBe(1)
+
+      service['addParticipant']('battle-1', 'client-none', BATTLE_TEAM.NONE)
+
+      const beforeTotal = state.participants.size // 2명
+      const beforeTeamA = state.teamA.users.length // 1명
+      const beforeTeamB = state.teamB.users.length // 0명
+      const beforeTeamNone = beforeTotal - beforeTeamA - beforeTeamB // 2 - 1 - 0 = 1
+
+      expect(beforeTeamNone).toBe(1)
+      expect(state.participants.get('client-none')).toBe(BATTLE_TEAM.NONE)
+
+      // A팀에서 B팀으로 변경
+      service.voteTeam(
+        {
+          battleId: 'battle-1',
+          team: BATTLE_TEAM.B,
+        },
+        'client-1',
+      )
+
+      service['updatePhase']('battle-1')
+
+      const afterTotal = state.participants.size
+      const afterTeamA = state.teamA.users.length // 0명
+      const afterTeamB = state.teamB.users.length // 1명
+      const afterTeamNone = afterTotal - afterTeamA - afterTeamB // 2 - 0 - 1 = 1
+
+      expect(afterTeamNone).toBe(beforeTeamNone)
+      expect(afterTeamA).toBe(0)
+      expect(afterTeamB).toBe(1)
+      expect(state.participants.get('client-1')).toBe(BATTLE_TEAM.B)
+      expect(state.participants.get('client-none')).toBe(BATTLE_TEAM.NONE)
+    })
   })
 
   describe('getOpenBattles', () => {
@@ -612,7 +678,7 @@ describe('BattlesService', () => {
     })
 
     it('정상적으로 공격 이의제기에 투표한다', () => {
-      const attack = service['activeBattles'].get('battle-1')!.teamA.attacks[0]
+      const attack = service['activeBattles'].get('battle-1')!.teamA.attacks[0]!
 
       const result = service.handleAttackVote('battle-1', attack.discussionId, {
         userId: 'voter-1',
@@ -629,7 +695,7 @@ describe('BattlesService', () => {
     })
 
     it('같은 유저가 중복 투표하면 BadRequestException', () => {
-      const attack = service['activeBattles'].get('battle-1')!.teamA.attacks[0]
+      const attack = service['activeBattles'].get('battle-1')!.teamA.attacks[0]!
 
       service.handleAttackVote('battle-1', attack.discussionId, {
         userId: 'voter-1',
@@ -645,7 +711,7 @@ describe('BattlesService', () => {
     })
 
     it('중립 진영은 투표할 수 없다', () => {
-      const attack = service['activeBattles'].get('battle-1')!.teamA.attacks[0]
+      const attack = service['activeBattles'].get('battle-1')!.teamA.attacks[0]!
 
       expect(() =>
         service.handleAttackVote('battle-1', attack.discussionId, {
@@ -658,7 +724,7 @@ describe('BattlesService', () => {
     it('현재 수비 페이즈가 아니면 공격 페이즈에 관해 BadRequestException', () => {
       const state = service['activeBattles'].get('battle-1')!
 
-      const attack = state.teamA.attacks[0]
+      const attack = state.teamA.attacks[0]!
 
       expect(() =>
         service.handleDefenseVote('battle-1', attack.discussionId, {

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -325,7 +325,7 @@ export class BattlesService extends EventEmitter {
       teamNone: battleState.participants.size - (battleState.teamA.users.length + battleState.teamB.users.length),
     }
 
-    this.emit('battle:user:update', BattleUserUpdateResponseDto.of(battleId, counts))
+    this.emit('battle:user:updated', BattleUserUpdateResponseDto.of(battleId, counts))
   }
 
   private rebuildTeamUsers(state: ActiveBattleState) {
@@ -464,7 +464,7 @@ export class BattlesService extends EventEmitter {
     }
 
     if (changes.length) {
-      this.emit('battle:team:update', BattleTeamUpdateAllResponseDto.of(state.battleId, state.round, beforeCounts, afterCounts, changes))
+      this.emit('battle:team:updated', BattleTeamUpdateAllResponseDto.of(state.battleId, state.round, beforeCounts, afterCounts, changes))
     }
   }
 

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -37,6 +37,7 @@ import { BattlePhaseResponseDto, BattleRoundResponseDto } from '../dto/battleTur
 import { DiscussionVoteResponseDto } from '../dto/discussionVoteResponse.dto'
 import { DiscussionVoteResultDto } from '../dto/discussionVoteResult.dto'
 import { BattleClosedResponseDto } from '../dto/battleClosedResponse.dto'
+import { BattleTeamUpdateAllResponseDto } from '../dto/battleTeamUpdateAllResponse.dto'
 
 @Injectable()
 export class BattlesService extends EventEmitter {
@@ -427,6 +428,13 @@ export class BattlesService extends EventEmitter {
   private applyTeamVotes(state: ActiveBattleState) {
     const changes: Array<{ clientId: string; from: BattleTeam; to: BattleTeam }> = []
 
+    // 변경 전 인원 수 저장
+    const beforeCounts = {
+      teamA: state.teamA.users.length,
+      teamB: state.teamB.users.length,
+      teamNone: [...state.participants.values()].filter(t => t === BATTLE_TEAM.NONE).length,
+    }
+
     for (const [clientId, desiredTeam] of state.teamVotes.entries()) {
       const currentTeam = state.participants.get(clientId)
       if (!currentTeam) continue
@@ -439,16 +447,15 @@ export class BattlesService extends EventEmitter {
     state.teamVotes.clear()
     this.rebuildTeamUsers(state)
 
+    //변경 후 인원 수
+    const afterCounts = {
+      teamA: state.teamA.users.length,
+      teamB: state.teamB.users.length,
+      teamNone: state.participants.size - (state.teamA.users.length + state.teamB.users.length),
+    }
+
     if (changes.length) {
-      this.emit('battle:team:update', {
-        battleId: state.battleId,
-        changes,
-        counts: {
-          teamA: state.teamA.users.length,
-          teamB: state.teamB.users.length,
-          none: [...state.participants.values()].filter(t => t === BATTLE_TEAM.NONE).length,
-        },
-      })
+      this.emit('battle:team:update', BattleTeamUpdateAllResponseDto.of(state.battleId, state.round, beforeCounts, afterCounts, changes))
     }
   }
 

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -38,6 +38,7 @@ import { DiscussionVoteResponseDto } from '../dto/discussionVoteResponse.dto'
 import { DiscussionVoteResultDto } from '../dto/discussionVoteResult.dto'
 import { BattleClosedResponseDto } from '../dto/battleClosedResponse.dto'
 import { BattleTeamUpdateAllResponseDto } from '../dto/battleTeamUpdateAllResponse.dto'
+import { BattleUserUpdateResponseDto } from '../dto/battleUserUpdateResponse.dto'
 
 @Injectable()
 export class BattlesService extends EventEmitter {
@@ -317,6 +318,14 @@ export class BattlesService extends EventEmitter {
 
     battleState.participants.set(clientId, team as BattleTeam)
     this.rebuildTeamUsers(battleState)
+
+    const counts = {
+      teamA: battleState.teamA.users.length,
+      teamB: battleState.teamB.users.length,
+      teamNone: battleState.participants.size - (battleState.teamA.users.length + battleState.teamB.users.length),
+    }
+
+    this.emit('battle:user:update', BattleUserUpdateResponseDto.of(battleId, counts))
   }
 
   private rebuildTeamUsers(state: ActiveBattleState) {


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->
resolve #116

## ✅ 작업 내용


### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->
- `battle:user:update`
  - 새로운 참여자 접속 시 배틀 룸에 참여 중인 클라이언트에게 브로드캐스트

- `battle:team:update:all`
  - `before/after`: 진영 변경 전 / 후 각 팀 인원 수 전달
  - `difference` 배열: 변경된 인원 정보(이동한 인원 수) 전달
  - `dominantTeam` : 우세한 팀 정보 전달 
<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->
| user update |  team:update:all |
|--|--|
| <img width="600" height="321" alt="Image" src="https://github.com/user-attachments/assets/174e89f1-6bf9-4ab5-a343-6060d4477c5d" /> |<img width="655" height="516" alt="Image" src="https://github.com/user-attachments/assets/662e8794-3dc0-4784-b424-097fbadd9d9a" /> |
<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->

테스트 코드의 충돌 가능성이 높아,  우선 기능 위주로 머지 후 테스트 코드는 순차적으로 정리하려고 합니다.  
