### PR TITLE
[Feautre] (FE) 대주제를 선택하여 배틀을 생성할 수 있다.

### DIFF
--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -21,6 +21,7 @@ export interface BattleInfo {
   participantCount: number;
   currentRound: number;
   totalRounds: number;
+  topics: string[];
   timelines: {
     attacks: BattleDiscussion[];
     defenses: BattleDefense[];

--- a/frontend/src/pages/battleCreatePage/components/BattleTopicInput.tsx
+++ b/frontend/src/pages/battleCreatePage/components/BattleTopicInput.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+
+const DEFAULT_TOPICS = ['효율성', '가독성', '유지보수성', '테스트', '성능', '확장성'];
+
+type BattleTopicInputProps = {
+  rounds: number;
+  selectedTopics: string[];
+  onTopicsChange: React.Dispatch<React.SetStateAction<string[]>>;
+};
+
+export default function BattleTopicInput({ rounds, selectedTopics, onTopicsChange }: BattleTopicInputProps) {
+  const [topics, setTopics] = useState<string[]>(DEFAULT_TOPICS);
+  const [customTopic, setCustomTopic] = useState('');
+
+  const addTopic = (prev: string[], topic: string) => {
+    if (prev.includes(topic)) return prev;
+    if (prev.length >= rounds) return prev;
+    return [...prev, topic];
+  };
+
+  const handleTopicToggle = (topic: string) => {
+    onTopicsChange((prev) => (prev.includes(topic) ? prev.filter((t) => t !== topic) : addTopic(prev, topic)));
+  };
+
+  const handleAddCustomTopic = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing && customTopic.trim()) {
+      e.preventDefault();
+
+      const trimmedTopic = customTopic.trim();
+
+      if (!topics.includes(trimmedTopic)) {
+        setTopics((prev) => [...prev, trimmedTopic]);
+        onTopicsChange((prev) => addTopic(prev, trimmedTopic));
+      }
+
+      setCustomTopic('');
+    }
+  };
+
+  return (
+    <div>
+      <label className="block text-gray-300 mb-3 uppercase text-sm tracking-wider">대주제 선택</label>
+      <div className="bg-[#0a0a1a] border border-gray-800 rounded-lg p-4">
+        {/* 기본 주제 체크박스 */}
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-4">
+          {topics.map((topic) => (
+            <label
+              key={topic}
+              className={`flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-all ${
+                selectedTopics.includes(topic)
+                  ? 'bg-orange-500/20 border border-orange-500/50'
+                  : 'bg-[#1a1a2e] border border-gray-800 hover:border-orange-500/30'
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={selectedTopics.includes(topic)}
+                onChange={() => handleTopicToggle(topic)}
+                className="w-4 h-4 rounded border-gray-600 text-orange-500 focus:ring-orange-500 focus:ring-offset-0 bg-[#0a0a1a]"
+              />
+              <span className={`text-sm ${selectedTopics.includes(topic) ? 'text-orange-400' : 'text-gray-300'}`}>
+                {topic}
+              </span>
+            </label>
+          ))}
+        </div>
+
+        {/* 커스텀 주제 입력 */}
+        <div>
+          <input
+            type="text"
+            value={customTopic}
+            onChange={(e) => setCustomTopic(e.target.value)}
+            onKeyDown={handleAddCustomTopic}
+            placeholder="직접 입력하여 추가 (Enter)"
+            className="w-full px-4 py-2 bg-[#1a1a2e] text-white border border-gray-800 rounded-lg focus:outline-none focus:border-orange-500 transition-colors text-sm"
+          />
+          <p className="text-gray-500 text-xs mt-2">💡 직접 주제를 입력하고 Enter를 눌러 추가하세요</p>
+        </div>
+
+        {/* 선택된 주제 개수 표시 */}
+        {selectedTopics.length > 0 && (
+          <div className="mt-3 text-gray-400 text-xs">선택된 주제: {selectedTopics.length}개</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -2,10 +2,11 @@ import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import PlusIcon from '@/assets/icon/plus.svg?react';
 import { BATTLE_CATEGORY_CONFIG } from '../mainPage/types/battle';
+import BattleTopicInput from './components/BattleTopicInput';
 
 type BattleType = 'PUBLIC' | 'PRIVATE';
 type BattleLanguage = 'javascript' | 'typescript' | 'python';
-type BattlePlayTime = 'FIVE_MIN' | 'TEN_MIN' | 'THIRTY_MIN';
+export type BattlePlayTime = 'FIVE_MIN' | 'TEN_MIN' | 'THIRTY_MIN';
 
 const LANGUAGE_OPTIONS: Array<{ label: string; value: BattleLanguage }> = [
   { label: 'JavaScript', value: 'javascript' },
@@ -13,10 +14,10 @@ const LANGUAGE_OPTIONS: Array<{ label: string; value: BattleLanguage }> = [
   { label: 'Python', value: 'python' }
 ];
 
-const PLAYTIME_OPTIONS: Array<{ label: string; value: BattlePlayTime }> = [
-  { label: '5분', value: 'FIVE_MIN' },
-  { label: '10분', value: 'TEN_MIN' },
-  { label: '30분', value: 'THIRTY_MIN' }
+const PLAYTIME_OPTIONS: Array<{ label: string; value: BattlePlayTime; rounds: number }> = [
+  { label: '5분', value: 'FIVE_MIN', rounds: 1 },
+  { label: '10분', value: 'TEN_MIN', rounds: 2 },
+  { label: '30분', value: 'THIRTY_MIN', rounds: 6 }
 ];
 
 const VISIBILITY_OPTIONS: Array<{ label: string; value: BattleType }> = [
@@ -44,11 +45,16 @@ export default function BattleCreatePage() {
   const [language, setLanguage] = useState<BattleLanguage>('javascript');
   const [category, setCategory] = useState(categoryOptions[0]?.value ?? 'ALGORITHM');
   const [playTime, setPlayTime] = useState<BattlePlayTime>('TEN_MIN');
+  const [topics, setTopics] = useState<string[]>([]);
   const [type, setType] = useState<BattleType>('PUBLIC');
   const [password, setPassword] = useState('');
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const rounds = useMemo(() => {
+    return PLAYTIME_OPTIONS.find(({ value }) => value === playTime)?.rounds ?? 0;
+  }, [playTime]);
 
   const canSubmit = useMemo(() => {
     if (!title.trim()) return false;
@@ -56,8 +62,10 @@ export default function BattleCreatePage() {
     if (!aCode.trim()) return false;
     if (!bCode.trim()) return false;
     if (type === 'PRIVATE' && !password.trim()) return false;
+    if (topics.length !== rounds) return false;
+
     return true;
-  }, [title, description, aCode, bCode, type, password]);
+  }, [title, description, aCode, bCode, type, password, topics.length, rounds]);
 
   const handleSubmit = async () => {
     if (!canSubmit || isSubmitting) return;
@@ -78,7 +86,8 @@ export default function BattleCreatePage() {
           type,
           password: type === 'PRIVATE' ? password : undefined,
           category,
-          playTime
+          playTime,
+          topics
         })
       });
 
@@ -244,6 +253,8 @@ export default function BattleCreatePage() {
                   </div>
                 )}
               </div>
+
+              <BattleTopicInput rounds={rounds} selectedTopics={topics} onTopicsChange={setTopics} />
 
               {errorMessage && (
                 <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">

--- a/frontend/src/pages/teamSelectPage/components/steps/Step1BattleInfo.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/Step1BattleInfo.tsx
@@ -8,6 +8,7 @@ interface Step1BattleInfoProps {
   language: string;
   currentRound: number;
   totalRounds: number;
+  topics: string[];
   totalParticipants: number;
   currentPhase?: BattlePhase;
   phaseCount?: number;
@@ -59,6 +60,7 @@ export default function Step1BattleInfo({
   language,
   currentRound,
   totalRounds,
+  topics,
   totalParticipants,
   currentPhase,
   phaseCount
@@ -129,21 +131,31 @@ export default function Step1BattleInfo({
                 <p className="text-white text-3xl font-bold mb-2 text-left">
                   라운드 {currentPhase === 'PENDING' ? 0 : currentRound} / {totalRounds}
                 </p>
-                {phaseConfig && PhaseIcon && (
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <div
-                      className={`px-3 py-1 ${phaseConfig.bgColor} border ${phaseConfig.borderColor} rounded-lg flex items-center gap-1.5`}
-                    >
-                      <PhaseIcon className={`w-4 h-4 ${phaseConfig.color}`} />
-                      <span className={`${phaseConfig.color} text-sm font-bold`}>
-                        {phaseConfig.label}
-                        {(currentPhase === 'ATTACK' || currentPhase === 'DEFENSE') && phaseCount && (
-                          <span className="ml-1.5 text-xs opacity-80">{phaseCount === 1 ? '1차' : '2차'}</span>
-                        )}
-                      </span>
+                <div className="flex items-center gap-3 flex-wrap">
+                  {currentPhase !== 'PENDING' && (
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <div className="px-3 py-1 rounded-lg font-bold flex items-center gap-1.5 text-orange-400 bg-orange-500/20 border-orange-500/50">
+                        {topics[currentRound - 1]}
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
+
+                  {phaseConfig && PhaseIcon && (
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <div
+                        className={`px-3 py-1 ${phaseConfig.bgColor} border ${phaseConfig.borderColor} rounded-lg flex items-center gap-1.5`}
+                      >
+                        <PhaseIcon className={`w-4 h-4 ${phaseConfig.color}`} />
+                        <span className={`${phaseConfig.color} text-sm font-bold`}>
+                          {phaseConfig.label}
+                          {(currentPhase === 'ATTACK' || currentPhase === 'DEFENSE') && phaseCount && (
+                            <span className="ml-1.5 text-xs opacity-80">{phaseCount === 1 ? '1차' : '2차'}</span>
+                          )}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
             <div className="w-full bg-gray-700 rounded-full h-2.5 overflow-hidden">

--- a/frontend/src/pages/teamSelectPage/components/steps/Step3Timeline.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/Step3Timeline.tsx
@@ -1,15 +1,17 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { ChevronDown, ChevronUp, ThumbsUp, Zap, Shield, Flame, ArrowRight, ArrowLeft, Clock } from 'lucide-react';
 import type { BattleDiscussion, BattleDefense } from '@/commons/types/battle';
 
 interface Step3TimelineProps {
   timelines: Array<BattleDiscussion | BattleDefense>;
+  topics: string[];
   currentRound?: number;
   totalRounds?: number;
 }
 
 interface RoundData {
   round: number;
+  topic: string;
   isActive: boolean;
   isFuture: boolean;
   challenge: {
@@ -22,20 +24,18 @@ interface RoundData {
   };
 }
 
-export default function Step3Timeline({
-  timelines,
-  currentRound = 1,
-  totalRounds = 2,
-}: Step3TimelineProps) {
-  const [expandedRounds, setExpandedRounds] = useState<Set<number>>(
-    new Set([currentRound])
-  );
+export default function Step3Timeline({ topics, timelines, currentRound = 1, totalRounds = 2 }: Step3TimelineProps) {
+  const [expandedRounds, setExpandedRounds] = useState<Set<number>>(new Set([currentRound]));
 
   // useRef는 초기화 시에만 호출되므로 Date.now()는 마운트 시 한 번만 실행됨
   const nowRef = useRef<number>(0);
-  if (nowRef.current === 0) {
-    nowRef.current = Date.now();
-  }
+
+  useEffect(() => {
+    if (nowRef.current === 0) {
+      nowRef.current = Date.now();
+    }
+  }, []);
+
   const now = nowRef.current;
 
   // 라운드별로 메시지 그룹화
@@ -43,8 +43,8 @@ export default function Step3Timeline({
     const rounds: RoundData[] = [];
 
     // attacks와 defenses 분리
-    const attacks = timelines.filter(item => item.type === 'ATTACK') as BattleDiscussion[];
-    const defenses = timelines.filter(item => item.type === 'DEFENSE') as BattleDefense[];
+    const attacks = timelines.filter((item) => item.type === 'ATTACK') as BattleDiscussion[];
+    const defenses = timelines.filter((item) => item.type === 'DEFENSE') as BattleDefense[];
 
     for (let i = 1; i <= totalRounds; i++) {
       // 각 라운드는 A팀, B팀 순서로 2개씩 저장됨
@@ -55,21 +55,22 @@ export default function Step3Timeline({
 
       const challengeA = attacks[aAttackIdx] || null;
       const challengeB = attacks[bAttackIdx] || null;
-      const rebuttalA = defenses[aDefenseIdx] as BattleDefense || null;
-      const rebuttalB = defenses[bDefenseIdx] as BattleDefense || null;
+      const rebuttalA = (defenses[aDefenseIdx] as BattleDefense) || null;
+      const rebuttalB = (defenses[bDefenseIdx] as BattleDefense) || null;
 
       rounds.push({
         round: i,
+        topic: topics[i - 1],
         isActive: i === currentRound,
         isFuture: i > currentRound,
         challenge: {
           teamA: challengeA,
-          teamB: challengeB,
+          teamB: challengeB
         },
         rebuttal: {
           teamA: rebuttalA,
-          teamB: rebuttalB,
-        },
+          teamB: rebuttalB
+        }
       });
     }
 
@@ -121,9 +122,11 @@ export default function Step3Timeline({
         {/* Header */}
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
-            <span className={`px-2 py-1 rounded text-xs font-bold ${
-              isTeamA ? 'bg-blue-600 text-white' : 'bg-red-600 text-white'
-            }`}>
+            <span
+              className={`px-2 py-1 rounded text-xs font-bold ${
+                isTeamA ? 'bg-blue-600 text-white' : 'bg-red-600 text-white'
+              }`}
+            >
               {isTeamA ? 'A팀' : 'B팀'}
             </span>
             <span className="text-white font-medium text-sm">
@@ -134,22 +137,16 @@ export default function Step3Timeline({
         </div>
 
         {/* Content */}
-        <p className="text-gray-300 mb-4 leading-relaxed text-sm">
-          {message.content}
-        </p>
+        <p className="text-gray-300 mb-4 leading-relaxed text-sm">{message.content}</p>
 
         {/* Vote Display */}
         <div
           className={`flex items-center gap-2 px-4 py-2 rounded-lg border-2 w-fit ${
-            isTeamA
-              ? 'bg-blue-600/20 border-blue-500/30'
-              : 'bg-red-600/20 border-red-500/30'
+            isTeamA ? 'bg-blue-600/20 border-blue-500/30' : 'bg-red-600/20 border-red-500/30'
           }`}
         >
           <ThumbsUp className={`w-4 h-4 ${isTeamA ? 'text-blue-400' : 'text-red-400'}`} />
-          <span className={`font-bold ${isTeamA ? 'text-blue-300' : 'text-red-300'}`}>
-            {message.upvotes}
-          </span>
+          <span className={`font-bold ${isTeamA ? 'text-blue-300' : 'text-red-300'}`}>{message.upvotes}</span>
         </div>
       </div>
     );
@@ -203,14 +200,27 @@ export default function Step3Timeline({
                   >
                     <div className="flex items-center gap-3">
                       {/* Round Badge */}
-                      <div className={`px-4 py-2 rounded-lg font-bold ${
-                        roundData.isActive
-                          ? 'bg-gradient-to-r from-orange-500 to-orange-600 text-white shadow-lg shadow-orange-500/30'
-                          : roundData.isFuture
-                            ? 'bg-gray-700/30 text-gray-600'
-                            : 'bg-gray-700/50 text-gray-400'
-                      }`}>
+                      <div
+                        className={`px-4 py-2 rounded-lg font-bold ${
+                          roundData.isActive
+                            ? 'bg-gradient-to-r from-orange-500 to-orange-600 text-white shadow-lg shadow-orange-500/30'
+                            : roundData.isFuture
+                              ? 'bg-gray-700/30 text-gray-600'
+                              : 'bg-gray-700/50 text-gray-400'
+                        }`}
+                      >
                         Round {roundData.round}
+                      </div>
+                      <div
+                        className={`px-4 py-2 rounded-lg font-semibold transition-all duration-300 ${
+                          roundData.isActive
+                            ? 'bg-gradient-to-r from-purple-400 to-purple-500 text-white shadow-md shadow-purple-400/20'
+                            : roundData.isFuture
+                              ? 'bg-gray-700/20 text-gray-500'
+                              : 'bg-gray-700/40 text-gray-400'
+                        }`}
+                      >
+                        {roundData.topic}
                       </div>
 
                       {/* Status Indicator */}
@@ -222,26 +232,16 @@ export default function Step3Timeline({
                       )}
 
                       {!roundData.isFuture && !roundData.isActive && hasContent && (
-                        <div className="text-sm text-gray-500">
-                          완료
-                        </div>
+                        <div className="text-sm text-gray-500">완료</div>
                       )}
 
-                      {roundData.isFuture && (
-                        <div className="text-sm text-gray-600">
-                          대기 중
-                        </div>
-                      )}
+                      {roundData.isFuture && <div className="text-sm text-gray-600">대기 중</div>}
                     </div>
 
                     {/* Expand Icon */}
                     {!roundData.isFuture && (
                       <div className="text-gray-400">
-                        {isExpanded ? (
-                          <ChevronUp className="w-5 h-5" />
-                        ) : (
-                          <ChevronDown className="w-5 h-5" />
-                        )}
+                        {isExpanded ? <ChevronUp className="w-5 h-5" /> : <ChevronDown className="w-5 h-5" />}
                       </div>
                     )}
                   </button>
@@ -263,9 +263,7 @@ export default function Step3Timeline({
                             <ArrowRight className="w-5 h-5 text-gray-500" />
                             <div className="flex items-center gap-2">
                               <Shield className="w-4 h-4 text-blue-400" />
-                              <span className="text-blue-400 font-bold text-xs uppercase tracking-wider">
-                                B 반론
-                              </span>
+                              <span className="text-blue-400 font-bold text-xs uppercase tracking-wider">B 반론</span>
                             </div>
                           </div>
                         </div>
@@ -301,9 +299,7 @@ export default function Step3Timeline({
                           <div className="flex items-center justify-center gap-3">
                             <div className="flex items-center gap-2">
                               <Shield className="w-4 h-4 text-blue-400" />
-                              <span className="text-blue-400 font-bold text-xs uppercase tracking-wider">
-                                A 반론
-                              </span>
+                              <span className="text-blue-400 font-bold text-xs uppercase tracking-wider">A 반론</span>
                             </div>
                             <ArrowLeft className="w-5 h-5 text-gray-500" />
                             <div className="flex items-center gap-2">

--- a/frontend/src/pages/teamSelectPage/components/steps/test/Step1BattleInfo.test.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/test/Step1BattleInfo.test.tsx
@@ -9,6 +9,7 @@ describe('Step1BattleInfo', () => {
     category: 'JavaScript',
     language: 'javascript',
     currentRound: 3,
+    topics: ['효율성', '가독성', '유지보수성', '테스트', '성능'],
     totalRounds: 5,
     totalParticipants: 95
   };

--- a/frontend/src/pages/teamSelectPage/components/steps/test/Step3Timeline.test.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/test/Step3Timeline.test.tsx
@@ -58,7 +58,7 @@ describe('Step3Timeline', () => {
   const mockTimelines = [mockAttackA, mockAttackB, mockDefenseA, mockDefenseB];
 
   it('렌더링된다', () => {
-    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} />);
+    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} topics={['효율성', '가독성']} />);
 
     // 상단 섹션 확인
     expect(screen.getByText('타임라인')).toBeInTheDocument();
@@ -66,14 +66,14 @@ describe('Step3Timeline', () => {
   });
 
   it('라운드 헤더가 표시된다', () => {
-    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} />);
+    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} topics={['효율성', '가독성']} />);
 
     // 라운드 1 헤더 확인
     expect(screen.getByText('Round 1')).toBeInTheDocument();
   });
 
   it('현재 라운드는 기본으로 펼쳐진다', () => {
-    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} />);
+    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} topics={['효율성', '가독성']} />);
 
     // 타임라인 내용이 보임
     expect(screen.getByText('구현 A의 Set 사용이 더 효율적입니다.')).toBeInTheDocument();
@@ -82,7 +82,7 @@ describe('Step3Timeline', () => {
 
   it('라운드를 접거나 펼칠 수 있다', async () => {
     const user = userEvent.setup();
-    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} />);
+    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} topics={['효율성', '가독성']} />);
 
     // 라운드 1 버튼 찾기
     const roundButton = screen.getByRole('button', { name: /Round 1/i });
@@ -104,21 +104,21 @@ describe('Step3Timeline', () => {
   });
 
   it('빈 타임라인일 때 메시지가 표시된다', () => {
-    render(<Step3Timeline timelines={[]} currentRound={1} totalRounds={2} />);
+    render(<Step3Timeline timelines={[]} currentRound={1} totalRounds={2} topics={['효율성', '가독성']} />);
 
     expect(screen.getByText('아직 이의제기가 없습니다')).toBeInTheDocument();
     expect(screen.getByText('배틀이 시작되면 여기에 표시됩니다')).toBeInTheDocument();
   });
 
   it('활성 라운드는 강조 표시된다', () => {
-    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} />);
+    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} topics={['효율성', '가독성']} />);
 
     // "진행 중" 텍스트 확인
     expect(screen.getByText('진행 중')).toBeInTheDocument();
   });
 
   it('미래 라운드는 비활성화된다', () => {
-    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} />);
+    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} topics={['효율성', '가독성']} />);
 
     // 라운드 2 버튼 찾기
     const round2Button = screen.getByRole('button', { name: /Round 2/i });
@@ -128,7 +128,7 @@ describe('Step3Timeline', () => {
   });
 
   it('팀 배지가 표시된다', () => {
-    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} />);
+    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} topics={['효율성', '가독성']} />);
 
     // A팀, B팀 배지 확인 (A팀 attack이 있고, B팀 defense가 있음)
     const teamABadges = screen.getAllByText('A팀');
@@ -138,7 +138,7 @@ describe('Step3Timeline', () => {
   });
 
   it('투표 수가 표시된다', () => {
-    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} />);
+    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} topics={['효율성', '가독성']} />);
 
     // 투표 수 확인
     expect(screen.getByText('15')).toBeInTheDocument(); // mockAttack upvotes
@@ -146,7 +146,7 @@ describe('Step3Timeline', () => {
   });
 
   it('VS 레이아웃으로 표시된다', () => {
-    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} />);
+    render(<Step3Timeline timelines={mockTimelines} currentRound={1} totalRounds={2} topics={['효율성', '가독성']} />);
 
     // Phase 헤더 확인 (A 이의제기, B 반론)
     expect(screen.getByText('A 이의제기')).toBeInTheDocument();

--- a/frontend/src/pages/teamSelectPage/index.tsx
+++ b/frontend/src/pages/teamSelectPage/index.tsx
@@ -74,6 +74,7 @@ export default function TeamSelectPage() {
             language={battleInfo.language}
             currentRound={battleInfo.currentRound}
             totalRounds={battleInfo.totalRounds}
+            topics={battleInfo.topics}
             totalParticipants={totalParticipants || battleInfo.participantCount}
             currentPhase={battleProgress?.phase}
             phaseCount={battleProgress?.phaseCount}
@@ -85,6 +86,7 @@ export default function TeamSelectPage() {
         return (
           <Step3Timeline
             timelines={[...attacks, ...defenses]}
+            topics={battleInfo.topics}
             currentRound={battleInfo.currentRound}
             totalRounds={battleInfo.totalRounds}
           />


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #135

## ✅ 작업 내용

### 생성
- [x] 배틀 생성 단계에서 사용자가 대주제를  선택할 수 있도록 체크박스를 추가하였습니다.
- [x] 주어진 대주제를 제외하고 사용자가 추가로 입력하여 항목을 추가합니다.
- [x] `playTime`에 정해진 라운드 수에 맞춰 대주제의 개수가 일치하여야 합니다.


![123](https://github.com/user-attachments/assets/53e4b93c-89e0-4675-b887-0d59b812a71e)

### 노출
- [x] 진영 선택 페이지 1번 카드에서 현재 라운드에 대한 대주제가 보여진다.
- [x] PENDING(대기) 상태에서는 보여지지 않는다.

|대기 상태|실행 상태|
|---|---|
|<img width="918" height="433" alt="스크린샷 2026-01-14 오후 4 36 09" src="https://github.com/user-attachments/assets/6372e1f9-f8dd-441b-bf4e-9d2583eecf2a" />|<img width="938" height="486" alt="스크린샷 2026-01-14 오후 4 36 22" src="https://github.com/user-attachments/assets/ae54c322-63d9-432a-ac15-da176950fbd5" />|

- [x] 진영 선택 페이지 3번 카드에서 타임라인과 함께 각 라운드별 대주제가 보여진다. 

<img width="1045" height="542" alt="스크린샷 2026-01-14 오후 4 40 17" src="https://github.com/user-attachments/assets/61fb4710-7b56-4361-aad7-7b8b87a95009" />

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

- 배틀 헤더 영역에도 대주제가 포함되어야 하는데, #133 이슈에서 추가적으로 작업할 예정입니다.
- 배틀 내 사이드바 타임라인 영역에 대주제를 포함하여야 하는데, Liger의 대대적인 타임라인 공사 #138  이 진행되면 의미가 사라질 것 같아, 리거 작업이 머지된 이후에 추가 작업 진행하겠습니다.
- 기획에는 없었지만 리키 작업물 #143  에도 라운드에 맞는 대주제가 포함되면 좋을 것 같아, 이 또한 다 머지되고 작업할 예정입니다.

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
