### PR TITLE
[Feature] 배틀 생성 후 배틀 시작 버튼을 눌러 배틀을 시작하고 싶다

### DIFF
--- a/backend/src/battles/const/battles.const.ts
+++ b/backend/src/battles/const/battles.const.ts
@@ -24,6 +24,7 @@ export const BATTLE_PHASE = {
 export const BATTLE_MAX_PHASE_COUNT = 2
 
 export const BATTLE_STATUS = {
+  PENDING: 'PENDING',
   OPEN: 'OPEN',
   CLOSED: 'CLOSED',
 } as const

--- a/backend/src/battles/dto/battleStart.dto.ts
+++ b/backend/src/battles/dto/battleStart.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator'
+
+export class BattleStartDto {
+  @IsString()
+  @IsNotEmpty()
+  battleId: string
+
+  // @IsString()
+  // @IsNotEmpty()
+  // userId: string
+}

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -22,6 +22,7 @@ import { BattleTeamVoteDto } from '../dto/battleTeamVote.dto'
 import { BattleClosedResponseDto } from '../dto/battleClosedResponse.dto'
 import { BattleTeamUpdateAllResponseDto } from '../dto/battleTeamUpdateAllResponse.dto'
 import { BattleUserUpdateResponseDto } from '../dto/battleUserUpdateResponse.dto'
+import { BattleStartDto } from '../dto/battleStart.dto'
 
 @WebSocketGateway()
 export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect, OnModuleInit {
@@ -75,6 +76,16 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
         })
       }
     }
+  }
+
+  @SubscribeMessage('battle:start')
+  handleStart(@MessageBody() dto: BattleStartDto) {
+    const { battleId } = dto
+    this.battlesService.startBattle(battleId)
+
+    const battleRoomId = this.battlesService.getBattleRoomId(battleId)
+
+    this.server.to(battleRoomId).emit('battle:started')
   }
 
   @SubscribeMessage('battle:attack')

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -221,10 +221,6 @@ export class BattlesService extends EventEmitter {
     if (!battleId) throw new BadRequestException('잘못된 요청입니다.')
     if (this.activeBattles.has(battleId)) return
 
-    const startedAt = Date.now()
-    // const expiredAt = startedAt + BATTLE_PHASE.OPINION_SHARE.time
-    const expiredAt = startedAt + BATTLE_PHASE.PENDING.time
-
     const activeBattleState: ActiveBattleState = {
       battleId,
       all: {
@@ -254,17 +250,26 @@ export class BattlesService extends EventEmitter {
       round: 1,
       phaseCount: 1,
 
-      startedAt,
-      expiredAt,
+      startedAt: null,
+      expiredAt: null,
     }
 
     this.activeBattles.set(battleId, activeBattleState)
+  }
 
-    // 시작 버튼으로 분류될 예정
+  startBattle(battleId: string) {
+    const battleState = this.getBattleState(battleId)
+
+    const startedAt = Date.now()
+    const expiredAt = startedAt + BATTLE_PHASE.PENDING.time
+
+    battleState.startedAt = startedAt
+    battleState.expiredAt = expiredAt
+
     const res = BattlePhaseResponseDto.of({
       battleId,
-      phase: activeBattleState.phase,
-      phaseCount: activeBattleState.phaseCount,
+      phase: battleState.phase,
+      phaseCount: battleState.phaseCount,
       startedAt,
       expiredAt,
     })

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -76,7 +76,7 @@ export class BattlesService extends EventEmitter {
       category: payload.category,
       playTime,
       password: payload.type === BATTLE_TYPE.PRIVATE ? undefined : payload.password?.trim(),
-      status: BATTLE_STATUS.OPEN,
+      status: BATTLE_STATUS.PENDING,
       createdAt: now,
       updatedAt: now,
       participantCount: 1,
@@ -96,7 +96,7 @@ export class BattlesService extends EventEmitter {
   //Todo: 정렬 기준 재설정
   //실시간 배틀 목록 조회
   getOpenBattles(limit: number, offset: number) {
-    const filtered = this.battles.filter(battle => this.isPublicAndOpen(battle))
+    const filtered = this.battles.filter(battle => this.isPublicAndWaitingOrOpen(battle))
     const battles = filtered.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()).slice(offset, offset + limit) // TODO: ORM 적용 시 take/skip
 
     return {
@@ -259,12 +259,16 @@ export class BattlesService extends EventEmitter {
 
   startBattle(battleId: string) {
     const battleState = this.getBattleState(battleId)
+    const battle = this.battles.find(b => b.id === battleId)
 
     const startedAt = Date.now()
     const expiredAt = startedAt + BATTLE_PHASE.PENDING.time
 
     battleState.startedAt = startedAt
     battleState.expiredAt = expiredAt
+    if (battle) {
+      battle.status = BATTLE_STATUS.OPEN
+    }
 
     const res = BattlePhaseResponseDto.of({
       battleId,
@@ -502,8 +506,8 @@ export class BattlesService extends EventEmitter {
     this.emit('battle:closed', BattleClosedResponseDto.of({ battleId: battle.id }))
   }
 
-  private isPublicAndOpen(battle: Battle): boolean {
-    return battle.type === BATTLE_TYPE.PUBLIC && battle.status === BATTLE_STATUS.OPEN
+  private isPublicAndWaitingOrOpen(battle: Battle): boolean {
+    return battle.type === BATTLE_TYPE.PUBLIC && (battle.status === BATTLE_STATUS.OPEN || battle.status === BATTLE_STATUS.PENDING)
   }
 
   private isPublicAndClosed(battle: Battle): boolean {

--- a/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
+++ b/frontend/src/pages/battlePage/components/header/BattleHeader.tsx
@@ -1,25 +1,51 @@
 import StatusCard from './StatusCard';
 import VoteStatus from './VoteStatus';
-import { useBattleStore, selectCurrentStage, selectBattleProgress, selectTeamCounts } from '../../stores/battleStore';
+import {
+  useBattleStore,
+  selectCurrentStage,
+  selectBattleProgress,
+  selectTeamCounts,
+  selectBattleId,
+  selectSocket
+} from '../../stores/battleStore';
 import { useBattleTimer } from '../../hooks/useBattleTimer';
 
 export default function BattleHeader() {
   const currentStage = useBattleStore(selectCurrentStage);
   const battleProgress = useBattleStore(selectBattleProgress);
   const { teamACount, teamBCount, none } = useBattleStore(selectTeamCounts);
+  const battleId = useBattleStore(selectBattleId);
+  const socket = useBattleStore(selectSocket);
 
   const { formattedTime } = useBattleTimer({
     expiredAt: battleProgress?.expiredAt
   });
 
   const status = currentStage || 'END';
+
+  const handleStart = () => {
+    if (!socket || !battleId) return;
+    socket.emit('battle:start', { battleId });
+  };
+
+  const showStartButton = currentStage === 'PENDING';
+
   return (
     <header className="bg-[#1E1E2F] px-8 py-6 rounded-lg mb-2">
       <div className="flex justify-between">
         <div className="flex items-center gap-4">
-          <StatusCard turn={status} timer={formattedTime} />
+          <StatusCard phase={status} timer={formattedTime} />
           <VoteStatus teamACounts={teamACount} teamBCounts={teamBCount} teamNoneCounts={none} />
         </div>
+        {showStartButton && (
+          <button
+            type="button"
+            onClick={handleStart}
+            className="h-10 px-4 rounded-lg border border-[#FF6900] text-[#FF6900] hover:bg-[#FF6900]/10"
+          >
+            배틀 시작
+          </button>
+        )}
       </div>
     </header>
   );

--- a/frontend/src/pages/mainPage/components/LiveBattleCard.tsx
+++ b/frontend/src/pages/mainPage/components/LiveBattleCard.tsx
@@ -11,7 +11,7 @@ interface LiveBattleCardProps {
 }
 
 export default function LiveBattleCard({ battleInform, isHot = false }: LiveBattleCardProps) {
-  const { category, title, description, timeLabel, clientCount, id } = battleInform;
+  const { category, title, description, timeLabel, clientCount, id, status } = battleInform;
   const config = BATTLE_CATEGORY_CONFIG[category] || BATTLE_CATEGORY_CONFIG.ETC;
   const { text, bg, bgSoft, icon: Icon } = config;
 
@@ -34,9 +34,9 @@ export default function LiveBattleCard({ battleInform, isHot = false }: LiveBatt
               <span className="text-gray-400 text-xs uppercase">{category}</span>
             </div>
           </div>
-          {isHot && (
+          {(isHot || status === 'PENDING') && (
             <Badge textClass={'text-yellow-400'} bgClass={'bg-yellow-400/20'}>
-              Hot
+              {status === 'PENDING' ? '대기방' : 'Hot'}
             </Badge>
           )}
         </div>

--- a/frontend/src/pages/mainPage/types/battle.ts
+++ b/frontend/src/pages/mainPage/types/battle.ts
@@ -1,6 +1,6 @@
 export type BattleCategory = 'ALGORITHM' | 'REFACTORING' | 'IMPLEMENTATION' | 'ETC';
 
-export type BattleStatus = 'OPEN' | 'CLOSED';
+export type BattleStatus = 'OPEN' | 'CLOSED' | 'PENDING';
 export type WinnerTeam = 'A' | 'B' | 'DRAW';
 
 import TrophyIcon from '@/assets/icon/trophy.svg?react';


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->
Closes #110 
Closes #111  

## ✅ 작업 내용
  - `backend/src/battles/gateway/battles.gateway.ts`
      - `battle:start` 이벤트를 수신하면 battle service에서 `startBattle()` 메서드를 실행
      - 해당 배틀 모든 인원들에게 `battle:started` 브로드 캐스트
  - `backend/src/battles/const/battles.const.ts`
      - BATTLE_STATUS에 PENDING 추가.
  - `backend/src/battles/service/battles.service.ts`
      - 배틀 생성 시 기본 상태를 PENDING으로 설정.
      - battle:start 호출 시 해당 배틀 상태를 OPEN으로 전환.
      - getOpenBattles 필터를 PENDING도 포함하도록 isPublicAndWaitingOrOpen으로 확장.
      - `startBattle()` 메서드 실행 시, 전달 받은 battle Id를 통해 해당 배틀 타이머 등록 및 `battle:phase:updated` emit
  - `frontend/src/pages/battlePage/components/header/BattleHeader.tsx`
      - StatusCard prop을 phase로 전달.
      - PENDING일 때만 “배틀 시작” 버튼을 표시, 클릭 시 battle:start 이벤트 emit.
  - `frontend/src/pages/mainPage/components/LiveBattleCard.tsx`
      - battle.status가 OPEN이면 우측 상단에 “대기방” 뱃지를 표시 


### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
