### PR TITLE
[Feature] 배틀 진행 현황판 UI 개선

### DIFF
--- a/frontend/src/pages/battlePage/components/header/index.tsx
+++ b/frontend/src/pages/battlePage/components/header/index.tsx
@@ -2,7 +2,6 @@ import ParticipantRatioBar from './ParticipantRatioBar';
 import StageIndicator from './StageIndicator';
 import BattleTimer from './BattleTimer';
 import TeamCounter from './TeamCounter';
-import TimeProgressBar from './TimeProgressBar';
 import {
   useBattleStore,
   selectBattleProgress,
@@ -33,10 +32,9 @@ export default function BattleHeader() {
 
   return (
     <header
-      className="h-[185px] w-[1800px] bg-[#1E1E2F] rounded-lg mb-2 overflow-hidden flex flex-col"
+      className="h-[179px] w-[1800px] bg-[#1E1E2F] rounded-lg mb-2 overflow-hidden flex flex-col"
       data-tutorial="phase-guide"
     >
-      <TimeProgressBar />
       <div className="px-8 flex-1 grid grid-cols-3 items-center">
         <StageIndicator />
         <div className="flex flex-col items-center justify-center" data-tutorial="timer">

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -65,11 +65,7 @@ const STAGES = [
   }
 ] as const;
 
-interface BattleProgressBoardProps {
-  raiseZIndex?: boolean;
-}
-
-export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgressBoardProps) {
+export default function BattleProgressBoard() {
   const [collapsed, setCollapsed] = useState(false);
   const battleProgress = useBattleStore(selectBattleProgress);
 

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -85,7 +85,7 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
           border-b-[1.333px] border-b-[#1E2939]
           shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.25)]
           transition-all duration-300 ease-in-out
-          ${collapsed ? '-translate-y-[120px] h-[32px]' : 'h-[143.33px]'}
+          ${collapsed ? '-translate-y-[120px] h-[32px]' : 'h-[100px] pb-3'}
         `}
       >
         {!collapsed && (
@@ -144,14 +144,14 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
 
         <div
           className={`
-            absolute left-[26.21px] top-[16px]
+            absolute left-[26.21px] top-[12px]
             w-[700px]
-            flex flex-col gap-2
+            flex flex-col gap-1.5
             transition-opacity duration-200
             ${collapsed ? 'opacity-0 pointer-events-none' : 'opacity-100'}
           `}
         >
-          <div className="flex items-center gap-4 px-4 pt-2">
+          <div className="flex items-center gap-4 px-4">
             <div className="text-[32px] font-bold text-[#FF6900] min-w-[100px] flex items-center justify-center h-[56px]">
               {getCurrentStageNumber()}
             </div>
@@ -168,7 +168,7 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
             ))}
           </div>
 
-          <div className="mt-4 h-[6px] bg-[#0A0A1A] rounded-full overflow-hidden">
+          <div className="mt-1.5 h-[6px] bg-[#0A0A1A] rounded-full overflow-hidden">
             <div
               key={`${battleProgress?.expiredAt}-${battleProgress?.startedAt}`}
               className="h-full bg-gradient-to-r from-[#FF6900] via-[#FF8904] to-[#F54900]"

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -43,9 +43,13 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
 
   // 현재 페이즈의 step 번호 계산 (1-6)
   const getCurrentPhaseStep = () => {
-    // phaseCount를 6으로 나눈 나머지 + 1 (1-6 순환)
-    const step = (phaseCount % 6) + 1;
-    return step;
+    // phaseCount는 ATTACK/DEFENSE 반복 횟수 (1~BATTLE_MAX_PHASE_COUNT)
+    // phase와 phaseCount로 step 계산
+    if (phase === 'OPINION_SHARE') return 1;
+    if (phase === 'ATTACK') return phaseCount * 2; // 1차: 2, 2차: 4
+    if (phase === 'DEFENSE') return phaseCount * 2 + 1; // 1차: 3, 2차: 5
+    if (phase === 'TEAM_SWITCH') return 6;
+    return 1;
   };
 
   // 현재 활성 단계인지 확인

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -134,9 +134,7 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
               bg-gradient-to-r from-[#FF6900] via-[#FF8904] to-[#F54900]"
           />
 
-          <div className="text-center text-[12px] tracking-[0.6px] uppercase text-[#FF6900]">배틀 진행 상황</div>
-
-          <div className="flex items-center justify-between gap-3 px-4">
+          <div className="flex items-center justify-between gap-3 px-4 pt-6">
             {STAGES.map((stage, index) => (
               <div key={stage.step} className="flex items-center gap-3">
                 <StageIcon
@@ -149,10 +147,6 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
                 {index < STAGES.length - 1 && <DownArrowIcon className="-rotate-90 opacity-40 -translate-y-2" />}
               </div>
             ))}
-          </div>
-
-          <div className="relative mt-1 h-[15px]">
-            <div className="text-center text-[10px] font-bold text-[#6A7282]">Round {round}</div>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -83,6 +83,11 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
 
   const { round, phase, phaseCount } = battleProgress;
 
+  // PENDING 상태일 때는 아예 렌더링하지 않음
+  if ((phase as string) === 'PENDING') {
+    return null;
+  }
+
   // 현재 페이즈의 step 번호 계산 (1-6)
   const getCurrentPhaseStep = () => {
     // phaseCount는 ATTACK/DEFENSE 반복 횟수 (1~BATTLE_MAX_PHASE_COUNT)
@@ -113,8 +118,8 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
         sticky top-0 z-10
         flex justify-center
         pointer-events-none
-        ${raiseZIndex ? 'z-[110]' : 'z-0'}
-      `}
+        animate-slideDown
+      "
     >
       <div
         data-tutorial="progress-board"
@@ -227,6 +232,19 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
         @keyframes shrink {
           from { width: 100%; }
           to { width: 0%; }
+        }
+        @keyframes slideDown {
+          from {
+            transform: translateY(-100%);
+            opacity: 0;
+          }
+          to {
+            transform: translateY(0);
+            opacity: 1;
+          }
+        }
+        .animate-slideDown {
+          animation: slideDown 0.5s ease-out;
         }
       `}</style>
     </div>

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -52,7 +52,7 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
   const getCurrentStageNumber = () => {
     if (phase === 'PENDING') return '배틀 대기중';
     const currentStage = STAGES.find((stage) => isActiveStage(stage.phase, stage.turn));
-    return currentStage ? `${currentStage.turn || round}-${currentStage.step}` : '1-1';
+    return currentStage ? `${currentStage.turn || round} - ${currentStage.step}` : '1 - 1';
   };
 
   const getStageColor = (stage: BattlePhase) => COLOR_MAP[stage] || COLOR_MAP.BASE;
@@ -71,7 +71,7 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
         className={`
           pointer-events-auto
           relative
-          w-[850px]
+          w-[750px]
           rounded-lg
           bg-[#1a1a2ef2]
           border-b-[1.333px] border-b-[#1E2939]
@@ -137,19 +137,21 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
         <div
           className={`
             absolute left-[26.21px] top-[16px]
-            w-[800px]
+            w-[700px]
             flex flex-col gap-2
             transition-opacity duration-200
             ${collapsed ? 'opacity-0 pointer-events-none' : 'opacity-100'}
           `}
         >
           <div
-            className="absolute left-[6px] top-[-4px] h-[4px] w-[790px]
+            className="absolute left-[6px] top-[-4px] h-[4px] w-[690px]
               bg-gradient-to-r from-[#FF6900] via-[#FF8904] to-[#F54900]"
           />
 
-          <div className="flex items-center justify-between gap-3 px-4 pt-6">
-            <div className="text-[24px] font-bold text-[#FF6900] min-w-[120px]">{getCurrentStageNumber()}</div>
+          <div className="flex items-center gap-4 px-4 pt-6">
+            <div className="text-[32px] font-bold text-[#FF6900] min-w-[100px] flex items-center justify-center h-[52.8px]">
+              {getCurrentStageNumber()}
+            </div>
             {STAGES.map((stage, index) => (
               <div key={stage.step} className="flex items-center gap-3">
                 <StageIcon
@@ -158,7 +160,7 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
                   active={isActiveStage(stage.phase, stage.turn)}
                   small={stage.step !== 1}
                 />
-                {index < STAGES.length - 1 && <DownArrowIcon className="-rotate-90 opacity-40 -translate-y-2" />}
+                {index < STAGES.length - 1 && <DownArrowIcon className="-rotate-90 opacity-40" />}
               </div>
             ))}
           </div>

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -15,12 +15,54 @@ const COLOR_MAP = {
 
 // 6단계 정의 (한 라운드당 6개 페이즈)
 const STAGES = [
-  { step: 1, phase: 'OPINION_SHARE', icon: 'message', label: '의견공유' },
-  { step: 2, phase: 'ATTACK', icon: 'battle', label: '공격(1차)' },
-  { step: 3, phase: 'DEFENSE', icon: 'shield', label: '수비(1차)' },
-  { step: 4, phase: 'ATTACK', icon: 'battle', label: '공격(2차)' },
-  { step: 5, phase: 'DEFENSE', icon: 'shield', label: '수비(2차)' },
-  { step: 6, phase: 'TEAM_SWITCH', icon: 'switch', label: '팀변경' }
+  {
+    step: 1,
+    phase: 'OPINION_SHARE',
+    icon: 'message',
+    label: '의견공유',
+    description:
+      '의견공유 시간입니다. 현재 라운드의 대주제를 확인하고 라운지에서 자유롭게 의견을 나누며 이의제기를 준비해주세요!'
+  },
+  {
+    step: 2,
+    phase: 'ATTACK',
+    icon: 'battle',
+    label: '공격(1차)',
+    description:
+      '1차 이의제기 시간입니다. 주어진 3분 동안 상대 코드의 문제점을 찾고 투표를 통해 공격할 내용을 선정해보세요!'
+  },
+  {
+    step: 3,
+    phase: 'DEFENSE',
+    icon: 'shield',
+    label: '수비(1차)',
+    description:
+      '1차 반론 시간입니다. 주어진 4분 동안 상대의 공격에 대한 반박 논리를 작성하고 투표를 통해 방어할 내용을 선정해보세요!'
+  },
+  {
+    step: 4,
+    phase: 'ATTACK',
+    icon: 'battle',
+    label: '공격(2차)',
+    description:
+      '2차 이의제기 시간입니다. 주어진 3분 동안 상대 코드 혹은 반론에 대한 문제점을 찾고 투표를 통해 공격할 내용을 선정해보세요!'
+  },
+  {
+    step: 5,
+    phase: 'DEFENSE',
+    icon: 'shield',
+    label: '수비(2차)',
+    description:
+      '2차 반론 시간입니다. 주어진 4분 동안 상대의 공격에 대한 반박 논리를 작성하고 투표를 통해 최종적으로 방어할 내용을 선정해보세요!'
+  },
+  {
+    step: 6,
+    phase: 'TEAM_SWITCH',
+    icon: 'switch',
+    label: '팀변경',
+    description:
+      '진영 선택 시간입니다. 라운드를 진행하며 나눈 공격과 수비를 다시 확인해보고 지지하시는 팀으로 변경하실 수 있습니다!'
+  }
 ] as const;
 
 interface BattleProgressBoardProps {
@@ -162,6 +204,7 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
                   {...getStageColor(stage.phase as BattlePhase)}
                   active={isActiveStage(stage.step)}
                   small={true}
+                  tooltip={stage.description}
                 />
                 {index < STAGES.length - 1 && <DownArrowIcon className="-rotate-90 opacity-40" />}
               </div>

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -41,6 +41,13 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
     return round === stageTurn;
   };
 
+  // 현재 라운드-페이즈 번호 계산
+  const getCurrentStageNumber = () => {
+    if (phase === 'PENDING') return '배틀 대기중';
+    const currentStage = STAGES.find((stage) => isActiveStage(stage.phase, stage.turn));
+    return currentStage ? `${currentStage.turn || round}-${currentStage.step}` : '1-1';
+  };
+
   const getStageColor = (stage: BattlePhase) => COLOR_MAP[stage] || COLOR_MAP.BASE;
 
   return (
@@ -135,10 +142,10 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
           />
 
           <div className="flex items-center justify-between gap-3 px-4 pt-6">
+            <div className="text-[24px] font-bold text-[#FF6900] min-w-[120px]">{getCurrentStageNumber()}</div>
             {STAGES.map((stage, index) => (
               <div key={stage.step} className="flex items-center gap-3">
                 <StageIcon
-                  label={stage.label}
                   icon={stage.icon as 'message' | 'battle' | 'shield' | 'switch'}
                   {...getStageColor(stage.phase as BattlePhase)}
                   active={isActiveStage(stage.phase, stage.turn)}

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { StageIcon } from './StageIcon';
 import DownArrowIcon from '@/assets/icon/downArrow.svg?react';
 import { selectBattleProgress, useBattleStore } from '../../stores/battleStore';
@@ -30,6 +30,13 @@ interface BattleProgressBoardProps {
 export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgressBoardProps) {
   const [collapsed, setCollapsed] = useState(false);
   const battleProgress = useBattleStore(selectBattleProgress);
+
+  // 프로그레스 바 duration 계산
+  const duration = useMemo(() => {
+    if (!battleProgress?.expiredAt || !battleProgress?.startedAt) return 60;
+    return Math.max(0, (battleProgress.expiredAt - battleProgress.startedAt) / 1000);
+  }, [battleProgress?.expiredAt, battleProgress?.startedAt]);
+
   if (!battleProgress) return null;
 
   const { round, phase } = battleProgress;
@@ -155,8 +162,25 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
               </div>
             ))}
           </div>
+
+          <div className="mt-4 h-[6px] bg-[#0A0A1A] rounded-full overflow-hidden">
+            <div
+              key={`${battleProgress?.expiredAt}-${battleProgress?.startedAt}`}
+              className="h-full bg-gradient-to-r from-[#FF6900] via-[#FF8904] to-[#F54900]"
+              style={{
+                animation: `shrink ${duration}s linear`,
+                animationFillMode: 'forwards'
+              }}
+            />
+          </div>
         </div>
       </div>
+      <style>{`
+        @keyframes shrink {
+          from { width: 100%; }
+          to { width: 0%; }
+        }
+      `}</style>
     </div>
   );
 }

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -104,10 +104,9 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
     return getCurrentPhaseStep() === stageStep;
   };
 
-  // 현재 라운드-페이즈 번호 계산
+  // 현재 라운드 번호 표시
   const getCurrentStageNumber = () => {
-    if (phase === 'PENDING') return '대기중';
-    return `${round} - ${getCurrentPhaseStep()}`;
+    return `Round ${round}`;
   };
 
   const getStageColor = (stage: BattlePhase) => COLOR_MAP[stage] || COLOR_MAP.BASE;
@@ -199,7 +198,7 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
           `}
         >
           <div className="flex items-center gap-4 px-4">
-            <div className="text-[32px] font-bold text-[#FF6900] min-w-[100px] flex items-center justify-center h-[56px]">
+            <div className="text-[22px] font-bold text-[#FF6900] min-w-[100px] flex items-center justify-center h-[56px]">
               {getCurrentStageNumber()}
             </div>
             {STAGES.map((stage, index) => (

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -67,8 +67,8 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
 
   return (
     <div
-      className={`
-        sticky top-0
+      className="
+        sticky top-0 z-10
         flex justify-center
         pointer-events-none
         ${raiseZIndex ? 'z-[110]' : 'z-0'}
@@ -151,12 +151,7 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
             ${collapsed ? 'opacity-0 pointer-events-none' : 'opacity-100'}
           `}
         >
-          <div
-            className="absolute left-[6px] top-[-4px] h-[4px] w-[690px]
-              bg-gradient-to-r from-[#FF6900] via-[#FF8904] to-[#F54900]"
-          />
-
-          <div className="flex items-center gap-4 px-4 pt-6">
+          <div className="flex items-center gap-4 px-4 pt-2">
             <div className="text-[32px] font-bold text-[#FF6900] min-w-[100px] flex items-center justify-center h-[56px]">
               {getCurrentStageNumber()}
             </div>

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -13,14 +13,14 @@ const COLOR_MAP = {
   PENDING: { bg: '#0A0A1A', border: '#364153', text: '#99A1AF' }
 };
 
-// 6단계 정의
+// 6단계 정의 (한 라운드당 6개 페이즈)
 const STAGES = [
-  { step: 1, phase: 'OPINION_SHARE', icon: 'message', label: '의견공유', turn: null },
-  { step: 2, phase: 'ATTACK', icon: 'battle', label: '공격(1차)', turn: 1 },
-  { step: 3, phase: 'DEFENSE', icon: 'shield', label: '수비(1차)', turn: 1 },
-  { step: 4, phase: 'ATTACK', icon: 'battle', label: '공격(2차)', turn: 2 },
-  { step: 5, phase: 'DEFENSE', icon: 'shield', label: '수비(2차)', turn: 2 },
-  { step: 6, phase: 'TEAM_SWITCH', icon: 'switch', label: '팀변경', turn: null }
+  { step: 1, phase: 'OPINION_SHARE', icon: 'message', label: '의견공유' },
+  { step: 2, phase: 'ATTACK', icon: 'battle', label: '공격(1차)' },
+  { step: 3, phase: 'DEFENSE', icon: 'shield', label: '수비(1차)' },
+  { step: 4, phase: 'ATTACK', icon: 'battle', label: '공격(2차)' },
+  { step: 5, phase: 'DEFENSE', icon: 'shield', label: '수비(2차)' },
+  { step: 6, phase: 'TEAM_SWITCH', icon: 'switch', label: '팀변경' }
 ] as const;
 
 interface BattleProgressBoardProps {
@@ -39,20 +39,24 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
 
   if (!battleProgress) return null;
 
-  const { round, phase } = battleProgress;
+  const { round, phase, phaseCount } = battleProgress;
+
+  // 현재 페이즈의 step 번호 계산 (1-6)
+  const getCurrentPhaseStep = () => {
+    // phaseCount를 6으로 나눈 나머지 + 1 (1-6 순환)
+    const step = (phaseCount % 6) + 1;
+    return step;
+  };
 
   // 현재 활성 단계인지 확인
-  const isActiveStage = (stagePhase: string, stageTurn: number | null) => {
-    if (phase !== stagePhase) return false;
-    if (stageTurn === null) return true;
-    return round === stageTurn;
+  const isActiveStage = (stageStep: number) => {
+    return getCurrentPhaseStep() === stageStep;
   };
 
   // 현재 라운드-페이즈 번호 계산
   const getCurrentStageNumber = () => {
     if (phase === 'PENDING') return '배틀 대기중';
-    const currentStage = STAGES.find((stage) => isActiveStage(stage.phase, stage.turn));
-    return currentStage ? `${currentStage.turn || round} - ${currentStage.step}` : '1 - 1';
+    return `${round} - ${getCurrentPhaseStep()}`;
   };
 
   const getStageColor = (stage: BattlePhase) => COLOR_MAP[stage] || COLOR_MAP.BASE;
@@ -157,7 +161,7 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
                 <StageIcon
                   icon={stage.icon as 'message' | 'battle' | 'shield' | 'switch'}
                   {...getStageColor(stage.phase as BattlePhase)}
-                  active={isActiveStage(stage.phase, stage.turn)}
+                  active={isActiveStage(stage.step)}
                   small={stage.step !== 1}
                 />
                 {index < STAGES.length - 1 && <DownArrowIcon className="-rotate-90 opacity-40" />}

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -59,7 +59,7 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
 
   // 현재 라운드-페이즈 번호 계산
   const getCurrentStageNumber = () => {
-    if (phase === 'PENDING') return '배틀 대기중';
+    if (phase === 'PENDING') return '대기중';
     return `${round} - ${getCurrentPhaseStep()}`;
   };
 

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -157,7 +157,7 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
           />
 
           <div className="flex items-center gap-4 px-4 pt-6">
-            <div className="text-[32px] font-bold text-[#FF6900] min-w-[100px] flex items-center justify-center h-[52.8px]">
+            <div className="text-[32px] font-bold text-[#FF6900] min-w-[100px] flex items-center justify-center h-[56px]">
               {getCurrentStageNumber()}
             </div>
             {STAGES.map((stage, index) => (
@@ -166,7 +166,7 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
                   icon={stage.icon as 'message' | 'battle' | 'shield' | 'switch'}
                   {...getStageColor(stage.phase as BattlePhase)}
                   active={isActiveStage(stage.step)}
-                  small={stage.step !== 1}
+                  small={true}
                 />
                 {index < STAGES.length - 1 && <DownArrowIcon className="-rotate-90 opacity-40" />}
               </div>

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -13,6 +13,16 @@ const COLOR_MAP = {
   PENDING: { bg: '#0A0A1A', border: '#364153', text: '#99A1AF' }
 };
 
+// 6단계 정의
+const STAGES = [
+  { step: 1, phase: 'OPINION_SHARE', icon: 'message', label: '의견공유', turn: null },
+  { step: 2, phase: 'ATTACK', icon: 'battle', label: '공격(1차)', turn: 1 },
+  { step: 3, phase: 'DEFENSE', icon: 'shield', label: '수비(1차)', turn: 1 },
+  { step: 4, phase: 'ATTACK', icon: 'battle', label: '공격(2차)', turn: 2 },
+  { step: 5, phase: 'DEFENSE', icon: 'shield', label: '수비(2차)', turn: 2 },
+  { step: 6, phase: 'TEAM_SWITCH', icon: 'switch', label: '팀변경', turn: null }
+] as const;
+
 interface BattleProgressBoardProps {
   raiseZIndex?: boolean;
 }
@@ -24,9 +34,14 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
 
   const { round, phase } = battleProgress;
 
-  const isActive = (stage: BattlePhase) => phase === stage;
+  // 현재 활성 단계인지 확인
+  const isActiveStage = (stagePhase: string, stageTurn: number | null) => {
+    if (phase !== stagePhase) return false;
+    if (stageTurn === null) return true;
+    return round === stageTurn;
+  };
 
-  const getStageColor = (stage: BattlePhase) => (isActive(stage) ? COLOR_MAP[stage] : COLOR_MAP.BASE);
+  const getStageColor = (stage: BattlePhase) => COLOR_MAP[stage] || COLOR_MAP.BASE;
 
   return (
     <div
@@ -42,7 +57,7 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
         className={`
           pointer-events-auto
           relative
-          w-[400px]
+          w-[850px]
           rounded-lg
           bg-[#1a1a2ef2]
           border-b-[1.333px] border-b-[#1E2939]
@@ -108,44 +123,32 @@ export default function BattleProgressBoard({ raiseZIndex = false }: BattleProgr
         <div
           className={`
             absolute left-[26.21px] top-[16px]
-            w-[347.58px]
+            w-[800px]
             flex flex-col gap-2
             transition-opacity duration-200
             ${collapsed ? 'opacity-0 pointer-events-none' : 'opacity-100'}
           `}
         >
           <div
-            className="absolute left-[6px] top-[-4px] h-[4px] w-[336px]
+            className="absolute left-[6px] top-[-4px] h-[4px] w-[790px]
               bg-gradient-to-r from-[#FF6900] via-[#FF8904] to-[#F54900]"
           />
 
           <div className="text-center text-[12px] tracking-[0.6px] uppercase text-[#FF6900]">배틀 진행 상황</div>
 
-          <div className="flex items-center gap-4">
-            <StageIcon
-              label="의견 공유"
-              icon="message"
-              {...getStageColor('OPINION_SHARE')}
-              active={isActive('OPINION_SHARE')}
-            />
-
-            <DownArrowIcon className="-rotate-90 opacity-40 -translate-y-2" />
-
-            <StageIcon label="이의제기" icon="battle" small {...getStageColor('ATTACK')} active={isActive('ATTACK')} />
-
-            <DownArrowIcon className="-rotate-90 opacity-40 -translate-y-2" />
-
-            <StageIcon label="반박" icon="shield" small {...getStageColor('DEFENSE')} active={isActive('DEFENSE')} />
-
-            <DownArrowIcon className="-rotate-90 opacity-40 -translate-y-2" />
-
-            <StageIcon
-              label="팀 변경"
-              icon="switch"
-              small
-              {...getStageColor('TEAM_SWITCH')}
-              active={isActive('TEAM_SWITCH')}
-            />
+          <div className="flex items-center justify-between gap-3 px-4">
+            {STAGES.map((stage, index) => (
+              <div key={stage.step} className="flex items-center gap-3">
+                <StageIcon
+                  label={stage.label}
+                  icon={stage.icon as 'message' | 'battle' | 'shield' | 'switch'}
+                  {...getStageColor(stage.phase as BattlePhase)}
+                  active={isActiveStage(stage.phase, stage.turn)}
+                  small={stage.step !== 1}
+                />
+                {index < STAGES.length - 1 && <DownArrowIcon className="-rotate-90 opacity-40 -translate-y-2" />}
+              </div>
+            ))}
           </div>
 
           <div className="relative mt-1 h-[15px]">

--- a/frontend/src/pages/battlePage/components/progressBoard/StageIcon.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/StageIcon.tsx
@@ -18,9 +18,12 @@ export function StageIcon({
   active?: boolean;
   small?: boolean;
 }) {
-  const size = small ? 'w-[48px] h-[48px]' : 'w-[52.8px] h-[52.8px]';
-  const iconClass = `w-[20px] h-[20px] ${active ? '' : 'opacity-40'}`;
-  const iconStyle = active ? { color: text } : undefined;
+  const baseSize = small ? 48 : 52.8;
+  const activeSize = small ? 56 : 60;
+  const size = active ? activeSize : baseSize;
+
+  const iconClass = `w-[20px] h-[20px] transition-all`;
+  const iconStyle = active ? { color: text } : { color: '#99A1AF' };
 
   const renderIcon = () => {
     switch (icon) {
@@ -41,16 +44,17 @@ export function StageIcon({
     <div className="flex flex-col items-center gap-1">
       <div
         className={`
-          ${size}
           rounded-[12px]
           flex items-center justify-center
           border-[1.333px]
-          transition-all
+          transition-all duration-300 ease-in-out
           ${active ? 'shadow-[0px_20px_25px_-5px_rgba(0,0,0,0.25)]' : ''}
         `}
         style={{
-          background: bg,
-          borderColor: border
+          width: `${size}px`,
+          height: `${size}px`,
+          background: active ? bg : '#0A0A1A',
+          borderColor: active ? border : '#364153'
         }}
       >
         {renderIcon()}

--- a/frontend/src/pages/battlePage/components/progressBoard/StageIcon.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/StageIcon.tsx
@@ -74,6 +74,17 @@ export function StageIcon({
           "
         >
           {tooltip}
+          {/* 테두리용 화살표 (더 크게) */}
+          <div
+            className="
+              absolute bottom-full left-1/2 -translate-x-1/2 translate-y-[0.5px]
+              w-0 h-0
+              border-l-[8px] border-l-transparent
+              border-r-[8px] border-r-transparent
+              border-b-[8px] border-b-[#364153]
+            "
+          />
+          {/* 배경색 화살표 (작게, 위에 겹침) */}
           <div
             className="
               absolute bottom-full left-1/2 -translate-x-1/2

--- a/frontend/src/pages/battlePage/components/progressBoard/StageIcon.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/StageIcon.tsx
@@ -4,7 +4,6 @@ import ShieldIcon from '@/assets/icon/shield.svg?react';
 import SwitchIcon from '@/assets/icon/switch.svg?react';
 
 export function StageIcon({
-  label,
   icon,
   bg,
   border,
@@ -12,7 +11,6 @@ export function StageIcon({
   active,
   small
 }: {
-  label: string;
   icon: 'message' | 'battle' | 'shield' | 'switch';
   bg: string;
   border: string;
@@ -56,10 +54,6 @@ export function StageIcon({
         }}
       >
         {renderIcon()}
-      </div>
-
-      <div className="text-[10px] font-bold text-center" style={{ color: active ? text : '#99A1AF' }}>
-        {label}
       </div>
     </div>
   );

--- a/frontend/src/pages/battlePage/components/progressBoard/StageIcon.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/StageIcon.tsx
@@ -9,7 +9,8 @@ export function StageIcon({
   border,
   text,
   active,
-  small
+  small,
+  tooltip
 }: {
   icon: 'message' | 'battle' | 'shield' | 'switch';
   bg: string;
@@ -17,6 +18,7 @@ export function StageIcon({
   text: string;
   active?: boolean;
   small?: boolean;
+  tooltip?: string;
 }) {
   const baseSize = small ? 48 : 52.8;
   const activeSize = small ? 56 : 60;
@@ -41,7 +43,7 @@ export function StageIcon({
   };
 
   return (
-    <div className="flex flex-col items-center gap-1">
+    <div className="relative flex flex-col items-center gap-1 group">
       <div
         className={`
           rounded-[12px]
@@ -59,6 +61,30 @@ export function StageIcon({
       >
         {renderIcon()}
       </div>
+      {tooltip && (
+        <div
+          className="
+            absolute top-full mt-2 px-3 py-2
+            bg-[#1E1E2F] text-white text-sm rounded-lg
+            shadow-lg border border-[#364153]
+            opacity-0 group-hover:opacity-100
+            pointer-events-none
+            transition-opacity duration-200
+            whitespace-nowrap z-20
+          "
+        >
+          {tooltip}
+          <div
+            className="
+              absolute bottom-full left-1/2 -translate-x-1/2
+              w-0 h-0
+              border-l-[6px] border-l-transparent
+              border-r-[6px] border-r-transparent
+              border-b-[6px] border-b-[#1E1E2F]
+            "
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -111,10 +111,10 @@ export default function BattlePage() {
           isSidebarOpen ? 'ml-sidebar' : 'ml-0'
         }`}
       >
-        <div className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'}`}>
-          <div className="-mb-[10px]">
-            <BattleProgressBoard raiseZIndex={isTutorialOpen && currentStep === 'progressBoard'} />
-          </div>
+        <BattleProgressBoard />
+        <div
+          className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'} -mt-[10px]`}
+        >
           <BattleHeader />
         </div>
         <main className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'}`}>


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #140

## ✅ 작업 내용

### 💡개선 사항

1. **아이콘 상태 시각화 강화**
   - 활성화 시 크기 증가 (48px → 56px) 및 원래 색상 표시
   - 비활성화 시 회색 처리로 명확한 구분

2. **프로그레스 바 통합**
   - 헤더의 중복 프로그레스 바 제거
   - 현황판 하단에 프로그레스 바 통합하여 일관성 향상

3. **레이아웃 최적화**
   - Sticky 동작 개선으로 스크롤 시 항상 표시
   - 높이 최소화 (143px → 100px)로 화면 공간 효율화
   - 불필요한 상단 장식 줄 제거

4. **사용자 가이드 추가**
   - 각 페이즈 아이콘에 호버 시 상세 설명 툴팁 표시
   - 각 페이즈별 진행 방법 안내

5. **애니메이션 효과**
   - 대기 중에는 현황판 숨김 처리
   - 배틀 시작 시 슬라이드 다운 애니메이션 (0.5s)

6. **라운드 표시 개선**
   - "라운드 - 페이즈" → "Round N" 형태로 간소화
   - 글자 크기 30% 축소 (32px → 22px)
<br />

## 📸 참고 사항

<img width="2032" height="1167" alt="스크린샷 2026-01-15 오후 3 39 33" src="https://github.com/user-attachments/assets/88d1fb37-8165-4a71-97d0-c87136b5b2c9" />

<img width="2032" height="1167" alt="스크린샷 2026-01-15 오후 3 39 47" src="https://github.com/user-attachments/assets/ccebbc4f-7000-4c45-988b-66b4ceb834be" />

<img width="2032" height="1167" alt="스크린샷 2026-01-15 오후 3 40 12" src="https://github.com/user-attachments/assets/df772bbf-7bb3-4324-b3d4-65e2ea757ba4" />

<br />

## 💬 질문사항 (고민했던 부분)
