### PR TITLE
[Feature] 배틀페이지 가이드라인 UI 구현 

### DIFF
--- a/backend/src/battles/const/battles.const.ts
+++ b/backend/src/battles/const/battles.const.ts
@@ -17,7 +17,7 @@ export const BATTLE_PHASE = {
   },
   TEAM_SWITCH: {
     name: 'TEAM_SWITCH',
-    time: 15 * 1000, // 10초
+    time: 15 * 1000, // 15초
   },
 } as const
 

--- a/frontend/src/assets/icon/question.svg
+++ b/frontend/src/assets/icon/question.svg
@@ -1,0 +1,5 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20.0007 36.6673C29.2054 36.6673 36.6673 29.2054 36.6673 20.0007C36.6673 10.7959 29.2054 3.33398 20.0007 3.33398C10.7959 3.33398 3.33398 10.7959 3.33398 20.0007C3.33398 29.2054 10.7959 36.6673 20.0007 36.6673Z" stroke="currentColor" stroke-width="3.33333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.1504 15.0009C15.5422 13.8871 16.3156 12.9478 17.3336 12.3495C18.3517 11.7512 19.5485 11.5325 20.7124 11.7321C21.8762 11.9318 22.9318 12.5368 23.6922 13.4402C24.4526 14.3435 24.8688 15.4868 24.8671 16.6676C24.8671 20.0009 19.8671 21.6676 19.8671 21.6676" stroke="currentColor" stroke-width="3.33333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20 28.334H20.0167" stroke="currentColor" stroke-width="3.33333" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -40,7 +40,7 @@ export default function ChatSection() {
   };
 
   return (
-    <section className="w-full flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden">
+    <section className="w-full flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden" data-tutorial="chat">
       <div className="px-4 pt-3 pb-2 border-b border-[#2D2D3F]">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">

--- a/frontend/src/pages/battlePage/components/codeview/CodeSection.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/CodeSection.tsx
@@ -14,7 +14,10 @@ export default function CodeSection({ onViewChange, currentView, codeA, codeB, l
   const [currentTab, setCurrentTab] = useState<'A' | 'B'>('A');
 
   return (
-    <section className="w-full h-fit flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden">
+    <section
+      className="w-full h-fit flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden"
+      data-tutorial="code-section"
+    >
       <CodeHeader
         onViewChange={onViewChange}
         currentView={currentView}

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -46,6 +46,7 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
   return (
     <section
       className={`w-full bg-linear-to-r ${colors.containerGradient} border ${colors.border} rounded-lg overflow-hidden shadow-lg`}
+      data-tutorial="discussion-input"
     >
       {/* 헤더 */}
       <div className="px-4 pt-4 pb-3">

--- a/frontend/src/pages/battlePage/components/header/TeamCounter.tsx
+++ b/frontend/src/pages/battlePage/components/header/TeamCounter.tsx
@@ -62,10 +62,8 @@ export default function TeamCounter() {
     };
   }, [teamBCount]);
 
-  // @Todo  중립 팀 인원수 추가 로직 필요 현재는 임시적으로 0으로 고정하여 사용
-
   return (
-    <div className="flex items-center gap-8 min-w-[200px] justify-end">
+    <div className="flex items-center gap-8 max-w-[200px]" data-tutorial="team-status">
       <div className="text-center">
         <div
           className={`text-[46px] font-bold text-[#3B82F6] ${

--- a/frontend/src/pages/battlePage/components/header/index.tsx
+++ b/frontend/src/pages/battlePage/components/header/index.tsx
@@ -32,7 +32,10 @@ export default function BattleHeader() {
   };
 
   return (
-    <header className="h-[185px] w-[1800px] bg-[#1E1E2F] rounded-lg mb-2 overflow-hidden flex flex-col">
+    <header
+      className="h-[185px] w-[1800px] bg-[#1E1E2F] rounded-lg mb-2 overflow-hidden flex flex-col"
+      data-tutorial="phase-guide"
+    >
       <TimeProgressBar />
       <div className="px-8 flex-1 grid grid-cols-3 items-center">
         <StageIndicator />

--- a/frontend/src/pages/battlePage/components/tutorial/SpotlightOverlay.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/SpotlightOverlay.tsx
@@ -1,0 +1,59 @@
+import type { SpotlightPosition } from '../../hooks/useSpotlight';
+
+interface SpotlightOverlayProps {
+  spotlight: SpotlightPosition | null;
+  onBackdropClick?: () => void;
+}
+
+export default function SpotlightOverlay({ spotlight, onBackdropClick }: SpotlightOverlayProps) {
+  if (!spotlight) {
+    return <div className="absolute inset-0 bg-black/70 pointer-events-auto" onClick={onBackdropClick} />;
+  }
+
+  return (
+    <>
+      <div
+        className="absolute left-0 right-0 bg-black/70 pointer-events-auto transition-all duration-300"
+        style={{ top: 0, height: `${spotlight.top}px` }}
+        onClick={onBackdropClick}
+      />
+      <div
+        className="absolute bg-black/70 pointer-events-auto transition-all duration-300"
+        style={{
+          top: `${spotlight.top}px`,
+          left: 0,
+          width: `${spotlight.left}px`,
+          height: `${spotlight.height}px`
+        }}
+        onClick={onBackdropClick}
+      />
+      <div
+        className="absolute bg-black/70 pointer-events-auto transition-all duration-300"
+        style={{
+          top: `${spotlight.top}px`,
+          left: `${spotlight.left + spotlight.width}px`,
+          right: 0,
+          height: `${spotlight.height}px`
+        }}
+        onClick={onBackdropClick}
+      />
+      <div
+        className="absolute left-0 right-0 bg-black/70 pointer-events-auto transition-all duration-300"
+        style={{
+          top: `${spotlight.top + spotlight.height}px`,
+          bottom: 0
+        }}
+        onClick={onBackdropClick}
+      />
+      <div
+        className="absolute border-2 border-[#FF6900] rounded-lg pointer-events-none transition-all duration-300 shadow-[0_0_20px_rgba(255,105,0,0.5)]"
+        style={{
+          top: `${spotlight.top}px`,
+          left: `${spotlight.left}px`,
+          width: `${spotlight.width}px`,
+          height: `${spotlight.height}px`
+        }}
+      />
+    </>
+  );
+}

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialModal.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialModal.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import QuestionIcon from '@/assets/icon/question.svg?react';
+
+interface TutorialModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onStart: () => void;
+}
+
+export default function TutorialModal({ isOpen, onClose, onStart }: TutorialModalProps) {
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  const handleStart = () => {
+    onStart();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="relative w-[420px] rounded-2xl bg-[#1E2432] border border-[#2D3648] shadow-2xl p-8">
+        <div className="flex justify-center mb-6">
+          <div className="w-[60px] h-[60px] rounded-full bg-gradient-to-br from-[#FF6900] to-[#FB2C36] flex items-center justify-center">
+            <QuestionIcon className="w-10 h-10 text-white" />
+          </div>
+        </div>
+
+        <h2 className="text-center text-[24px] font-bold text-white mb-4">배틀 페이지 튜토리얼</h2>
+
+        <p className="text-center text-[14px] text-[#99A1AF] leading-relaxed mb-6">
+          처음이신가요? 배틀 페이지 사용법을 안내해드릴까요?
+          <br />
+          간단한 가이드로 쉽게 배워보세요.
+        </p>
+
+        <label className="flex items-center justify-center gap-2 mb-6 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={dontShowAgain}
+            onChange={(e) => setDontShowAgain(e.target.checked)}
+            className="w-4 h-4 rounded border-[#4A5568] bg-[#0A0A1A] checked:bg-[#FF6900] checked:border-[#FF6900] cursor-pointer"
+          />
+          <span className="text-[13px] text-[#99A1AF]">다시 보지 않기</span>
+        </label>
+
+        <div className="flex gap-3">
+          <button
+            onClick={handleClose}
+            className="flex-1 h-[48px] rounded-lg bg-[#2D3648] hover:bg-[#3A4255] text-white text-[15px] font-medium transition-colors"
+          >
+            건너뛰기
+          </button>
+          <button
+            onClick={handleStart}
+            className="flex-1 h-[48px] rounded-lg bg-gradient-to-r from-[#FF6900] to-[#FB2C36] hover:from-[#FF7A1A] hover:to-[#FC3D47] text-white text-[15px] font-bold transition-all shadow-lg shadow-orange-500/30"
+          >
+            시작하기
+          </button>
+        </div>
+
+        <div className="flex items-center justify-center gap-1 mt-4">
+          <span className="text-[10px] text-[#6A7282]">💡 우측 상단</span>
+          <span className="text-[10px] text-white">? </span>
+          <span className="text-[10px] text-[#6A7282]">버튼을 클릭하면 언제든지 튜토리얼을 다시 볼 수 있어요.</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialModal.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialModal.tsx
@@ -1,15 +1,20 @@
-import { useState } from 'react';
 import QuestionIcon from '@/assets/icon/question.svg?react';
 
 interface TutorialModalProps {
   isOpen: boolean;
   onClose: () => void;
   onStart: () => void;
+  dontShowAgain: boolean;
+  onDontShowAgainChange: (value: boolean) => void;
 }
 
-export default function TutorialModal({ isOpen, onClose, onStart }: TutorialModalProps) {
-  const [dontShowAgain, setDontShowAgain] = useState(false);
-
+export default function TutorialModal({
+  isOpen,
+  onClose,
+  onStart,
+  dontShowAgain,
+  onDontShowAgainChange
+}: TutorialModalProps) {
   if (!isOpen) return null;
 
   const handleClose = () => {
@@ -32,16 +37,16 @@ export default function TutorialModal({ isOpen, onClose, onStart }: TutorialModa
         <h2 className="text-center text-[24px] font-bold text-white mb-4">배틀 페이지 튜토리얼</h2>
 
         <p className="text-center text-[14px] text-[#99A1AF] leading-relaxed mb-6">
-          처음이신가요? 배틀 페이지 사용법을 안내해드릴까요?
+          처음이신가요? 배틀 페이지 사용법을 안내해드릴게요!
           <br />
-          간단한 가이드로 쉽게 배워보세요.
+          7단계의 가이드로 쉽게 배워보세요.
         </p>
 
         <label className="flex items-center justify-center gap-2 mb-6 cursor-pointer">
           <input
             type="checkbox"
             checked={dontShowAgain}
-            onChange={(e) => setDontShowAgain(e.target.checked)}
+            onChange={(e) => onDontShowAgainChange(e.target.checked)}
             className="w-4 h-4 rounded border-[#4A5568] bg-[#0A0A1A] checked:bg-[#FF6900] checked:border-[#FF6900] cursor-pointer"
           />
           <span className="text-[13px] text-[#99A1AF]">다시 보지 않기</span>

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
@@ -1,6 +1,7 @@
 import type { TutorialStep } from '../../hooks/useTutorial';
 import { useSpotlight } from '../../hooks/useSpotlight';
 import SpotlightOverlay from './SpotlightOverlay';
+import TutorialVoteExample from './TutorialVoteExample';
 import { TUTORIAL_STEPS, TOTAL_STEPS } from './const/tutorialSteps';
 import QuestionIcon from '@/assets/icon/question.svg?react';
 
@@ -36,6 +37,13 @@ export default function TutorialStepModal({
   return (
     <div className="fixed inset-0 z-[100]">
       <SpotlightOverlay spotlight={spotlight} onBackdropClick={onSkip} />
+
+      {/* Mock Vote UI - vote 단계에서만 표시 */}
+      {currentStep === 'vote' && (
+        <div data-tutorial="vote" className="absolute right-[155px] top-[205px] z-[99]">
+          <TutorialVoteExample />
+        </div>
+      )}
 
       <div
         className="absolute pointer-events-auto transition-all duration-300"

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
@@ -1,4 +1,7 @@
 import type { TutorialStep } from '../../hooks/useTutorial';
+import { useSpotlight } from '../../hooks/useSpotlight';
+import SpotlightOverlay from './SpotlightOverlay';
+import { TUTORIAL_STEPS, TOTAL_STEPS } from './const/tutorialSteps';
 import QuestionIcon from '@/assets/icon/question.svg?react';
 
 interface TutorialStepModalProps {
@@ -10,67 +13,6 @@ interface TutorialStepModalProps {
   onClose: () => void;
 }
 
-interface StepContent {
-  title: string;
-  description: string;
-  stepNumber: number;
-  totalSteps: number;
-  highlightElement?: string;
-}
-
-const TUTORIAL_STEPS: Record<TutorialStep, StepContent | null> = {
-  welcome: null,
-  timer: {
-    title: '타이머 & 진행 상황',
-    description:
-      '각 페이즈의 남은 시간을 확인하세요. 시간이 5초 이하가 되면 경고음이 울립니다! 상단의 프로그레스 바로 전체 배틀 진행률을 확인할 수 있어요.',
-    stepNumber: 1,
-    totalSteps: 7
-  },
-  phaseGuide: {
-    title: '현재 페이즈 안내',
-    description:
-      '지금 무엇을 해야 하는지 알려드립니다. 페이즈마다 할 수 있는 행동이 달라요! 이의제기 → 반론 → 진영 변경 순서로 진행됩니다.',
-    stepNumber: 2,
-    totalSteps: 7
-  },
-  teamStatus: {
-    title: '팀 현황',
-    description:
-      'A팀, B팀, 중립의 실시간 인원수를 확인하세요. 인원이 변하면 애니메이션이 재생됩니다! 하단의 막대 그래프로 비율을 한눈에 파악할 수 있어요.',
-    stepNumber: 3,
-    totalSteps: 7
-  },
-  codeCompare: {
-    title: '코드 비교',
-    description:
-      '두 팀의 코드를 비교하고 분석하세요. 상단 버튼으로 탭 보기와 분할 보기를 전환할 수 있어요. 코드에 마우스를 올리면 라인 번호가 표시됩니다.',
-    stepNumber: 4,
-    totalSteps: 7
-  },
-  vote: {
-    title: '투표',
-    description: '더 나은 코드를 선택하세요! 투표는 각 라운드마다 진행되며, 실시간으로 결과가 반영됩니다.',
-    stepNumber: 5,
-    totalSteps: 7
-  },
-  chat: {
-    title: '채팅',
-    description:
-      '팀 채팅으로 전략을 논의하거나, 전체 채팅으로 모두와 소통하세요! 채팅창 상단의 탭을 클릭하여 전환할 수 있습니다.',
-    stepNumber: 6,
-    totalSteps: 7
-  },
-  discussionInput: {
-    title: '의견 입력',
-    description:
-      '이의제기 페이즈에는 이의제기를, 반론 페이즈에는 반박을 작성할 수 있어요. 엔터키로 빠르게 제출할 수 있습니다!',
-    stepNumber: 7,
-    totalSteps: 7
-  },
-  completed: null
-};
-
 export default function TutorialStepModal({
   isOpen,
   currentStep,
@@ -79,19 +21,30 @@ export default function TutorialStepModal({
   onSkip,
   onClose
 }: TutorialStepModalProps) {
-  if (!isOpen || currentStep === 'welcome' || currentStep === 'completed') return null;
-
   const stepContent = TUTORIAL_STEPS[currentStep];
+  const spotlight = useSpotlight({
+    selector: stepContent?.highlightElement,
+    enabled: isOpen && currentStep !== 'welcome' && currentStep !== 'completed'
+  });
+
+  if (!isOpen || currentStep === 'welcome' || currentStep === 'completed') return null;
   if (!stepContent) return null;
 
-  const { title, description, stepNumber, totalSteps } = stepContent;
-  const isLastStep = stepNumber === totalSteps;
+  const { title, description, stepNumber } = stepContent;
+  const isLastStep = stepNumber === TOTAL_STEPS;
 
   return (
-    <div className="fixed inset-0 z-[100] pointer-events-none">
-      <div className="absolute inset-0 bg-black/70 pointer-events-auto" onClick={onSkip} />
+    <div className="fixed inset-0 z-[100]">
+      <SpotlightOverlay spotlight={spotlight} onBackdropClick={onSkip} />
 
-      <div className="absolute top-20 left-1/2 transform -translate-x-1/2 pointer-events-auto">
+      <div
+        className="absolute pointer-events-auto transition-all duration-300"
+        style={
+          spotlight && spotlight.top > 400
+            ? { top: '80px', left: '50%', transform: 'translateX(-50%)' }
+            : { bottom: '80px', left: '50%', transform: 'translateX(-50%)' }
+        }
+      >
         <div className="relative w-[420px] rounded-2xl bg-[#1E2432] border-2 border-[#FF6900] shadow-2xl p-6">
           <button
             onClick={onClose}
@@ -109,14 +62,14 @@ export default function TutorialStepModal({
           <div className="text-center mb-2">
             <h3 className="text-[22px] font-bold text-white mb-1">{title}</h3>
             <span className="text-[13px] font-medium text-[#FF6900]">
-              {stepNumber} / {totalSteps}
+              {stepNumber} / {TOTAL_STEPS}
             </span>
           </div>
 
           <p className="text-center text-[14px] text-[#99A1AF] leading-relaxed mb-6 px-2">{description}</p>
 
           <div className="flex justify-center gap-2 mb-6">
-            {Array.from({ length: totalSteps }, (_, i) => (
+            {Array.from({ length: TOTAL_STEPS }, (_, i) => (
               <div
                 key={i}
                 className={`h-2 w-2 rounded-full transition-all duration-300 ${
@@ -139,14 +92,12 @@ export default function TutorialStepModal({
               <span>←</span>
               <span>이전</span>
             </button>
-
             <button
               onClick={onSkip}
               className="flex-1 h-[44px] rounded-lg bg-[#2D3648] hover:bg-[#3A4255] text-white text-[14px] font-medium transition-colors"
             >
               건너뛰기
             </button>
-
             <button
               onClick={onNext}
               className="px-6 h-[44px] rounded-lg bg-gradient-to-r from-[#FF6900] to-[#FB2C36] hover:from-[#FF7A1A] hover:to-[#FC3D47] text-white text-[14px] font-bold transition-all shadow-lg shadow-orange-500/30 flex items-center gap-1"

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
@@ -1,0 +1,162 @@
+import type { TutorialStep } from '../../hooks/useTutorial';
+import QuestionIcon from '@/assets/icon/question.svg?react';
+
+interface TutorialStepModalProps {
+  isOpen: boolean;
+  currentStep: TutorialStep;
+  onNext: () => void;
+  onPrev: () => void;
+  onSkip: () => void;
+  onClose: () => void;
+}
+
+interface StepContent {
+  title: string;
+  description: string;
+  stepNumber: number;
+  totalSteps: number;
+  highlightElement?: string;
+}
+
+const TUTORIAL_STEPS: Record<TutorialStep, StepContent | null> = {
+  welcome: null,
+  timer: {
+    title: '타이머 & 진행 상황',
+    description:
+      '각 페이즈의 남은 시간을 확인하세요. 시간이 5초 이하가 되면 경고음이 울립니다! 상단의 프로그레스 바로 전체 배틀 진행률을 확인할 수 있어요.',
+    stepNumber: 1,
+    totalSteps: 7
+  },
+  phaseGuide: {
+    title: '현재 페이즈 안내',
+    description:
+      '지금 무엇을 해야 하는지 알려드립니다. 페이즈마다 할 수 있는 행동이 달라요! 이의제기 → 반론 → 진영 변경 순서로 진행됩니다.',
+    stepNumber: 2,
+    totalSteps: 7
+  },
+  teamStatus: {
+    title: '팀 현황',
+    description:
+      'A팀, B팀, 중립의 실시간 인원수를 확인하세요. 인원이 변하면 애니메이션이 재생됩니다! 하단의 막대 그래프로 비율을 한눈에 파악할 수 있어요.',
+    stepNumber: 3,
+    totalSteps: 7
+  },
+  codeCompare: {
+    title: '코드 비교',
+    description:
+      '두 팀의 코드를 비교하고 분석하세요. 상단 버튼으로 탭 보기와 분할 보기를 전환할 수 있어요. 코드에 마우스를 올리면 라인 번호가 표시됩니다.',
+    stepNumber: 4,
+    totalSteps: 7
+  },
+  vote: {
+    title: '투표',
+    description: '더 나은 코드를 선택하세요! 투표는 각 라운드마다 진행되며, 실시간으로 결과가 반영됩니다.',
+    stepNumber: 5,
+    totalSteps: 7
+  },
+  chat: {
+    title: '채팅',
+    description:
+      '팀 채팅으로 전략을 논의하거나, 전체 채팅으로 모두와 소통하세요! 채팅창 상단의 탭을 클릭하여 전환할 수 있습니다.',
+    stepNumber: 6,
+    totalSteps: 7
+  },
+  discussionInput: {
+    title: '의견 입력',
+    description:
+      '이의제기 페이즈에는 이의제기를, 반론 페이즈에는 반박을 작성할 수 있어요. 엔터키로 빠르게 제출할 수 있습니다!',
+    stepNumber: 7,
+    totalSteps: 7
+  },
+  completed: null
+};
+
+export default function TutorialStepModal({
+  isOpen,
+  currentStep,
+  onNext,
+  onPrev,
+  onSkip,
+  onClose
+}: TutorialStepModalProps) {
+  if (!isOpen || currentStep === 'welcome' || currentStep === 'completed') return null;
+
+  const stepContent = TUTORIAL_STEPS[currentStep];
+  if (!stepContent) return null;
+
+  const { title, description, stepNumber, totalSteps } = stepContent;
+  const isLastStep = stepNumber === totalSteps;
+
+  return (
+    <div className="fixed inset-0 z-[100] pointer-events-none">
+      <div className="absolute inset-0 bg-black/70 pointer-events-auto" onClick={onSkip} />
+
+      <div className="absolute top-20 left-1/2 transform -translate-x-1/2 pointer-events-auto">
+        <div className="relative w-[420px] rounded-2xl bg-[#1E2432] border-2 border-[#FF6900] shadow-2xl p-6">
+          <button
+            onClick={onClose}
+            className="absolute top-4 right-4 w-8 h-8 flex items-center justify-center text-[#99A1AF] hover:text-white transition-colors"
+          >
+            ✕
+          </button>
+
+          <div className="flex justify-center mb-4">
+            <div className="w-[56px] h-[56px] rounded-full bg-gradient-to-br from-[#FF6900] to-[#FB2C36] flex items-center justify-center">
+              <QuestionIcon className="w-8 h-8 text-white" />
+            </div>
+          </div>
+
+          <div className="text-center mb-2">
+            <h3 className="text-[22px] font-bold text-white mb-1">{title}</h3>
+            <span className="text-[13px] font-medium text-[#FF6900]">
+              {stepNumber} / {totalSteps}
+            </span>
+          </div>
+
+          <p className="text-center text-[14px] text-[#99A1AF] leading-relaxed mb-6 px-2">{description}</p>
+
+          <div className="flex justify-center gap-2 mb-6">
+            {Array.from({ length: totalSteps }, (_, i) => (
+              <div
+                key={i}
+                className={`h-2 w-2 rounded-full transition-all duration-300 ${
+                  i < stepNumber - 1
+                    ? 'bg-[#00C950]'
+                    : i === stepNumber - 1
+                      ? 'w-8 bg-gradient-to-r from-[#FF6900] to-[#FB2C36]'
+                      : 'bg-[#3A4255]'
+                }`}
+              />
+            ))}
+          </div>
+
+          <div className="flex gap-2">
+            <button
+              onClick={onPrev}
+              disabled={stepNumber === 1}
+              className="px-4 h-[44px] rounded-lg bg-[#2D3648] hover:bg-[#3A4255] disabled:opacity-50 disabled:cursor-not-allowed text-white text-[14px] font-medium transition-colors flex items-center gap-1"
+            >
+              <span>←</span>
+              <span>이전</span>
+            </button>
+
+            <button
+              onClick={onSkip}
+              className="flex-1 h-[44px] rounded-lg bg-[#2D3648] hover:bg-[#3A4255] text-white text-[14px] font-medium transition-colors"
+            >
+              건너뛰기
+            </button>
+
+            <button
+              onClick={onNext}
+              className="px-6 h-[44px] rounded-lg bg-gradient-to-r from-[#FF6900] to-[#FB2C36] hover:from-[#FF7A1A] hover:to-[#FC3D47] text-white text-[14px] font-bold transition-all shadow-lg shadow-orange-500/30 flex items-center gap-1"
+            >
+              <span>{isLastStep ? '완료' : '다음'}</span>
+              <span>→</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialVoteExample.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialVoteExample.tsx
@@ -1,0 +1,44 @@
+import DiscussionVoteItem from '../discussion/DiscussionVoteItem';
+import ScaleIcon from '@/assets/icon/scale.svg?react';
+import { MOCK_DISCUSSIONS } from './const/tutorialSteps';
+
+export default function TutorialVoteExample() {
+  return (
+    <section className="w-[590px] bg-[#1E1E2F] rounded-lg overflow-hidden">
+      <div className="bg-gradient-to-r from-[#59168B] to-[#1C398E] p-4">
+        <div className="flex items-center gap-2 mb-2">
+          <ScaleIcon className="w-[20px] h-[20px]" />
+          <h3 className="text-[14px] font-medium text-white">제출된 이의제기 목록</h3>
+        </div>
+
+        <div className="text-[11px] text-white flex items-center gap-1">
+          <span className="inline-block w-1 h-1 rounded-full bg-white"></span>
+          이의제기가 실시간으로 추가되며, 바로 투표 가능합니다!
+        </div>
+      </div>
+
+      <div className="p-4 bg-gradient-to-r from-[#1E1E2F] to-[#59168B]">
+        <div className="space-y-3">
+          {MOCK_DISCUSSIONS.map((discussion) => (
+            <DiscussionVoteItem
+              key={discussion.id}
+              user={discussion.user}
+              team={discussion.team}
+              content={discussion.content}
+              votes={discussion.votes}
+              totalVotes={discussion.totalVotes}
+              hasVoted={discussion.hasVoted}
+              onVote={() => {}}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="py-4 bg-gradient-to-r from-[#1C398E] to-[#59168B] border-t border-[#2D2D3F] flex items-center justify-center gap-2 text-[13px]">
+        <span className="text-[#FFB800]">⚡</span>
+        <span className="text-white font-medium">총 {MOCK_DISCUSSIONS.length}개의 이의제기</span>
+        <span className="text-[#99A1AF]">/ 투표 가능</span>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/battlePage/components/tutorial/const/tutorialSteps.ts
+++ b/frontend/src/pages/battlePage/components/tutorial/const/tutorialSteps.ts
@@ -1,0 +1,63 @@
+import type { TutorialStep } from '../../../hooks/useTutorial';
+
+export interface StepContent {
+  title: string;
+  description: string;
+  stepNumber: number;
+  highlightElement?: string;
+}
+
+export const TUTORIAL_STEPS: Record<TutorialStep, StepContent | null> = {
+  welcome: null,
+  phaseGuide: {
+    title: '현재 페이즈 안내',
+    description:
+      '지금 무엇을 해야 하는지 알려드립니다. 페이즈마다 할 수 있는 행동이 달라요! 이의제기 → 반론 → 진영 변경 순서로 진행됩니다.',
+    stepNumber: 1,
+    highlightElement: '[data-tutorial="phase-guide"]'
+  },
+  timer: {
+    title: '타이머 & 진행 상황',
+    description:
+      '각 페이즈의 남은 시간을 확인하세요. 시간이 5초 이하가 되면 경고음이 울립니다! 상단의 프로그레스 바로 전체 배틀 진행률을 확인할 수 있어요.',
+    stepNumber: 2,
+    highlightElement: '[data-tutorial="timer"]'
+  },
+  teamStatus: {
+    title: '팀 현황',
+    description:
+      'A팀, B팀, 중립의 실시간 인원수를 확인하세요. 인원이 변하면 애니메이션이 재생됩니다! 하단의 막대 그래프로 비율을 한눈에 파악할 수 있어요.',
+    stepNumber: 3,
+    highlightElement: '[data-tutorial="team-status"]'
+  },
+  codeCompare: {
+    title: '코드 비교',
+    description:
+      '두 팀의 코드를 비교하고 분석하세요. 상단 버튼으로 탭 보기와 분할 보기를 전환할 수 있어요. 코드에 마우스를 올리면 라인 번호가 표시됩니다.',
+    stepNumber: 4,
+    highlightElement: '[data-tutorial="code-section"]'
+  },
+  vote: {
+    title: '투표',
+    description: '더 나은 코드를 선택하세요! 투표는 각 라운드마다 진행되며, 실시간으로 결과가 반영됩니다.',
+    stepNumber: 5,
+    highlightElement: '[data-tutorial="vote"]'
+  },
+  chat: {
+    title: '채팅',
+    description:
+      '팀 채팅으로 전략을 논의하거나, 전체 채팅으로 모두와 소통하세요! 채팅창 상단의 탭을 클릭하여 전환할 수 있습니다.',
+    stepNumber: 6,
+    highlightElement: '[data-tutorial="chat"]'
+  },
+  discussionInput: {
+    title: '의견 입력',
+    description:
+      '이의제기 페이즈에는 이의제기를, 반론 페이즈에는 반박을 작성할 수 있어요. 엔터키로 빠르게 제출할 수 있습니다!',
+    stepNumber: 7,
+    highlightElement: '[data-tutorial="discussion-input"]'
+  },
+  completed: null
+};
+
+export const TOTAL_STEPS = 7;

--- a/frontend/src/pages/battlePage/components/tutorial/const/tutorialSteps.ts
+++ b/frontend/src/pages/battlePage/components/tutorial/const/tutorialSteps.ts
@@ -7,6 +7,27 @@ export interface StepContent {
   highlightElement?: string;
 }
 
+export const MOCK_DISCUSSIONS = [
+  {
+    id: 1,
+    user: '김개발',
+    team: 'A' as const,
+    content: 'A 코드는 가독성이 좋고 유지보수가 쉬워 보입니다.',
+    votes: 12,
+    totalVotes: 25,
+    hasVoted: false
+  },
+  {
+    id: 2,
+    user: '박코딩',
+    team: 'B' as const,
+    content: 'B 코드가 성능 면에서 더 효율적입니다.',
+    votes: 13,
+    totalVotes: 25,
+    hasVoted: false
+  }
+];
+
 export const TUTORIAL_STEPS: Record<TutorialStep, StepContent | null> = {
   welcome: null,
   phaseGuide: {

--- a/frontend/src/pages/battlePage/hooks/useSpotlight.ts
+++ b/frontend/src/pages/battlePage/hooks/useSpotlight.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect } from 'react';
+
+export interface SpotlightPosition {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+interface UseSpotlightOptions {
+  selector: string | null | undefined;
+  enabled?: boolean;
+  padding?: number;
+}
+
+export function useSpotlight({ selector, enabled = true, padding = 8 }: UseSpotlightOptions) {
+  const [position, setPosition] = useState<SpotlightPosition | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !selector) {
+      setPosition(null);
+      return;
+    }
+
+    const updateSpotlight = () => {
+      const element = document.querySelector(selector);
+      if (element) {
+        const rect = element.getBoundingClientRect();
+
+        setPosition({
+          top: rect.top - padding,
+          left: rect.left - padding,
+          width: rect.width + padding * 2,
+          height: rect.height + padding * 2
+        });
+      } else {
+        setPosition(null);
+      }
+    };
+
+    updateSpotlight();
+
+    window.addEventListener('resize', updateSpotlight);
+    window.addEventListener('scroll', updateSpotlight, true);
+
+    return () => {
+      window.removeEventListener('resize', updateSpotlight);
+      window.removeEventListener('scroll', updateSpotlight, true);
+    };
+  }, [enabled, selector, padding]);
+
+  return position;
+}

--- a/frontend/src/pages/battlePage/hooks/useTutorial.ts
+++ b/frontend/src/pages/battlePage/hooks/useTutorial.ts
@@ -46,15 +46,15 @@ export function useTutorial(): UseTutorialReturn {
 
   // 튜토리얼 시작
   const startTutorial = useCallback(() => {
-    setCurrentStep('timer');
+    setCurrentStep('phaseGuide');
   }, [dontShowAgain]);
 
   // 다음 단계로
   const nextStep = useCallback(() => {
     const steps: TutorialStep[] = [
       'welcome',
-      'timer',
       'phaseGuide',
+      'timer',
       'teamStatus',
       'codeCompare',
       'vote',

--- a/frontend/src/pages/battlePage/hooks/useTutorial.ts
+++ b/frontend/src/pages/battlePage/hooks/useTutorial.ts
@@ -1,0 +1,122 @@
+import { useState, useCallback } from 'react';
+
+export type TutorialStep =
+  | 'welcome'
+  | 'timer'
+  | 'phaseGuide'
+  | 'teamStatus'
+  | 'codeCompare'
+  | 'vote'
+  | 'chat'
+  | 'discussionInput'
+  | 'completed';
+
+interface UseTutorialReturn {
+  // 모달 상태
+  isModalOpen: boolean;
+  currentStep: TutorialStep;
+  dontShowAgain: boolean;
+
+  // 액션
+  openTutorial: () => void;
+  closeTutorial: () => void;
+  startTutorial: () => void;
+  nextStep: () => void;
+  prevStep: () => void;
+  skipTutorial: () => void;
+  setDontShowAgain: (value: boolean) => void;
+}
+
+export function useTutorial(): UseTutorialReturn {
+  const [isModalOpen, setIsModalOpen] = useState(true);
+  const [currentStep, setCurrentStep] = useState<TutorialStep>('welcome');
+  const [dontShowAgain, setDontShowAgainState] = useState(false);
+
+  // 튜토리얼 열기
+  const openTutorial = useCallback(() => {
+    setCurrentStep('welcome');
+    setIsModalOpen(true);
+  }, []);
+
+  // 튜토리얼 닫기
+  const closeTutorial = useCallback(() => {
+    setIsModalOpen(false);
+    setCurrentStep('welcome');
+  }, []);
+
+  // 튜토리얼 시작
+  const startTutorial = useCallback(() => {
+    setCurrentStep('timer');
+  }, [dontShowAgain]);
+
+  // 다음 단계로
+  const nextStep = useCallback(() => {
+    const steps: TutorialStep[] = [
+      'welcome',
+      'timer',
+      'phaseGuide',
+      'teamStatus',
+      'codeCompare',
+      'vote',
+      'chat',
+      'discussionInput',
+      'completed'
+    ];
+    const currentIndex = steps.indexOf(currentStep);
+
+    if (currentIndex < steps.length - 1) {
+      const nextStepValue = steps[currentIndex + 1];
+      setCurrentStep(nextStepValue);
+
+      // 마지막 단계 완료 시
+      if (nextStepValue === 'completed') {
+        setTimeout(() => {
+          closeTutorial();
+        }, 1500);
+      }
+    }
+  }, [currentStep, closeTutorial]);
+
+  // 이전 단계로
+  const prevStep = useCallback(() => {
+    const steps: TutorialStep[] = [
+      'welcome',
+      'timer',
+      'phaseGuide',
+      'teamStatus',
+      'codeCompare',
+      'vote',
+      'chat',
+      'discussionInput',
+      'completed'
+    ];
+    const currentIndex = steps.indexOf(currentStep);
+
+    if (currentIndex > 0) {
+      setCurrentStep(steps[currentIndex - 1]);
+    }
+  }, [currentStep]);
+
+  // 튜토리얼 건너뛰기
+  const skipTutorial = useCallback(() => {
+    closeTutorial();
+  }, [dontShowAgain, closeTutorial]);
+
+  // 다시 보지 않기 설정
+  const setDontShowAgain = useCallback((value: boolean) => {
+    setDontShowAgainState(value);
+  }, []);
+
+  return {
+    isModalOpen,
+    currentStep,
+    dontShowAgain,
+    openTutorial,
+    closeTutorial,
+    startTutorial,
+    nextStep,
+    prevStep,
+    skipTutorial,
+    setDontShowAgain
+  };
+}

--- a/frontend/src/pages/battlePage/hooks/useTutorial.ts
+++ b/frontend/src/pages/battlePage/hooks/useTutorial.ts
@@ -1,5 +1,7 @@
 import { useState, useCallback } from 'react';
 
+const TUTORIAL_STORAGE_KEY = 'battlePageTutorialCompleted';
+
 export type TutorialStep =
   | 'welcome'
   | 'timer'
@@ -28,7 +30,10 @@ interface UseTutorialReturn {
 }
 
 export function useTutorial(): UseTutorialReturn {
-  const [isModalOpen, setIsModalOpen] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState(() => {
+    const completed = localStorage.getItem(TUTORIAL_STORAGE_KEY);
+    return completed !== 'true';
+  });
   const [currentStep, setCurrentStep] = useState<TutorialStep>('welcome');
   const [dontShowAgain, setDontShowAgainState] = useState(false);
 
@@ -40,9 +45,12 @@ export function useTutorial(): UseTutorialReturn {
 
   // 튜토리얼 닫기
   const closeTutorial = useCallback(() => {
+    if (dontShowAgain) {
+      localStorage.setItem(TUTORIAL_STORAGE_KEY, 'true');
+    }
     setIsModalOpen(false);
     setCurrentStep('welcome');
-  }, []);
+  }, [dontShowAgain]);
 
   // 튜토리얼 시작
   const startTutorial = useCallback(() => {
@@ -70,12 +78,15 @@ export function useTutorial(): UseTutorialReturn {
 
       // 마지막 단계 완료 시
       if (nextStepValue === 'completed') {
+        if (dontShowAgain) {
+          localStorage.setItem(TUTORIAL_STORAGE_KEY, 'true');
+        }
         setTimeout(() => {
           closeTutorial();
         }, 1500);
       }
     }
-  }, [currentStep, closeTutorial]);
+  }, [currentStep, dontShowAgain, closeTutorial]);
 
   // 이전 단계로
   const prevStep = useCallback(() => {
@@ -99,6 +110,9 @@ export function useTutorial(): UseTutorialReturn {
 
   // 튜토리얼 건너뛰기
   const skipTutorial = useCallback(() => {
+    if (dontShowAgain) {
+      localStorage.setItem(TUTORIAL_STORAGE_KEY, 'true');
+    }
     closeTutorial();
   }, [dontShowAgain, closeTutorial]);
 

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -3,6 +3,7 @@ import { useParams, useLoaderData } from 'react-router-dom';
 import type { BattleInfo } from '@/commons/types/battle';
 import { useBattle } from './hooks/useBattle';
 import { useTeamVoteResult } from './hooks/useTeamVoteResult';
+import { useTutorial } from './hooks/useTutorial';
 import useModal from '@/commons/hooks/useModal';
 import { soundManager } from '@/commons/utils/soundManager';
 
@@ -14,6 +15,7 @@ import DiscussionVote from './components/discussion/DiscussionVote';
 import BattleSidebar from './components/sidebar/BattleSidebar';
 import BookmarkButton from './components/sidebar/BookmarkButton';
 import TutorialModal from './components/tutorial/TutorialModal';
+import TutorialStepModal from './components/tutorial/TutorialStepModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
 import DiscussionModal from './components/effects/DiscussionModal';
 import BattleProgressBoard from './components/progressBoard/ProgressBoard';
@@ -24,7 +26,19 @@ export default function BattlePage() {
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
-  const { isOpen: isTutorialOpen, closeModal: closeTutorial } = useModal(true);
+
+  // 튜토리얼 관리
+  const {
+    isModalOpen: isTutorialOpen,
+    currentStep,
+    dontShowAgain,
+    skipTutorial,
+    startTutorial,
+    nextStep,
+    prevStep,
+    setDontShowAgain,
+    closeTutorial
+  } = useTutorial();
 
   // 사운드 초기화
   useEffect(() => {
@@ -44,10 +58,6 @@ export default function BattlePage() {
   });
 
   const { voteResult, isModalOpen: isVoteResultModalOpen, closeModal: closeVoteResultModal } = useTeamVoteResult();
-
-  const handleTutorialStart = () => {
-    closeTutorial();
-  };
 
   return (
     <div className="text-white relative min-h-screen">
@@ -130,7 +140,22 @@ export default function BattlePage() {
           />
         )}
 
-        <TutorialModal isOpen={isTutorialOpen} onClose={closeTutorial} onStart={handleTutorialStart} />
+        <TutorialModal
+          isOpen={isTutorialOpen && currentStep === 'welcome'}
+          onClose={skipTutorial}
+          onStart={startTutorial}
+          dontShowAgain={dontShowAgain}
+          onDontShowAgainChange={setDontShowAgain}
+        />
+
+        <TutorialStepModal
+          isOpen={isTutorialOpen && currentStep !== 'welcome' && currentStep !== 'completed'}
+          currentStep={currentStep}
+          onNext={nextStep}
+          onPrev={prevStep}
+          onSkip={skipTutorial}
+          onClose={closeTutorial}
+        />
       </div>
     </div>
   );

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useParams, useLoaderData } from 'react-router-dom';
 import type { BattleInfo } from '@/commons/types/battle';
+import { useBattle } from './hooks/useBattle';
+import { useTeamVoteResult } from './hooks/useTeamVoteResult';
+import useModal from '@/commons/hooks/useModal';
+import { soundManager } from '@/commons/utils/soundManager';
+
 import BattleHeader from './components/header';
 import CodeSection from './components/codeview/CodeSection';
 import ChatSection from './components/chatting/ChatSection';
@@ -8,20 +13,18 @@ import DiscussionInput from './components/discussion/DiscussionInput';
 import DiscussionVote from './components/discussion/DiscussionVote';
 import BattleSidebar from './components/sidebar/BattleSidebar';
 import BookmarkButton from './components/sidebar/BookmarkButton';
-import { useBattle } from './hooks/useBattle';
-import { useTeamVoteResult } from './hooks/useTeamVoteResult';
-import useModal from '@/commons/hooks/useModal';
+import TutorialModal from './components/tutorial/TutorialModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
 import DiscussionModal from './components/effects/DiscussionModal';
 import BattleProgressBoard from './components/progressBoard/ProgressBoard';
 import TeamVoteResultModal from './components/effects/TeamVoteResultModal';
-import { soundManager } from '@/commons/utils/soundManager';
 
 export default function BattlePage() {
   const { id: battleId } = useParams<{ id: string }>();
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
+  const { isOpen: isTutorialOpen, closeModal: closeTutorial } = useModal(true);
 
   // 사운드 초기화
   useEffect(() => {
@@ -41,6 +44,10 @@ export default function BattlePage() {
   });
 
   const { voteResult, isModalOpen: isVoteResultModalOpen, closeModal: closeVoteResultModal } = useTeamVoteResult();
+
+  const handleTutorialStart = () => {
+    closeTutorial();
+  };
 
   return (
     <div className="text-white relative min-h-screen">
@@ -87,7 +94,7 @@ export default function BattlePage() {
           </div>
         </main>
 
-        {/* DiscussionInput 항상 중앙 하단에 고정 */}
+        {/* DiscussionInput  */}
         <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-[1800px] px-4 pb-4 z-50">
           <div className="max-w-[590px] mx-auto">
             <DiscussionInput onSubmit={handleDiscussionSubmit} />
@@ -122,6 +129,8 @@ export default function BattlePage() {
             onClose={closeVoteResultModal}
           />
         )}
+
+        <TutorialModal isOpen={isTutorialOpen} onClose={closeTutorial} onStart={handleTutorialStart} />
       </div>
     </div>
   );


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #119

## ✅ 작업 내용

### 💡개선 사항

#### 1. 배틀 페이지 튜토리얼 시스템 구현

<img width="849" height="656" alt="image" src="https://github.com/user-attachments/assets/3e17860a-3986-457d-acd0-d67a0dde534f" />

처음 배틀 페이지에 진입한 유저를 위한 단계별 가이드 튜토리얼을 구현했습니다.

##### 튜토리얼 주요 기능

* **스포트라이트 효과**: 각 단계마다 해당 영역을 하이라이트 처리해서 사용자의 시선을 자연스럽게 유도합니다.
* **7단계 가이드**: 페이즈 안내 → 타이머 → 팀 현황 → 코드 비교 → 투표 → 채팅 → 의견 입력 순서로 진행됩니다.
* **다시 보지 않기 옵션**: LocalStorage를 활용해 사용자가 선택한 경우 다음 방문 시 자동으로 튜토리얼을 건너뛰도록 했습니다.

##### 스포트라이트 구현

`useSpotlight` 훅으로 특정 DOM 요소의 위치를 계산하고, 4방향 오버레이로 어두운 배경을 렌더링하여 해당 영역만 강조되도록 했습니다.

```typescript
export function useSpotlight({ selector, enabled = true, padding = 8 }: UseSpotlightOptions) {
  const [position, setPosition] = useState<SpotlightPosition | null>(null);

  useEffect(() => {
    if (!enabled || !selector) {
      setPosition(null);
      return;
    }

    const updateSpotlight = () => {
      const element = document.querySelector(selector);
      if (element) {
        const rect = element.getBoundingClientRect();

        setPosition({
          top: rect.top - padding,
          left: rect.left - padding,
          width: rect.width + padding * 2,
          height: rect.height + padding * 2
        });
      }
    };

    updateSpotlight();
    window.addEventListener('resize', updateSpotlight);
    window.addEventListener('scroll', updateSpotlight, true);

    return () => {
      window.removeEventListener('resize', updateSpotlight);
      window.removeEventListener('scroll', updateSpotlight, true);
    };
  }, [enabled, selector, padding]);

  return position;
}
```

<br/>

##### ETC.
투표 단계에서는 실제 투표 UI가 아닌 Mock 예시 컴포넌트(TutorialVoteExample)를 렌더링해서 사용자가 튜토리얼 중에도 투표 흐름을 이해할 수 있도록 했습니다.

<br/>

### 📸 참고 사항
#### 기술적 특이사항
data-tutorial 속성 활용: 각 튜토리얼 단계에서 하이라이트할 요소에 data-tutorial 속성을 부여하여 DOM 선택자로 사용했습니다.
LocalStorage 영구 저장: battlePageTutorialCompleted 키로 사용자의 튜토리얼 완료 여부를 저장하여 재방문 시 자동 스킵 기능을 구현했습니다.
동적 위치 계산: 스포트라이트 대상의 위치가 화면 상단/하단에 따라 튜토리얼 모달 위치를 자동으로 조정하여 가독성을 높였습니다.
실시간 위치 추적: resize와 scroll 이벤트를 모두 감지하여 화면 크기나 스크롤 변경 시에도 스포트라이트가 정확한 위치를 유지하도록 했습니다.

<br />

### 💬 질문사항 (고민했던 부분)
튜토리얼 단계 순서: 현재 페이즈 안내 → 타이머 → 팀 현황 순으로 진행하는데, 사용자 입장에서 더 직관적인 순서가 있을지 고민했습니다.
