### PR TITLE
[Refactor] 배틀 코드 영역 UI 개선

### DIFF
--- a/frontend/src/commons/components/CodeViewer.tsx
+++ b/frontend/src/commons/components/CodeViewer.tsx
@@ -37,6 +37,11 @@ export default function CodeViewer({
           maxHeight,
           overflow: 'auto'
         }}
+        PreTag={({ children, ...props }: any) => (
+          <pre {...props} className="custom-scrollbar">
+            {children}
+          </pre>
+        )}
       >
         {code}
       </SyntaxHighlighter>

--- a/frontend/src/commons/components/CodeViewer.tsx
+++ b/frontend/src/commons/components/CodeViewer.tsx
@@ -9,6 +9,7 @@ interface CodeViewerProps {
   containerClassName?: string;
   minHeight?: string;
   maxHeight?: string;
+  'data-testid'?: string;
 }
 
 export default function CodeViewer({
@@ -16,12 +17,13 @@ export default function CodeViewer({
   language,
   containerClassName,
   minHeight = '460px',
-  maxHeight = '600px'
+  maxHeight = '600px',
+  'data-testid': dataTestId
 }: CodeViewerProps) {
   const syntaxLanguage = languageMapper(language);
 
   return (
-    <div className={`${containerClassName || 'w-full h-full'}  overflow-hidden `}>
+    <div data-testid={dataTestId} className={`${containerClassName || 'w-full h-full'}  overflow-hidden `}>
       <SyntaxHighlighter
         language={syntaxLanguage}
         style={vscDarkPlus}

--- a/frontend/src/commons/components/CodeViewer.tsx
+++ b/frontend/src/commons/components/CodeViewer.tsx
@@ -1,0 +1,43 @@
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { languageMapper } from '@/commons/utils/languageMapper';
+
+interface CodeViewerProps {
+  code: string;
+  language: string;
+  team: 'A' | 'B';
+  containerClassName?: string;
+  minHeight?: string;
+  maxHeight?: string;
+}
+
+export default function CodeViewer({
+  code,
+  language,
+  containerClassName,
+  minHeight = '460px',
+  maxHeight = '600px'
+}: CodeViewerProps) {
+  const syntaxLanguage = languageMapper(language);
+
+  return (
+    <div className={`${containerClassName || 'w-full h-full'}  overflow-hidden `}>
+      <SyntaxHighlighter
+        language={syntaxLanguage}
+        style={vscDarkPlus}
+        showLineNumbers
+        customStyle={{
+          margin: 0,
+          padding: '1rem',
+          background: '#1E1E2F',
+          fontSize: '14px',
+          minHeight,
+          maxHeight,
+          overflow: 'auto'
+        }}
+      >
+        {code}
+      </SyntaxHighlighter>
+    </div>
+  );
+}

--- a/frontend/src/commons/utils/languageMapper.ts
+++ b/frontend/src/commons/utils/languageMapper.ts
@@ -1,0 +1,9 @@
+export function languageMapper(language: string): string {
+  const languageMap: Record<string, string> = {
+    TS: 'typescript',
+    JS: 'javascript',
+    PYTHON: 'python'
+  };
+
+  return languageMap[language];
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,9 +1,24 @@
 @import 'tailwindcss';
 
 @keyframes timer-shake {
-  0%, 50%, 100% { transform: translateX(0); }
-  5%, 15%, 25%, 35%, 45% { transform: translateX(-2px); }
-  10%, 20%, 30%, 40% { transform: translateX(2px); }
+  0%,
+  50%,
+  100% {
+    transform: translateX(0);
+  }
+  5%,
+  15%,
+  25%,
+  35%,
+  45% {
+    transform: translateX(-2px);
+  }
+  10%,
+  20%,
+  30%,
+  40% {
+    transform: translateX(2px);
+  }
 }
 
 .animate-timer-shake {
@@ -11,23 +26,73 @@
 }
 
 @keyframes bounce-scale {
-  0% { transform: scale(1); }
-  30% { transform: scale(1.3); }
-  50% { transform: scale(0.9); }
-  70% { transform: scale(1.1); }
-  100% { transform: scale(1); }
+  0% {
+    transform: scale(1);
+  }
+  30% {
+    transform: scale(1.3);
+  }
+  50% {
+    transform: scale(0.9);
+  }
+  70% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 .animate-bounce-scale {
   animation: bounce-scale 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
+/* 스크롤바 */
+.custom-scrollbar::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: rgba(30, 30, 47, 0.5);
+  border-radius: 4px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  transition: background 0.2s ease;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+/* Firefox */
+.custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.2) rgba(30, 30, 47, 0.5);
+}
+
 @keyframes shake-fade-out {
-  0% { transform: scale(1) translateX(0); opacity: 1; }
-  25% { transform: scale(0.9) translateX(-5px); }
-  50% { transform: scale(0.85) translateX(5px); }
-  75% { transform: scale(0.8) translateX(-3px); opacity: 0.7; }
-  100% { transform: scale(1) translateX(0); opacity: 1; }
+  0% {
+    transform: scale(1) translateX(0);
+    opacity: 1;
+  }
+  25% {
+    transform: scale(0.9) translateX(-5px);
+  }
+  50% {
+    transform: scale(0.85) translateX(5px);
+  }
+  75% {
+    transform: scale(0.8) translateX(-3px);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(1) translateX(0);
+    opacity: 1;
+  }
 }
 
 .animate-shake-fade-out {

--- a/frontend/src/pages/battlePage/components/codeview/CodeSection.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/CodeSection.tsx
@@ -15,7 +15,7 @@ export default function CodeSection({ onViewChange, currentView, codeA, codeB, l
 
   return (
     <section
-      className="w-full h-fit flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden"
+      className="w-full max-w-full h-fit flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden"
       data-tutorial="code-section"
     >
       <CodeHeader
@@ -24,7 +24,7 @@ export default function CodeSection({ onViewChange, currentView, codeA, codeB, l
         currentTab={currentTab}
         onTabChange={setCurrentTab}
       />
-      <div className="flex gap-4 p-4 flex-1">
+      <div className="flex gap-4 p-4 flex-1 min-w-0">
         {currentView === 'split' ? (
           <>
             <CodeViewer team="A" language={language} code={codeA} />

--- a/frontend/src/pages/battlePage/components/codeview/CodeViewer.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/CodeViewer.tsx
@@ -25,7 +25,7 @@ export default function BattleCodeViewer({ team, language, code }: CodeViewerPro
   const styles = TEAM_STYLES[team];
 
   return (
-    <div className={`flex-1 ${styles.bg} rounded-lg overflow-hidden border-2 ${styles.border}`}>
+    <div className={`flex-1 min-w-0 ${styles.bg} rounded-lg overflow-hidden border-2 ${styles.border}`}>
       <div className={`${styles.header} px-4 py-2 flex justify-between items-center`}>
         <span className="text-[14px] text-white">{language}</span>
         <span className={`text-[16px] font-bold ${styles.text}`}>구현 {team}</span>

--- a/frontend/src/pages/battlePage/components/codeview/CodeViewer.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/CodeViewer.tsx
@@ -1,10 +1,12 @@
+import CodeViewer from '@/commons/components/CodeViewer';
+
 interface CodeViewerProps {
   team: 'A' | 'B';
   language: string;
   code: string;
 }
 
-const TEAMSTYLES = {
+const TEAM_STYLES = {
   A: {
     bg: 'bg-[#1C2B4A]',
     header: 'bg-[#2B5BA6]',
@@ -17,28 +19,18 @@ const TEAMSTYLES = {
     text: 'text-[#FF5A5F]',
     border: 'border-[#FB2C36]'
   }
-};
+} as const;
 
-export default function CodeViewer({ team, language, code }: CodeViewerProps) {
-  const styles = TEAMSTYLES[team];
-  const lines = code.split('\n');
+export default function BattleCodeViewer({ team, language, code }: CodeViewerProps) {
+  const styles = TEAM_STYLES[team];
 
   return (
-    <div className={`flex-1 ${styles.bg} rounded-lg overflow-hidden border ${styles.border}`}>
+    <div className={`flex-1 ${styles.bg} rounded-lg overflow-hidden border-2 ${styles.border}`}>
       <div className={`${styles.header} px-4 py-2 flex justify-between items-center`}>
         <span className="text-[14px] text-white">{language}</span>
         <span className={`text-[16px] font-bold ${styles.text}`}>구현 {team}</span>
       </div>
-      <div className="p-4 min-h-[460px]">
-        <pre className="text-[13px] text-[#E0E0E0] font-mono leading-relaxed">
-          {lines.map((line, index) => (
-            <div key={index} className="flex">
-              <span className="text-[#5A5A5A] w-8 text-right mr-4 select-none">{index + 1}</span>
-              <span>{line}</span>
-            </div>
-          ))}
-        </pre>
-      </div>
+      <CodeViewer code={code} language={language} team={team} containerClassName="w-full" />
     </div>
   );
 }

--- a/frontend/src/pages/battlePage/components/codeview/test/CodeSection.test.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/test/CodeSection.test.tsx
@@ -4,9 +4,10 @@ import userEvent from '@testing-library/user-event';
 import CodeSection from '@/pages/battlePage/components/codeview/CodeSection';
 
 vi.mock('@/pages/battlePage/components/codeview/CodeViewer', () => ({
-  default: ({ team, code }: { team: 'A' | 'B'; code: string }) => (
+  default: ({ team, language, code }: { team: 'A' | 'B'; language: string; code: string }) => (
     <div data-testid={`code-viewer-${team}`}>
       <span>구현 {team}</span>
+      <span>{language}</span>
       <pre>{code}</pre>
     </div>
   )

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -88,7 +88,7 @@ export default function BattlePage() {
         </div>
         <main className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'}`}>
           <div className="flex gap-2 py-4">
-            <div className="flex-1">
+            <div className="flex-1 min-w-0">
               <CodeSection
                 onViewChange={setViewMode}
                 currentView={viewMode}

--- a/frontend/src/pages/teamSelectPage/components/CodeCarousel.tsx
+++ b/frontend/src/pages/teamSelectPage/components/CodeCarousel.tsx
@@ -7,6 +7,15 @@ interface CodeCarouselProps {
   language: string;
 }
 
+const TEAM_STYLES = {
+  A: {
+    border: 'border-[#2B7FFF]'
+  },
+  B: {
+    border: 'border-[#FB2C36]'
+  }
+} as const;
+
 export default function CodeCarousel({ aCode, bCode, language }: CodeCarouselProps) {
   const { hoveredCode, handleHover, handleLeave } = useCodeHover();
 
@@ -14,7 +23,7 @@ export default function CodeCarousel({ aCode, bCode, language }: CodeCarouselPro
     <div className="flex items-start justify-center gap-4 w-full">
       {/* A 코드 */}
       <div
-        className={`transition-all duration-300 ${hoveredCode === 'A' ? 'w-[60%]' : hoveredCode === 'B' ? 'w-[40%]' : 'w-1/2'}`}
+        className={`transition-all duration-300 border-2 ${TEAM_STYLES.A.border} rounded-lg overflow-hidden ${hoveredCode === 'A' ? 'w-[60%]' : hoveredCode === 'B' ? 'w-[40%]' : 'w-1/2'}`}
         onMouseEnter={() => handleHover('A')}
         onMouseLeave={handleLeave}
       >
@@ -23,7 +32,7 @@ export default function CodeCarousel({ aCode, bCode, language }: CodeCarouselPro
 
       {/* B 코드 */}
       <div
-        className={`transition-all duration-300 ${hoveredCode === 'B' ? 'w-[60%]' : hoveredCode === 'A' ? 'w-[40%]' : 'w-1/2'}`}
+        className={`transition-all duration-300 border-2 ${TEAM_STYLES.B.border} rounded-lg overflow-hidden ${hoveredCode === 'B' ? 'w-[60%]' : hoveredCode === 'A' ? 'w-[40%]' : 'w-1/2'}`}
         onMouseEnter={() => handleHover('B')}
         onMouseLeave={handleLeave}
       >

--- a/frontend/src/pages/teamSelectPage/components/CodeViewer.tsx
+++ b/frontend/src/pages/teamSelectPage/components/CodeViewer.tsx
@@ -1,5 +1,4 @@
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import CodeViewer from '@/commons/components/CodeViewer';
 
 interface CodeViewerProps {
   code: string;
@@ -8,48 +7,6 @@ interface CodeViewerProps {
   isHovered?: boolean;
 }
 
-const TEAM_STYLES = {
-  A: {
-    border: 'border-[#2B7FFF]',
-    bg: 'bg-[#1C398E]'
-  },
-  B: {
-    border: 'border-[#FB2C36]',
-    bg: 'bg-[#82181A]'
-  }
-};
-
-export default function CodeViewer({ code, language, team }: CodeViewerProps) {
-  const teamStyle = TEAM_STYLES[team];
-
-  return (
-    <div
-      data-testid="code-viewer"
-      className={`
-        w-full
-        h-full
-        border-2
-        ${teamStyle.border}
-        rounded-lg
-        overflow-hidden
-      `}
-    >
-      <SyntaxHighlighter
-        language={language}
-        style={vscDarkPlus}
-        customStyle={{
-          margin: 0,
-          padding: '1rem',
-          background: '#1E1E2F',
-          fontSize: '14px',
-          minHeight: '500px',
-          maxHeight: '600px',
-          overflow: 'auto'
-        }}
-        showLineNumbers
-      >
-        {code}
-      </SyntaxHighlighter>
-    </div>
-  );
+export default function TeamSelectCodeViewer({ code, language, team }: CodeViewerProps) {
+  return <CodeViewer code={code} language={language} team={team} minHeight="500px" data-testid="code-viewer" />;
 }

--- a/frontend/src/pages/teamSelectPage/components/test/CodeViewer.test.tsx
+++ b/frontend/src/pages/teamSelectPage/components/test/CodeViewer.test.tsx
@@ -15,6 +15,17 @@ vi.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({
   vscDarkPlus: {}
 }));
 
+vi.mock('@/commons/utils/languageMapper', () => ({
+  languageMapper: (lang: string) => {
+    const map: Record<string, string> = {
+      TS: 'typescript',
+      JS: 'javascript',
+      PYTHON: 'python'
+    };
+    return map[lang] || lang;
+  }
+}));
+
 describe('CodeViewer', () => {
   const mockCode = 'function hello() { return "world"; }';
 
@@ -25,18 +36,11 @@ describe('CodeViewer', () => {
     expect(screen.getByText(mockCode)).toBeInTheDocument();
   });
 
-  it('A팀은 파란색 테두리를 사용한다', () => {
+  it('data-testid가 code-viewer로 설정된다', () => {
     const { container } = render(<CodeViewer code={mockCode} language="javascript" team="A" />);
 
     const codeContainer = container.querySelector('[data-testid="code-viewer"]');
-    expect(codeContainer).toHaveClass('border-[#2B7FFF]');
-  });
-
-  it('B팀은 빨간색 테두리를 사용한다', () => {
-    const { container } = render(<CodeViewer code={mockCode} language="javascript" team="B" />);
-
-    const codeContainer = container.querySelector('[data-testid="code-viewer"]');
-    expect(codeContainer).toHaveClass('border-[#FB2C36]');
+    expect(codeContainer).toBeInTheDocument();
   });
 
   it('전체 너비를 사용한다', () => {
@@ -47,7 +51,7 @@ describe('CodeViewer', () => {
   });
 
   it('language prop이 syntax highlighter에 전달된다', () => {
-    render(<CodeViewer code={mockCode} language="typescript" team="A" />);
+    render(<CodeViewer code={mockCode} language="TS" team="A" />);
 
     const highlighter = screen.getByTestId('syntax-highlighter');
     expect(highlighter).toHaveAttribute('data-language', 'typescript');


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->
resolve #148 

## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

#### 코드 가독성 향상을 위해 react-highlight 기반 코드 뷰어 적용
   - 라이브러리 컨벤션에 맞추기 위해 언어 매핑 유틸 함수 생성 (TS → typescript로)
#### 코드 뷰어 UI 개선
  - 코드 영역 너비 고정
  - 가로 스크롤바 스타일 커스텀
  
#### 공통 컴포넌트화
코드 뷰어를 common 영역으로 분리하여 재사용 가능하도록 구성
- 배틀 페이지, 배틀 진영 선택 페이지에서 공통 code viewer 컴포넌트 사용하도록 수정


<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->
| code viewer |
|-|
|  <img width="1283" height="628" alt="image" src="https://github.com/user-attachments/assets/4d871497-73ca-4c26-9d63-89baf57184f1" /> |


<br />

