### PR TITLE
[Feature] 클라이언트에서 배틀 인원수 실시간 업데이트 소켓 이벤트 구독

### DIFF
--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -39,14 +39,23 @@ export interface BattleDefense extends BattleDiscussion {
   attackId: string;
 }
 
+// Socket 이벤트 응답 타입 (공통)
+export interface TeamCounts {
+  teamA: number;
+  teamB: number;
+  teamNone: number;
+}
+
+export interface TeamChange {
+  clientId: string;
+  from: Team;
+  to: Team;
+}
+
 // BattleJoinResponseDto 타입
 export interface BattleJoinData {
   battleId: string;
-  counts: {
-    teamA: number;
-    teamB: number;
-    teamNone: number;
-  };
+  counts: TeamCounts;
   timelines: {
     attacks: BattleDiscussion[];
     defenses: BattleDefense[];
@@ -105,3 +114,25 @@ export interface BattleDefensedResult {
 
 // 이펙트 타입
 export type BattleEffectType = 'OBJECTION' | 'REVERSAL' | 'SURRENDER';
+
+// battle:user:update 이벤트 응답
+export interface BattleUserUpdateResponse {
+  battleId: string;
+  totalCount: number;
+  counts: TeamCounts;
+}
+
+// battle:team:update:all 이벤트 응답
+export interface BattleTeamUpdateAllResponse {
+  battleId: string;
+  round: number;
+  before: TeamCounts;
+  after: TeamCounts;
+  changes: TeamChange[];
+  difference: {
+    teamA: number;
+    teamB: number;
+    teamNone: number;
+  };
+  dominantTeam: Team | null;
+}

--- a/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
+++ b/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
@@ -6,7 +6,7 @@ import { useBattleTimer } from '../../hooks/useBattleTimer';
 export default function BattleHeader() {
   const currentStage = useBattleStore(selectCurrentStage);
   const battleProgress = useBattleStore(selectBattleProgress);
-  const { teamACount, teamBCount, teamNoneCount } = useBattleStore(selectTeamCounts);
+  const { teamACount, teamBCount, none } = useBattleStore(selectTeamCounts);
 
   const { formattedTime } = useBattleTimer({
     expiredAt: battleProgress?.expiredAt
@@ -18,7 +18,7 @@ export default function BattleHeader() {
       <div className="flex justify-between">
         <div className="flex items-center gap-4">
           <StatusCard turn={status} timer={formattedTime} />
-          <VoteStatus teamACounts={teamACount} teamBCounts={teamBCount} teamNoneCounts={teamNoneCount} />
+          <VoteStatus teamACounts={teamACount} teamBCounts={teamBCount} teamNoneCounts={none} />
         </div>
       </div>
     </header>

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -53,7 +53,7 @@ export function useBattleSocket() {
       setTeamCounts({
         teamACount: data.counts.teamA,
         teamBCount: data.counts.teamB,
-        teamNoneCount: data.counts.teamNone
+        none: data.counts.teamNone
       });
       setTimelines(data.timelines);
       setTeamChats(data.chats || []);

--- a/frontend/src/pages/battlePage/hooks/useBattleTeam.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTeam.ts
@@ -63,10 +63,10 @@ export function useBattleTeam({ onOpenTeamChangeModal, onCloseTeamChangeModal }:
       );
     };
 
-    socket.on('battle:user:update', handleUserUpdate);
+    socket.on('battle:user:updated', handleUserUpdate);
 
     return () => {
-      socket.off('battle:user:update', handleUserUpdate);
+      socket.off('battle:user:updated', handleUserUpdate);
     };
   }, [socket, setTeamCounts]);
 

--- a/frontend/src/pages/battlePage/hooks/useBattleTeam.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTeam.ts
@@ -6,6 +6,7 @@ import {
   selectSocket,
   selectBattleId
 } from '../stores/battleStore';
+import type { BattleUserUpdateResponse } from '@/commons/types/battle';
 
 interface UseBattleTeamProps {
   onOpenTeamChangeModal: () => void;
@@ -15,7 +16,7 @@ interface UseBattleTeamProps {
 export function useBattleTeam({ onOpenTeamChangeModal, onCloseTeamChangeModal }: UseBattleTeamProps) {
   const socket = useBattleStore(selectSocket);
   const battleId = useBattleStore(selectBattleId);
-  const { setSelectedTeam } = useBattleStore();
+  const { setSelectedTeam, setTeamCounts } = useBattleStore();
   const battleProgress = useBattleStore(selectBattleProgress);
   const selectedTeam = useBattleStore(selectSelectedTeam);
 
@@ -44,6 +45,30 @@ export function useBattleTeam({ onOpenTeamChangeModal, onCloseTeamChangeModal }:
       socket.off('battle:team:update', handleChangedTeam);
     };
   }, [socket, setSelectedTeam]);
+
+  // 새 참여자 입장 시 전체 인원 수 업데이트
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleUserUpdate = (data: BattleUserUpdateResponse) => {
+      if (data.battleId !== battleId) return;
+
+      setTeamCounts(
+        {
+          teamACount: data.counts.teamA,
+          teamBCount: data.counts.teamB,
+          none: data.counts.teamNone
+        },
+        data.totalCount
+      );
+    };
+
+    socket.on('battle:user:update', handleUserUpdate);
+
+    return () => {
+      socket.off('battle:user:update', handleUserUpdate);
+    };
+  }, [socket, setTeamCounts]);
 
   // 팀 변경 요청
   const handleTeamChange = useCallback(

--- a/frontend/src/pages/battlePage/hooks/useTeamVoteResult.ts
+++ b/frontend/src/pages/battlePage/hooks/useTeamVoteResult.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { useBattleStore, selectSocket, selectBattleId } from '../stores/battleStore';
+import type { BattleTeamUpdateAllResponse } from '@/commons/types/battle';
+
+export function useTeamVoteResult() {
+  const socket = useBattleStore(selectSocket);
+  const battleId = useBattleStore(selectBattleId);
+  const { setTeamCounts } = useBattleStore();
+
+  const [voteResult, setVoteResult] = useState<BattleTeamUpdateAllResponse | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // battle:all:updated 이벤트 구독
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleTeamUpdateAll = (data: BattleTeamUpdateAllResponse) => {
+      if (data.battleId !== battleId) return;
+
+      // Store에 최종 인원 수 업데이트
+      setTeamCounts({
+        teamACount: data.after.teamA,
+        teamBCount: data.after.teamB,
+        none: data.after.teamNone
+      });
+
+      // 모달용 전체 데이터 저장
+      setVoteResult(data);
+      setIsModalOpen(true);
+    };
+
+    socket.on('battle:all:updated', handleTeamUpdateAll);
+
+    return () => {
+      socket.off('battle:all:updated', handleTeamUpdateAll);
+    };
+  }, [socket, battleId, setTeamCounts]);
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setVoteResult(null);
+  };
+
+  return {
+    voteResult,
+    isModalOpen,
+    closeModal
+  };
+}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -9,6 +9,7 @@ import DiscussionVote from './components/discussion/DiscussionVote';
 import BattleSidebar from './components/sidebar/BattleSidebar';
 import BookmarkButton from './components/sidebar/BookmarkButton';
 import { useBattle } from './hooks/useBattle';
+import { useTeamVoteResult } from './hooks/useTeamVoteResult';
 import useModal from '@/commons/hooks/useModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
 import DiscussionModal from './components/effects/DiscussionModal';
@@ -30,6 +31,10 @@ export default function BattlePage() {
     onOpenTeamChangeModal: handleOpenTeamChangeModal,
     onCloseTeamChangeModal: handleCloseTeamChangeModal
   });
+
+  // TODO: 진영 투표 결과 모달 추가 시 주석 해제
+  // const { voteResult, isModalOpen: isVoteResultModalOpen, closeModal: closeVoteResultModal } = useTeamVoteResult();
+  useTeamVoteResult(); // 이벤트 구독만 활성화
 
   return (
     <div className="text-white relative min-h-screen">

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -21,8 +21,9 @@ interface BattleStore {
   teamCounts: {
     teamACount: number;
     teamBCount: number;
-    teamNoneCount: number;
+    none: number;
   };
+  totalParticipants: number;
   timelines: {
     attacks: BattleDiscussion[];
     defenses: BattleDefense[];
@@ -40,7 +41,7 @@ interface BattleStore {
   setDiscussions: (discussions: BattleStore['discussions']) => void;
   addDiscussion: (discussion: BattleStore['discussions'][0]) => void;
   updateDiscussionVote: (discussionId: string, upvotes: number, votes: string[], userId: string) => void;
-  setTeamCounts: (counts: { teamACount: number; teamBCount: number; teamNoneCount: number }) => void;
+  setTeamCounts: (counts: { teamACount: number; teamBCount: number; none: number }, totalParticipants?: number) => void;
   setTimelines: (timelines: { attacks: BattleDiscussion[]; defenses: BattleDefense[] }) => void;
   addAttackTimeline: (attack: BattleDiscussion) => void;
   addDefenseTimeline: (defense: BattleDefense) => void;
@@ -58,7 +59,8 @@ export const useBattleStore = create<BattleStore>((set) => ({
   currentStage: null,
   battleProgress: null,
   discussions: [],
-  teamCounts: { teamACount: 0, teamBCount: 0, teamNoneCount: 0 },
+  teamCounts: { teamACount: 0, teamBCount: 0, none: 0 },
+  totalParticipants: 0,
   timelines: null,
   teamChats: [],
   allChats: [],
@@ -91,7 +93,11 @@ export const useBattleStore = create<BattleStore>((set) => ({
       };
     }),
 
-  setTeamCounts: (counts) => set({ teamCounts: counts }),
+  setTeamCounts: (counts, totalParticipants) =>
+    set({
+      teamCounts: counts,
+      totalParticipants: totalParticipants ?? counts.teamACount + counts.teamBCount
+    }),
   setTimelines: (timelines) => set({ timelines }),
   addAttackTimeline: (attack) =>
     set((state) => ({


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #121 
## 작업 내용

### 1. Socket 이벤트 타입 정의
- `TeamCounts`, `TeamChange` 공통 인터페이스 추가
- `BattleUserUpdateResponse`: battle:user:updated 이벤트 응답 타입
- `BattleTeamUpdateAllResponse`: battle:all:updated 이벤트 응답 타입

### 2. `battle:user:updated` 이벤트 구독
- 새 참여자 입장 시 실시간 인원 수 업데이트
- `battleId` 검증으로 다른 배틀 이벤트 필터링
- `totalParticipants` store 업데이트 추가

### 3. `battle:all:updated` 이벤트 구독
-  진영 투표 결과 전담 기능을 하는`useTeamVoteResult` 훅 생성
- 진영 투표 종료 후 전체 인원 수 동기화 (after 값)
- 진영 투표 결과 데이터 관리 (before, after, difference, dominantTeam, changes)

## 참고 사항
- 진영 투표 결과 모달은 TODO로 남김 (useTeamVoteResult 주석 해제 후 사용)
