### PR TITLE
[Feature] 가이드라인 개선

### DIFF
--- a/frontend/src/pages/battlePage/components/header/index.tsx
+++ b/frontend/src/pages/battlePage/components/header/index.tsx
@@ -39,7 +39,7 @@ export default function BattleHeader() {
       <TimeProgressBar />
       <div className="px-8 flex-1 grid grid-cols-3 items-center">
         <StageIndicator />
-        <div className="flex flex-col items-center justify-center">
+        <div className="flex flex-col items-center justify-center" data-tutorial="timer">
           {phase === 'PENDING' ? (
             <button
               type="button"

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -13,7 +13,11 @@ const COLOR_MAP = {
   PENDING: { bg: '#0A0A1A', border: '#364153', text: '#99A1AF' }
 };
 
-export default function BattleProgressBoard() {
+interface BattleProgressBoardProps {
+  raiseZIndex?: boolean;
+}
+
+export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgressBoardProps) {
   const [collapsed, setCollapsed] = useState(false);
   const battleProgress = useBattleStore(selectBattleProgress);
   if (!battleProgress) return null;
@@ -26,13 +30,15 @@ export default function BattleProgressBoard() {
 
   return (
     <div
-      className="
-        sticky top-0 z-0
+      className={`
+        sticky top-0
         flex justify-center
         pointer-events-none
-      "
+        ${raiseZIndex ? 'z-[110]' : 'z-0'}
+      `}
     >
       <div
+        data-tutorial="progress-board"
         className={`
           pointer-events-auto
           relative

--- a/frontend/src/pages/battlePage/components/sidebar/BattleSidebar.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/BattleSidebar.tsx
@@ -11,18 +11,28 @@ interface BattleSidebarProps {
   description: string;
   language: string;
   category: string;
+  raiseZIndex?: boolean;
 }
 
 type Tab = 'info' | 'timeline';
 
-export default function BattleSidebar({ isOpen, onClose, title, description, language, category }: BattleSidebarProps) {
+export default function BattleSidebar({
+  isOpen,
+  onClose,
+  title,
+  description,
+  language,
+  category,
+  raiseZIndex = false
+}: BattleSidebarProps) {
   const [activeTab, setActiveTab] = useState<Tab>('info');
 
   return (
     <aside
-      className={`fixed top-0 left-0 h-full sidebar-width bg-[#0a0a1a] border-r border-[#1A1A2E] z-100 transform transition-transform duration-300 ease-in-out shadow-2xl ${
-        isOpen ? 'translate-x-0' : '-translate-x-full'
-      }`}
+      data-tutorial="sidebar-panel"
+      className={`fixed top-0 left-0 h-full sidebar-width bg-[#0a0a1a] border-r border-[#1A1A2E] transform transition-transform duration-300 ease-in-out shadow-2xl ${
+        raiseZIndex ? 'z-[120]' : 'z-100'
+      } ${isOpen ? 'translate-x-0' : '-translate-x-full'}`}
     >
       {/* 헤더 */}
       <div>

--- a/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
@@ -4,13 +4,17 @@ import MessageIcon from '@/assets/icon/message.svg?react';
 interface BookmarkButtonProps {
   onOpen: () => void;
   isOpen: boolean;
+  highlight?: boolean;
 }
 
-export default function BookmarkButton({ onOpen, isOpen }: BookmarkButtonProps) {
+export default function BookmarkButton({ onOpen, isOpen, highlight = false }: BookmarkButtonProps) {
   if (isOpen) return null;
 
   return (
-    <div className="fixed left-0 top-1/2 -translate-y-1/2 z-30 flex flex-col gap-2">
+    <div
+      className={`fixed left-0 top-1/2 -translate-y-1/2 flex flex-col gap-2 ${highlight ? 'z-[120]' : 'z-30'}`}
+      data-tutorial="sidebar-buttons"
+    >
       {/* 문제 설명 */}
       <button
         onClick={onOpen}

--- a/frontend/src/pages/battlePage/components/tutorial/const/tutorialSteps.ts
+++ b/frontend/src/pages/battlePage/components/tutorial/const/tutorialSteps.ts
@@ -37,12 +37,12 @@ export const TUTORIAL_STEPS: Record<TutorialStep, StepContent | null> = {
     stepNumber: 1,
     highlightElement: '[data-tutorial="phase-guide"]'
   },
-  timer: {
-    title: '타이머 & 진행 상황',
+  progressBoard: {
+    title: '배틀 현황판',
     description:
-      '각 페이즈의 남은 시간을 확인하세요. 시간이 5초 이하가 되면 경고음이 울립니다! 상단의 프로그레스 바로 전체 배틀 진행률을 확인할 수 있어요.',
+      '현재 페이즈 진행 상황을 한눈에 확인하세요. 단계 아이콘이 활성 페이즈를 표시하고, 하단에서 라운드를 확인할 수 있어요. 필요하면 접어둘 수도 있습니다.',
     stepNumber: 2,
-    highlightElement: '[data-tutorial="timer"]'
+    highlightElement: '[data-tutorial="progress-board"]'
   },
   teamStatus: {
     title: '팀 현황',
@@ -84,7 +84,14 @@ export const TUTORIAL_STEPS: Record<TutorialStep, StepContent | null> = {
     stepNumber: 8,
     highlightElement: '[data-tutorial="sidebar-buttons"]'
   },
+  sidebarPanel: {
+    title: '사이드바 상세 보기',
+    description:
+      '사이드바가 열렸어요. 상단 탭으로 문제 설명과 타임라인을 전환할 수 있고, 필요한 정보를 빠르게 확인할 수 있어요.',
+    stepNumber: 9,
+    highlightElement: '[data-tutorial="sidebar-panel"]'
+  },
   completed: null
 };
 
-export const TOTAL_STEPS = 8;
+export const TOTAL_STEPS = 9;

--- a/frontend/src/pages/battlePage/components/tutorial/const/tutorialSteps.ts
+++ b/frontend/src/pages/battlePage/components/tutorial/const/tutorialSteps.ts
@@ -78,7 +78,13 @@ export const TUTORIAL_STEPS: Record<TutorialStep, StepContent | null> = {
     stepNumber: 7,
     highlightElement: '[data-tutorial="discussion-input"]'
   },
+  sidebar: {
+    title: '사이드바',
+    description: '사이드바에서 문제 설명과 타임라인을 확인할 수 있어요. 필요한 정보를 빠르게 찾아보세요!',
+    stepNumber: 8,
+    highlightElement: '[data-tutorial="sidebar-buttons"]'
+  },
   completed: null
 };
 
-export const TOTAL_STEPS = 7;
+export const TOTAL_STEPS = 8;

--- a/frontend/src/pages/battlePage/hooks/useSpotlight.ts
+++ b/frontend/src/pages/battlePage/hooks/useSpotlight.ts
@@ -39,6 +39,8 @@ export function useSpotlight({ selector, enabled = true, padding = 8 }: UseSpotl
     };
 
     updateSpotlight();
+    const animationFrameId = window.requestAnimationFrame(updateSpotlight);
+    const delayedUpdateId = window.setTimeout(updateSpotlight, 350);
 
     window.addEventListener('resize', updateSpotlight);
     window.addEventListener('scroll', updateSpotlight, true);
@@ -46,6 +48,8 @@ export function useSpotlight({ selector, enabled = true, padding = 8 }: UseSpotl
     return () => {
       window.removeEventListener('resize', updateSpotlight);
       window.removeEventListener('scroll', updateSpotlight, true);
+      window.cancelAnimationFrame(animationFrameId);
+      window.clearTimeout(delayedUpdateId);
     };
   }, [enabled, selector, padding]);
 

--- a/frontend/src/pages/battlePage/hooks/useTutorial.ts
+++ b/frontend/src/pages/battlePage/hooks/useTutorial.ts
@@ -4,8 +4,8 @@ const TUTORIAL_STORAGE_KEY = 'battlePageTutorialCompleted';
 
 export type TutorialStep =
   | 'welcome'
-  | 'timer'
   | 'phaseGuide'
+  | 'timer'
   | 'teamStatus'
   | 'codeCompare'
   | 'vote'
@@ -92,8 +92,8 @@ export function useTutorial(): UseTutorialReturn {
   const prevStep = useCallback(() => {
     const steps: TutorialStep[] = [
       'welcome',
-      'timer',
       'phaseGuide',
+      'timer',
       'teamStatus',
       'codeCompare',
       'vote',

--- a/frontend/src/pages/battlePage/hooks/useTutorial.ts
+++ b/frontend/src/pages/battlePage/hooks/useTutorial.ts
@@ -11,6 +11,7 @@ export type TutorialStep =
   | 'vote'
   | 'chat'
   | 'discussionInput'
+  | 'sidebar'
   | 'completed';
 
 interface UseTutorialReturn {
@@ -68,6 +69,7 @@ export function useTutorial(): UseTutorialReturn {
       'vote',
       'chat',
       'discussionInput',
+      'sidebar',
       'completed'
     ];
     const currentIndex = steps.indexOf(currentStep);
@@ -99,6 +101,7 @@ export function useTutorial(): UseTutorialReturn {
       'vote',
       'chat',
       'discussionInput',
+      'sidebar',
       'completed'
     ];
     const currentIndex = steps.indexOf(currentStep);

--- a/frontend/src/pages/battlePage/hooks/useTutorial.ts
+++ b/frontend/src/pages/battlePage/hooks/useTutorial.ts
@@ -5,13 +5,14 @@ const TUTORIAL_STORAGE_KEY = 'battlePageTutorialCompleted';
 export type TutorialStep =
   | 'welcome'
   | 'phaseGuide'
-  | 'timer'
+  | 'progressBoard'
   | 'teamStatus'
   | 'codeCompare'
   | 'vote'
   | 'chat'
   | 'discussionInput'
   | 'sidebar'
+  | 'sidebarPanel'
   | 'completed';
 
 interface UseTutorialReturn {
@@ -63,13 +64,14 @@ export function useTutorial(): UseTutorialReturn {
     const steps: TutorialStep[] = [
       'welcome',
       'phaseGuide',
-      'timer',
+      'progressBoard',
       'teamStatus',
       'codeCompare',
       'vote',
       'chat',
       'discussionInput',
       'sidebar',
+      'sidebarPanel',
       'completed'
     ];
     const currentIndex = steps.indexOf(currentStep);
@@ -95,13 +97,14 @@ export function useTutorial(): UseTutorialReturn {
     const steps: TutorialStep[] = [
       'welcome',
       'phaseGuide',
-      'timer',
+      'progressBoard',
       'teamStatus',
       'codeCompare',
       'vote',
       'chat',
       'discussionInput',
       'sidebar',
+      'sidebarPanel',
       'completed'
     ];
     const currentIndex = steps.indexOf(currentStep);

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams, useLoaderData } from 'react-router-dom';
 import type { BattleInfo } from '@/commons/types/battle';
 import { useBattle } from './hooks/useBattle';
@@ -26,6 +26,7 @@ export default function BattlePage() {
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
+  const sidebarOpenedForTutorial = useRef(false);
 
   // 튜토리얼 관리
   const {
@@ -44,6 +45,21 @@ export default function BattlePage() {
   useEffect(() => {
     soundManager.preload('timerWarning', '/sounds/timerSound.wav');
   }, []);
+
+  useEffect(() => {
+    const shouldOpenSidebar = isTutorialOpen && currentStep === 'sidebarPanel';
+
+    if (shouldOpenSidebar && !isSidebarOpen) {
+      handleOpenSidebar();
+      sidebarOpenedForTutorial.current = true;
+      return;
+    }
+
+    if (!shouldOpenSidebar && sidebarOpenedForTutorial.current) {
+      handleCloseSidebar();
+      sidebarOpenedForTutorial.current = false;
+    }
+  }, [currentStep, isSidebarOpen, isTutorialOpen, handleCloseSidebar, handleOpenSidebar]);
 
   const {
     isOpen: isTeamChangeModalOpen,
@@ -76,6 +92,7 @@ export default function BattlePage() {
         description={battleInfo.description}
         language={battleInfo.language}
         category={battleInfo.category}
+        raiseZIndex={isTutorialOpen && currentStep === 'sidebarPanel'}
       />
 
       {/* 메인 콘텐츠 */}
@@ -86,7 +103,7 @@ export default function BattlePage() {
       >
         <div className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'}`}>
           <div className="-mb-[10px]">
-            <BattleProgressBoard />
+            <BattleProgressBoard raiseZIndex={isTutorialOpen && currentStep === 'progressBoard'} />
           </div>
           <BattleHeader />
         </div>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -62,7 +62,11 @@ export default function BattlePage() {
   return (
     <div className="text-white relative min-h-screen">
       {/* 책갈피 버튼 */}
-      <BookmarkButton onOpen={handleOpenSidebar} isOpen={isSidebarOpen} />
+      <BookmarkButton
+        onOpen={handleOpenSidebar}
+        isOpen={isSidebarOpen}
+        highlight={isTutorialOpen && currentStep === 'sidebar'}
+      />
 
       {/* 사이드바 */}
       <BattleSidebar


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->
Closes #151 

## ✅ 작업 내용

### 가이드라인 버그 수정 

1. 배틀 시작 전에는 timer DOM이 없어서 useSpotlight가 못찾는 버그

- `frontend/src/pages/battlePage/components/header/index.tsx` : 타이머/시작 버튼이 들어가는 컨테이너에 `data-tutorial="timer"를 부여해서 상태와 무관하게 스포트라이트 적용하도록 처리

2. step3 에서 이전 버튼 클릭 시 step1로 이동하고 step2에서 클릭 시 초기 화면으로 가는 버그

- `frontend/src/pages/battlePage/hooks/useTutorial.ts` : prevStep 배열 순서가 잘못 설정되어있어 수정


### 가이드라인에 사이드 바 추가

- `frontend/src/pages/battlePage/components/tutorial/const/tutorialSteps.ts`
- `frontend/src/pages/battlePage/hooks/useTutorial.ts`
- step8 사이드바 버튼 쪽 스포트라이트 적용하여 문제설명/타임라인 설명 추가

### 사이드 바 버튼에 스포트라이트 적용 안되는 버그

현재 스포트라이트 적용 방식이 선택된 영역 주변에 검정 패널을 4개 추가하여 적용하는 방식입니다
사이드 바 버튼의 경우 좌측 끝에 위치하여 버튼 왼쪽에 생기는 검정 패널이 버튼을 가려 스포트라이트가 적용되지 않고 있음

#### 해결 방법
- 1. 주변에 패널을 덮는 방식에서 영역을 뚫는 방식으로 변경
- 2. step8에서만 사이드 바 버튼의 Z-index를 수정

일단 2번 방식으로 해결을 했습니다.


---

### 추가 구현

1. 배틀 튜토리얼 step2를 배틀 현황판 안내로 교체
2. step9에 사이드바 오픈 가이드를 추가


  - frontend/src/pages/battlePage/components/tutorial/const/tutorialSteps.ts
      - step2를 progressBoard로 변경하고 제목/설명/하이라이트를 배틀 현황판 가이드로 교체
      - step9 sidebarPanel 추가: 사이드바가 열린 상태에서 탭/정보 확인 안내
      - TOTAL_STEPS를 8 → 9로 업데이트
  - frontend/src/pages/battlePage/hooks/useTutorial.ts
      - step 이름에 progressBoard, sidebarPanel 추가
      - 진행 순서 배열에 sidebarPanel 포함
  - frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
      - 튜토리얼 하이라이트용 data-tutorial="progress-board" 추가
      - step2에서만 위로 올릴 수 있도록 raiseZIndex prop과 z-[110] 조건 적용
  - frontend/src/pages/battlePage/index.tsx
      - step2일 때 BattleProgressBoard를 전면으로 올리도록 raiseZIndex 전달
      - step9 진입 시 사이드바 자동 오픈, 이 스텝 종료 시 자동 복원 로직 추가
      - step9일 때 BattleSidebar를 전면으로 올리도록 raiseZIndex 전달
  - frontend/src/pages/battlePage/components/sidebar/BattleSidebar.tsx
      - 하이라이트 타겟으로 data-tutorial="sidebar-panel" 추가
      - step9에서만 전면 표시되도록 raiseZIndex prop 추가 및 z-[120] 적용
  - frontend/src/pages/battlePage/hooks/useSpotlight.ts
      - 사이드바 애니메이션 후에도 위치 재계산되도록 requestAnimationFrame + setTimeout(350ms) 지연 업뎃 추가


### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->
<img width="3212" height="1398" alt="image" src="https://github.com/user-attachments/assets/78ee2070-7023-405d-9ea3-6c7be30f23e7" />

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
