### PR TITLE
[Feature] 이의제기/반박 input UI 개선 

### DIFF
--- a/backend/src/battles/const/battles.const.ts
+++ b/backend/src/battles/const/battles.const.ts
@@ -5,19 +5,19 @@ export const BATTLE_PHASE = {
   },
   OPINION_SHARE: {
     name: 'OPINION_SHARE',
-    time: 60 * 1000, // 1분
+    time: 4 * 1000, // 1분
   },
   ATTACK: {
     name: 'ATTACK',
-    time: 60 * 1000, // 1분
+    time: 10 * 1000, // 1분
   },
   DEFENSE: {
     name: 'DEFENSE',
-    time: 60 * 1000, // 1분
+    time: 10 * 1000, // 1분
   },
   TEAM_SWITCH: {
     name: 'TEAM_SWITCH',
-    time: 15 * 1000, // 15초
+    time: 5 * 1000, // 15초
   },
 } as const
 

--- a/backend/src/battles/const/battles.const.ts
+++ b/backend/src/battles/const/battles.const.ts
@@ -5,19 +5,19 @@ export const BATTLE_PHASE = {
   },
   OPINION_SHARE: {
     name: 'OPINION_SHARE',
-    time: 4 * 1000, // 1분
+    time: 60 * 1000, // 1분
   },
   ATTACK: {
     name: 'ATTACK',
-    time: 10 * 1000, // 1분
+    time: 60 * 1000, // 1분
   },
   DEFENSE: {
     name: 'DEFENSE',
-    time: 10 * 1000, // 1분
+    time: 60 * 1000, // 1분
   },
   TEAM_SWITCH: {
     name: 'TEAM_SWITCH',
-    time: 5 * 1000, // 15초
+    time: 15 * 1000, // 15초
   },
 } as const
 

--- a/backend/src/battles/dto/discussionVoteResult.dto.ts
+++ b/backend/src/battles/dto/discussionVoteResult.dto.ts
@@ -34,7 +34,7 @@ export class DiscussionVoteResultDto {
     dto.battleId = battleId
     dto.attack = {
       aTeam: DiscussionVoteResultItemDto.of(discussion.aTeam),
-      bTeam: DiscussionVoteResultItemDto.of(discussion.bTeam)
+      bTeam: DiscussionVoteResultItemDto.of(discussion.bTeam),
     }
     return dto
   }
@@ -44,7 +44,7 @@ export class DiscussionVoteResultDto {
     dto.battleId = battleId
     dto.defense = {
       aTeam: DiscussionVoteResultItemDto.of(discussion.aTeam),
-      bTeam: DiscussionVoteResultItemDto.of(discussion.bTeam)
+      bTeam: DiscussionVoteResultItemDto.of(discussion.bTeam),
     }
     return dto
   }

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { getDiscussionConfig } from '../../utils/battlePhase';
+import { getDiscussionConfig, isInputDisabled } from '../../utils/battlePhase';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from '../../stores/battleStore';
 import BattleIcon from '@/assets/icon/battle.svg?react';
 import ShieldIcon from '@/assets/icon/shield.svg?react';
@@ -15,10 +15,10 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
   const [inputValue, setInputValue] = useState('');
 
   const phase = battleProgress?.phase;
-  const isActive = phase === 'ATTACK' || phase === 'DEFENSE';
+  const shouldShow = !isInputDisabled(team, phase);
 
   // 중립 진영이거나 공격/방어 Phase가 아니면 DiscussionInput 표시 안 함
-  if (team === 'NONE' || !isActive) {
+  if (!shouldShow) {
     return null;
   }
 
@@ -46,7 +46,7 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
         iconColor: 'text-red-400',
         borderColor: 'border-red-500/50',
         focusRingColor: 'focus:ring-red-500/50',
-        bgGradient: 'from-red-950/30 to-red-900/20',
+        bgGradient: 'from-red-950/70 to-red-900/50',
         textColor: 'text-red-400'
       };
     } else {
@@ -57,7 +57,7 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
         iconColor: 'text-blue-400',
         borderColor: 'border-blue-500/50',
         focusRingColor: 'focus:ring-blue-500/50',
-        bgGradient: 'from-blue-950/30 to-blue-900/20',
+        bgGradient: 'from-blue-950/70 to-blue-900/50',
         textColor: 'text-blue-400'
       };
     }
@@ -94,9 +94,7 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
               <button
                 onClick={handleSubmit}
                 disabled={disabled}
-                className={`px-4 py-3 bg-black/30 backdrop-blur-md text-white rounded-lg border border-white/10 transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed shadow-[0_4px_6px_-1px_rgba(0,0,0,0.3),0_2px_4px_-1px_rgba(0,0,0,0.2)] hover:bg-black/40 hover:shadow-[0_10px_15px_-3px_rgba(0,0,0,0.4),0_4px_6px_-2px_rgba(0,0,0,0.3)] active:bg-black/50 font-medium text-[14px] ${
-                  isActive ? 'hover:scale-105' : ''
-                }`}
+                className={`px-4 py-3 bg-black/30 backdrop-blur-md text-white rounded-lg border border-white/10 transition-all flex items-center justify-center gap-2`}
               >
                 {config.buttonText}
               </button>

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useRef } from 'react';
 import { getDiscussionConfig } from '../../utils/battlePhase';
 import { useBattleStore, selectBattleProgress } from '../../stores/battleStore';
 import BattleIcon from '@/assets/icon/battle.svg?react';
@@ -17,12 +17,6 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
   const phase = battleProgress?.phase;
   const config = getDiscussionConfig(phase);
   const PhaseIcon = phase === 'ATTACK' ? BattleIcon : ShieldIcon;
-
-  // Phase 변경 시 input 초기화 및 focus
-  useEffect(() => {
-    setInputValue('');
-    inputRef.current?.focus();
-  }, [phase]);
 
   const handleSubmit = () => {
     if (inputValue.trim()) {
@@ -73,6 +67,7 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
               onFocus={() => setIsFocused(true)}
               onBlur={() => setIsFocused(false)}
               placeholder={config.placeholderText}
+              autoFocus
               className={`w-full bg-black/30 backdrop-blur-sm rounded-lg px-4 py-3.5 text-sm text-white placeholder-gray-500/60 border-2 transition-colors focus:outline-none focus:ring-2 ${
                 isFocused ? config.colors.focusBorder : config.colors.border
               } ${config.colors.focusRing} disabled:opacity-50 disabled:cursor-not-allowed`}

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import BattleIcon from '@/assets/icon/battle.svg?react';
-import { isInputDisabled, getDiscussionConfig } from '../../utils/battlePhase';
+import { getDiscussionConfig } from '../../utils/battlePhase';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from '../../stores/battleStore';
-import { TEAM_COLORS } from '../../types/teamColors';
+import BattleIcon from '@/assets/icon/battle.svg?react';
+import ShieldIcon from '@/assets/icon/shield.svg?react';
 
 interface DiscussionInputProps {
   disabled?: boolean;
@@ -14,18 +14,18 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
   const team = useBattleStore(selectSelectedTeam);
   const [inputValue, setInputValue] = useState('');
 
-  // 중립 진영은 DiscussionInput 표시 안 함
-  if (team === 'NONE') {
+  const phase = battleProgress?.phase;
+  const isActive = phase === 'ATTACK' || phase === 'DEFENSE';
+
+  // 중립 진영이거나 공격/방어 Phase가 아니면 DiscussionInput 표시 안 함
+  if (team === 'NONE' || !isActive) {
     return null;
   }
 
-  const phase = battleProgress?.phase;
-
-  const { placeholderText, buttonText, Icon, isAttacking } = getDiscussionConfig(team, phase);
-  const disabled_input = isInputDisabled(team, phase, disabled);
+  const config = getDiscussionConfig(phase);
 
   const handleSubmit = () => {
-    if (inputValue.trim() && !disabled_input) {
+    if (inputValue.trim() && !disabled) {
       onSubmit?.(inputValue);
       setInputValue('');
     }
@@ -37,59 +37,71 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
     }
   };
 
-  const hintText = isAttacking
-    ? '상대 진영의 코드와 주장의 빈틈을 노려 반론을 던져보세요.'
-    : '아직 이의제기 단계가 아닙니다. 잠시만 기다려주세요.';
+  // Phase별 컬러 및 아이콘 설정
+  const getPhaseStyle = () => {
+    if (phase === 'ATTACK') {
+      return {
+        Icon: BattleIcon,
+        iconBoxBg: 'bg-red-500/20',
+        iconColor: 'text-red-400',
+        borderColor: 'border-red-500/50',
+        focusRingColor: 'focus:ring-red-500/50',
+        bgGradient: 'from-red-950/30 to-red-900/20',
+        textColor: 'text-red-400'
+      };
+    } else {
+      // DEFENSE
+      return {
+        Icon: ShieldIcon,
+        iconBoxBg: 'bg-blue-500/20',
+        iconColor: 'text-blue-400',
+        borderColor: 'border-blue-500/50',
+        focusRingColor: 'focus:ring-blue-500/50',
+        bgGradient: 'from-blue-950/30 to-blue-900/20',
+        textColor: 'text-blue-400'
+      };
+    }
+  };
 
-  const colors = TEAM_COLORS[team];
+  const phaseStyle = getPhaseStyle();
+  const PhaseIcon = phaseStyle.Icon;
 
   return (
     <section
-      className={`w-full bg-linear-to-r ${colors.containerGradient} border ${colors.border} rounded-lg overflow-hidden shadow-lg`}
+      className={`w-full bg-linear-to-r ${phaseStyle.bgGradient} border ${phaseStyle.borderColor} rounded-lg overflow-hidden shadow-lg`}
       data-tutorial="discussion-input"
     >
-      {/* 헤더 */}
-      <div className="px-4 pt-4 pb-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <BattleIcon className={`w-5 h-5 ${colors.primary}`} />
-            <h3 className="text-white text-[15px] font-semibold">{team}팀 이의제기</h3>
+      <div className="px-4 py-4">
+        <div className="flex items-center gap-4">
+          {/* 좌측 아이콘 박스 */}
+          <div className={`rounded-xl flex items-center justify-center shrink-0 w-16 h-16 ${phaseStyle.iconBoxBg}`}>
+            <PhaseIcon className={`w-8 h-8 ${phaseStyle.iconColor}`} />
           </div>
-          {isAttacking && (
-            <div
-              className={`flex items-center gap-1.5 bg-linear-to-r ${colors.badgeGradient} px-3 py-1.5 rounded-full`}
-            >
-              <span className="text-white text-[12px] font-medium">반격 시간</span>
+
+          {/* 입력 영역 */}
+          <div className="flex-1 flex flex-col gap-3">
+            <div className="flex gap-3">
+              <input
+                type="text"
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={handleKeyPress}
+                placeholder={config.placeholderText}
+                disabled={disabled}
+                autoFocus
+                className={`flex-1 bg-black/30 backdrop-blur-md border ${phaseStyle.borderColor} rounded-lg px-4 py-3 text-[14px] text-white placeholder-gray-500 focus:outline-none focus:ring-2 ${phaseStyle.focusRingColor} disabled:opacity-50 disabled:cursor-not-allowed transition-all`}
+              />
+              <button
+                onClick={handleSubmit}
+                disabled={disabled}
+                className={`px-4 py-3 bg-black/30 backdrop-blur-md text-white rounded-lg border border-white/10 transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed shadow-[0_4px_6px_-1px_rgba(0,0,0,0.3),0_2px_4px_-1px_rgba(0,0,0,0.2)] hover:bg-black/40 hover:shadow-[0_10px_15px_-3px_rgba(0,0,0,0.4),0_4px_6px_-2px_rgba(0,0,0,0.3)] active:bg-black/50 font-medium text-[14px] ${
+                  isActive ? 'hover:scale-105' : ''
+                }`}
+              >
+                {config.buttonText}
+              </button>
             </div>
-          )}
-        </div>
-      </div>
-
-      {/* 입력 영역 */}
-      <div className="px-4 pb-4">
-        <div className="flex gap-2 mb-3">
-          <input
-            type="text"
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            onKeyDown={handleKeyPress}
-            placeholder={placeholderText}
-            disabled={disabled_input}
-            autoFocus
-            className={`flex-1 bg-[#2D2D3F] border ${colors.border} rounded-lg px-4 py-3 text-[14px] text-white placeholder-[#666] focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed transition-all`}
-          />
-          <button
-            onClick={handleSubmit}
-            disabled={disabled_input}
-            className={`px-6 py-3 ${colors.primaryBg} text-white rounded-lg ${colors.buttonHover} ${colors.buttonActive} transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed font-medium text-[14px] shadow-md hover:shadow-lg`}
-          >
-            <Icon className="w-5 h-5" />
-            {buttonText}
-          </button>
-        </div>
-
-        <div className={`flex items-start gap-2 ${colors.primary} text-[12px]`}>
-          <p className="leading-relaxed">{hintText}</p>
+          </div>
         </div>
       </div>
     </section>

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -13,7 +13,7 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
   const [inputValue, setInputValue] = useState('');
   const [isFocused, setIsFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-
+  const round = battleProgress?.round;
   const phase = battleProgress?.phase;
   const config = getDiscussionConfig(phase);
   const PhaseIcon = phase === 'ATTACK' ? BattleIcon : ShieldIcon;
@@ -50,7 +50,7 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
       >
         <span className="flex items-center gap-1.5">
           <span className="w-2 h-2 rounded-full bg-current animate-pulse" />
-          {config.label} 페이즈
+          {round}R {config.label}
         </span>
       </div>
 

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -1,44 +1,31 @@
 import { useState, useEffect, useRef } from 'react';
 import { getDiscussionConfig } from '../../utils/battlePhase';
 import { useBattleStore, selectBattleProgress } from '../../stores/battleStore';
+import BattleIcon from '@/assets/icon/battle.svg?react';
+import ShieldIcon from '@/assets/icon/shield.svg?react';
 
 interface DiscussionInputProps {
-  disabled?: boolean;
   onSubmit?: (content: string) => void;
 }
 
-export default function DiscussionInput({ disabled = false, onSubmit }: DiscussionInputProps) {
+export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
   const battleProgress = useBattleStore(selectBattleProgress);
   const [inputValue, setInputValue] = useState('');
   const [isFocused, setIsFocused] = useState(false);
-  const [glowIntensity, setGlowIntensity] = useState(0.2);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const phase = battleProgress?.phase;
   const config = getDiscussionConfig(phase);
-  const PhaseIcon = config.Icon;
-
-  // 아이콘 펄스 애니메이션
-  useEffect(() => {
-    if (disabled) return;
-
-    const interval = setInterval(() => {
-      setGlowIntensity((prev) => (prev === 0.2 ? 0.5 : 0.2));
-    }, 700);
-
-    return () => clearInterval(interval);
-  }, [disabled]);
+  const PhaseIcon = phase === 'ATTACK' ? BattleIcon : ShieldIcon;
 
   // Phase 변경 시 input 초기화 및 focus
   useEffect(() => {
     setInputValue('');
-    if (!disabled) {
-      inputRef.current?.focus();
-    }
-  }, [phase, disabled]);
+    inputRef.current?.focus();
+  }, [phase]);
 
   const handleSubmit = () => {
-    if (inputValue.trim() && !disabled) {
+    if (inputValue.trim()) {
       onSubmit?.(inputValue);
       setInputValue('');
     }
@@ -50,7 +37,7 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
     }
   };
 
-  if (!config.isActive || !PhaseIcon) return null;
+  if (!config.isActive) return null;
 
   return (
     <section
@@ -70,13 +57,10 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
       <div className="relative px-5 py-6 pt-8">
         <div className="flex items-center gap-4">
           <div
-            className={`rounded-xl flex items-center justify-center shrink-0 w-16 h-16 border-2 ${config.colors.iconBox}`}
+            className={`rounded-xl flex items-center justify-center shrink-0 w-16 h-16 border-2 ${config.colors.iconBox}
+    animate-pulse`}
           >
-            <PhaseIcon
-              className={`w-8 h-8 ${config.colors.icon} transition-transform duration-300 ${
-                glowIntensity > 0.3 ? 'scale-110' : 'scale-100'
-              }`}
-            />
+            <PhaseIcon className={`w-8 h-8 ${config.colors.icon}`} />
           </div>
 
           <div className="flex-1 flex gap-3">
@@ -89,7 +73,6 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
               onFocus={() => setIsFocused(true)}
               onBlur={() => setIsFocused(false)}
               placeholder={config.placeholderText}
-              disabled={disabled}
               className={`w-full bg-black/30 backdrop-blur-sm rounded-lg px-4 py-3.5 text-sm text-white placeholder-gray-500/60 border-2 transition-colors focus:outline-none focus:ring-2 ${
                 isFocused ? config.colors.focusBorder : config.colors.border
               } ${config.colors.focusRing} disabled:opacity-50 disabled:cursor-not-allowed`}
@@ -97,9 +80,9 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
 
             <button
               onClick={handleSubmit}
-              disabled={disabled || !inputValue.trim()}
+              disabled={!inputValue.trim()}
               className={`px-5 py-3.5 rounded-lg font-semibold text-sm flex items-center justify-center gap-2 transition-all whitespace-nowrap shrink-0 ${config.colors.button} disabled:opacity-40 disabled:cursor-not-allowed ${
-                !disabled && inputValue.trim() ? 'hover:scale-105' : ''
+                inputValue.trim() ? 'hover:scale-105' : ''
               }`}
             >
               {config.buttonText}

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -1,8 +1,6 @@
-import { useState } from 'react';
-import { getDiscussionConfig, isInputDisabled } from '../../utils/battlePhase';
-import { useBattleStore, selectBattleProgress, selectSelectedTeam } from '../../stores/battleStore';
-import BattleIcon from '@/assets/icon/battle.svg?react';
-import ShieldIcon from '@/assets/icon/shield.svg?react';
+import { useState, useEffect, useRef } from 'react';
+import { getDiscussionConfig } from '../../utils/battlePhase';
+import { useBattleStore, selectBattleProgress } from '../../stores/battleStore';
 
 interface DiscussionInputProps {
   disabled?: boolean;
@@ -11,18 +9,33 @@ interface DiscussionInputProps {
 
 export default function DiscussionInput({ disabled = false, onSubmit }: DiscussionInputProps) {
   const battleProgress = useBattleStore(selectBattleProgress);
-  const team = useBattleStore(selectSelectedTeam);
   const [inputValue, setInputValue] = useState('');
+  const [isFocused, setIsFocused] = useState(false);
+  const [glowIntensity, setGlowIntensity] = useState(0.2);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const phase = battleProgress?.phase;
-  const shouldShow = !isInputDisabled(team, phase);
-
-  // 중립 진영이거나 공격/방어 Phase가 아니면 DiscussionInput 표시 안 함
-  if (!shouldShow) {
-    return null;
-  }
-
   const config = getDiscussionConfig(phase);
+  const PhaseIcon = config.Icon;
+
+  // 아이콘 펄스 애니메이션
+  useEffect(() => {
+    if (disabled) return;
+
+    const interval = setInterval(() => {
+      setGlowIntensity((prev) => (prev === 0.2 ? 0.5 : 0.2));
+    }, 700);
+
+    return () => clearInterval(interval);
+  }, [disabled]);
+
+  // Phase 변경 시 input 초기화 및 focus
+  useEffect(() => {
+    setInputValue('');
+    if (!disabled) {
+      inputRef.current?.focus();
+    }
+  }, [phase, disabled]);
 
   const handleSubmit = () => {
     if (inputValue.trim() && !disabled) {
@@ -37,68 +50,60 @@ export default function DiscussionInput({ disabled = false, onSubmit }: Discussi
     }
   };
 
-  // Phase별 컬러 및 아이콘 설정
-  const getPhaseStyle = () => {
-    if (phase === 'ATTACK') {
-      return {
-        Icon: BattleIcon,
-        iconBoxBg: 'bg-red-500/20',
-        iconColor: 'text-red-400',
-        borderColor: 'border-red-500/50',
-        focusRingColor: 'focus:ring-red-500/50',
-        bgGradient: 'from-red-950/70 to-red-900/50',
-        textColor: 'text-red-400'
-      };
-    } else {
-      // DEFENSE
-      return {
-        Icon: ShieldIcon,
-        iconBoxBg: 'bg-blue-500/20',
-        iconColor: 'text-blue-400',
-        borderColor: 'border-blue-500/50',
-        focusRingColor: 'focus:ring-blue-500/50',
-        bgGradient: 'from-blue-950/70 to-blue-900/50',
-        textColor: 'text-blue-400'
-      };
-    }
-  };
-
-  const phaseStyle = getPhaseStyle();
-  const PhaseIcon = phaseStyle.Icon;
+  if (!config.isActive || !PhaseIcon) return null;
 
   return (
     <section
-      className={`w-full bg-linear-to-r ${phaseStyle.bgGradient} border ${phaseStyle.borderColor} rounded-lg overflow-hidden shadow-lg`}
-      data-tutorial="discussion-input"
+      className={`relative w-full rounded-xl overflow-visible border-2 transition-all duration-500 ${config.colors.bg} ${config.colors.glowBorder} ${
+        isFocused ? 'scale-[1.01]' : ''
+      }`}
     >
-      <div className="px-4 py-4">
+      <div
+        className={`absolute top-0 left-1/2 -translate-x-1/2 px-4 py-1 rounded-b-lg text-xs font-bold tracking-wider uppercase border-x border-b ${config.colors.badge}`}
+      >
+        <span className="flex items-center gap-1.5">
+          <span className="w-2 h-2 rounded-full bg-current animate-pulse" />
+          {config.label} 페이즈
+        </span>
+      </div>
+
+      <div className="relative px-5 py-6 pt-8">
         <div className="flex items-center gap-4">
-          {/* 좌측 아이콘 박스 */}
-          <div className={`rounded-xl flex items-center justify-center shrink-0 w-16 h-16 ${phaseStyle.iconBoxBg}`}>
-            <PhaseIcon className={`w-8 h-8 ${phaseStyle.iconColor}`} />
+          <div
+            className={`rounded-xl flex items-center justify-center shrink-0 w-16 h-16 border-2 ${config.colors.iconBox}`}
+          >
+            <PhaseIcon
+              className={`w-8 h-8 ${config.colors.icon} transition-transform duration-300 ${
+                glowIntensity > 0.3 ? 'scale-110' : 'scale-100'
+              }`}
+            />
           </div>
 
-          {/* 입력 영역 */}
-          <div className="flex-1 flex flex-col gap-3">
-            <div className="flex gap-3">
-              <input
-                type="text"
-                value={inputValue}
-                onChange={(e) => setInputValue(e.target.value)}
-                onKeyDown={handleKeyPress}
-                placeholder={config.placeholderText}
-                disabled={disabled}
-                autoFocus
-                className={`flex-1 bg-black/30 backdrop-blur-md border ${phaseStyle.borderColor} rounded-lg px-4 py-3 text-[14px] text-white placeholder-gray-500 focus:outline-none focus:ring-2 ${phaseStyle.focusRingColor} disabled:opacity-50 disabled:cursor-not-allowed transition-all`}
-              />
-              <button
-                onClick={handleSubmit}
-                disabled={disabled}
-                className={`px-4 py-3 bg-black/30 backdrop-blur-md text-white rounded-lg border border-white/10 transition-all flex items-center justify-center gap-2`}
-              >
-                {config.buttonText}
-              </button>
-            </div>
+          <div className="flex-1 flex gap-3">
+            <input
+              ref={inputRef}
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyPress}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setIsFocused(false)}
+              placeholder={config.placeholderText}
+              disabled={disabled}
+              className={`w-full bg-black/30 backdrop-blur-sm rounded-lg px-4 py-3.5 text-sm text-white placeholder-gray-500/60 border-2 transition-colors focus:outline-none focus:ring-2 ${
+                isFocused ? config.colors.focusBorder : config.colors.border
+              } ${config.colors.focusRing} disabled:opacity-50 disabled:cursor-not-allowed`}
+            />
+
+            <button
+              onClick={handleSubmit}
+              disabled={disabled || !inputValue.trim()}
+              className={`px-5 py-3.5 rounded-lg font-semibold text-sm flex items-center justify-center gap-2 transition-all whitespace-nowrap shrink-0 ${config.colors.button} disabled:opacity-40 disabled:cursor-not-allowed ${
+                !disabled && inputValue.trim() ? 'hover:scale-105' : ''
+              }`}
+            >
+              {config.buttonText}
+            </button>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/battlePage/components/discussion/test/DiscussionInput.test.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/test/DiscussionInput.test.tsx
@@ -5,8 +5,10 @@ import DiscussionInput from '@/pages/battlePage/components/discussion/Discussion
 
 let mockBattleProgress: {
   phase: string;
+  round?: number;
 } = {
-  phase: 'ATTACK'
+  phase: 'ATTACK',
+  round: 1
 };
 let mockSelectedTeam: 'A' | 'B' = 'A';
 
@@ -18,7 +20,7 @@ vi.mock('@/pages/battlePage/stores/battleStore', () => ({
     };
     return selector(state);
   }),
-  selectBattleProgress: (state: { battleProgress: { phase: string } }) => state.battleProgress,
+  selectBattleProgress: (state: { battleProgress: { phase: string; round?: number } }) => state.battleProgress,
   selectSelectedTeam: (state: { selectedTeam: 'A' | 'B' }) => state.selectedTeam
 }));
 
@@ -28,36 +30,39 @@ describe('DiscussionInput', () => {
   beforeEach(() => {
     mockOnSubmit.mockClear();
     mockBattleProgress = {
-      phase: 'ATTACK'
+      phase: 'ATTACK',
+      round: 1
     };
     mockSelectedTeam = 'A';
   });
 
-  it('공격 팀일 때 "상대 진영에 이의제기..." placeholder 표시', () => {
+  it('공격 팀일 때 올바른 placeholder와 라벨 표시', () => {
     mockSelectedTeam = 'A';
-    mockBattleProgress = { phase: 'ATTACK' };
+    mockBattleProgress = { phase: 'ATTACK', round: 1 };
 
     render(<DiscussionInput onSubmit={mockOnSubmit} />);
 
-    expect(screen.getByPlaceholderText('상대 진영에 이의제기...')).toBeInTheDocument();
-    expect(screen.getByText('이의제기')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('상대 코드의 허점을 찾아 이의 제기하세요')).toBeInTheDocument();
+    expect(screen.getByText('1R 이의제기')).toBeInTheDocument();
+    expect(screen.getByText('이의제기하기')).toBeInTheDocument();
   });
 
-  it('방어 팀일 때 "상대 진영에 반론..." placeholder 표시', () => {
+  it('방어 팀일 때 올바른 placeholder와 라벨 표시', () => {
     mockSelectedTeam = 'A';
-    mockBattleProgress = { phase: 'DEFENSE' };
+    mockBattleProgress = { phase: 'DEFENSE', round: 1 };
 
     render(<DiscussionInput onSubmit={mockOnSubmit} />);
 
-    expect(screen.getByPlaceholderText('상대 진영에 반론...')).toBeInTheDocument();
-    expect(screen.getByText('반론')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('상대 주장에 논리적으로 반박해 보세요')).toBeInTheDocument();
+    expect(screen.getByText('1R 반론')).toBeInTheDocument();
+    expect(screen.getByText('반론하기')).toBeInTheDocument();
   });
 
   it('버튼 클릭 시 제출', async () => {
     const user = userEvent.setup();
     render(<DiscussionInput onSubmit={mockOnSubmit} />);
 
-    const input = screen.getByPlaceholderText(/상대 진영에/);
+    const input = screen.getByPlaceholderText('상대 코드의 허점을 찾아 이의 제기하세요');
     await user.type(input, '버튼 클릭 테스트');
 
     const button = screen.getByRole('button');
@@ -70,7 +75,7 @@ describe('DiscussionInput', () => {
     const user = userEvent.setup();
     render(<DiscussionInput onSubmit={mockOnSubmit} />);
 
-    const input = screen.getByPlaceholderText(/상대 진영에/) as HTMLInputElement;
+    const input = screen.getByPlaceholderText('상대 코드의 허점을 찾아 이의 제기하세요') as HTMLInputElement;
     await user.type(input, '초기화 테스트');
     await user.click(screen.getByRole('button'));
 
@@ -81,35 +86,33 @@ describe('DiscussionInput', () => {
     const user = userEvent.setup();
     render(<DiscussionInput onSubmit={mockOnSubmit} />);
 
-    const input = screen.getByPlaceholderText(/상대 진영에/);
+    const input = screen.getByPlaceholderText('상대 코드의 허점을 찾아 이의 제기하세요');
     await user.type(input, '   {Enter}'); // 공백만 입력
 
     expect(mockOnSubmit).not.toHaveBeenCalled();
   });
 
-  it('OPINION_SHARE 단계에서 input 비활성화', () => {
-    mockBattleProgress = { phase: 'OPINION_SHARE' };
+  it('OPINION_SHARE 단계에서 컴포넌트가 렌더링되지 않음', () => {
+    mockBattleProgress = { phase: 'OPINION_SHARE', round: 1 };
 
-    render(<DiscussionInput onSubmit={mockOnSubmit} />);
+    const { container } = render(<DiscussionInput onSubmit={mockOnSubmit} />);
 
-    const input = screen.getByPlaceholderText('의견을 공유하세요...');
-    expect(input).toBeDisabled();
+    expect(container.firstChild).toBeNull();
   });
 
-  it('ATTACK/DEFENSE 외 페이즈에서는 input 비활성화', () => {
+  it('ATTACK/DEFENSE 외 페이즈에서는 컴포넌트가 렌더링되지 않음', () => {
     mockSelectedTeam = 'A';
-    mockBattleProgress = { phase: 'TEAM_SWITCH' };
+    mockBattleProgress = { phase: 'TEAM_SWITCH', round: 1 };
 
-    render(<DiscussionInput onSubmit={mockOnSubmit} />);
+    const { container } = render(<DiscussionInput onSubmit={mockOnSubmit} />);
 
-    const input = screen.getByPlaceholderText(/상대 진영에/);
-    expect(input).toBeDisabled();
+    expect(container.firstChild).toBeNull();
   });
 
-  it('disabled prop이 true일 때 input 비활성화', () => {
-    render(<DiscussionInput onSubmit={mockOnSubmit} disabled={true} />);
+  it('라운드 번호가 라벨에 표시됨', () => {
+    mockBattleProgress = { phase: 'ATTACK', round: 2 };
+    render(<DiscussionInput onSubmit={mockOnSubmit} />);
 
-    const input = screen.getByPlaceholderText(/상대 진영에/);
-    expect(input).toBeDisabled();
+    expect(screen.getByText(/2R/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/battlePage/components/discussion/test/DiscussionInput.test.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/test/DiscussionInput.test.tsx
@@ -44,7 +44,7 @@ describe('DiscussionInput', () => {
 
     expect(screen.getByPlaceholderText('상대 코드의 허점을 찾아 이의 제기하세요')).toBeInTheDocument();
     expect(screen.getByText('1R 이의제기')).toBeInTheDocument();
-    expect(screen.getByText('이의제기하기')).toBeInTheDocument();
+    expect(screen.getByText('이의제기')).toBeInTheDocument();
   });
 
   it('방어 팀일 때 올바른 placeholder와 라벨 표시', () => {
@@ -55,7 +55,7 @@ describe('DiscussionInput', () => {
 
     expect(screen.getByPlaceholderText('상대 주장에 논리적으로 반박해 보세요')).toBeInTheDocument();
     expect(screen.getByText('1R 반론')).toBeInTheDocument();
-    expect(screen.getByText('반론하기')).toBeInTheDocument();
+    expect(screen.getByText('반론')).toBeInTheDocument();
   });
 
   it('버튼 클릭 시 제출', async () => {

--- a/frontend/src/pages/battlePage/components/effects/DiscussionModal.tsx
+++ b/frontend/src/pages/battlePage/components/effects/DiscussionModal.tsx
@@ -63,10 +63,13 @@ export default function DiscussionModal({ isOpen, team, content, type, onClose }
     <div
       className={`fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm transition-opacity duration-300 ${animationClass}`}
       onClick={handleClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="discussion-modal-title"
     >
       <div
         className={`relative flex flex-col items-center transition-all duration-500 ${scaleClass}`}
-        onClick={(e) => e.stopPropagation()}
+        onClick={handleClose}
       >
         <div className={`absolute inset-0 blur-3xl bg-gradient-to-r ${gradient} opacity-30 animate-pulse`} />
 

--- a/frontend/src/pages/battlePage/components/effects/ObjectionModal.tsx
+++ b/frontend/src/pages/battlePage/components/effects/ObjectionModal.tsx
@@ -63,10 +63,13 @@ export default function DiscussionModal({ isOpen, team, content, type, onClose }
     <div
       className={`fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm transition-opacity duration-300 ${animationClass}`}
       onClick={handleClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="objection-modal-title"
     >
       <div
         className={`relative flex flex-col items-center transition-all duration-500 ${scaleClass}`}
-        onClick={(e) => e.stopPropagation()}
+        onClick={handleClose}
       >
         <div className={`absolute inset-0 blur-3xl bg-gradient-to-r ${gradient} opacity-30 animate-pulse`} />
 

--- a/frontend/src/pages/battlePage/components/effects/TeamVoteResultModal.tsx
+++ b/frontend/src/pages/battlePage/components/effects/TeamVoteResultModal.tsx
@@ -59,10 +59,13 @@ export default function TeamVoteResultModal({
       className={`fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm transition-opacity duration-300 ${animationClass}`}
       style={{ background: 'linear-gradient(180deg, #000000 0%, #0A0A1F 50%, #000000 100%)' }}
       onClick={handleClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="vote-result-modal-title"
     >
       <div
         className={`relative flex flex-col items-center transition-all duration-500 ${scaleClass}`}
-        onClick={(e) => e.stopPropagation()}
+        onClick={handleClose}
       >
         <div className="absolute inset-0 blur-[100px] bg-gradient-to-r from-orange-500 to-red-500 opacity-25 animate-pulse scale-125" />
 

--- a/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
@@ -26,7 +26,7 @@ export function useBattleDiscussions() {
       const targetDiscussion = discussions?.find((obj) => obj.id === discussionId);
       if (targetDiscussion?.hasVoted) return;
 
-      const { isAttacking } = getDiscussionConfig(team, battleProgress?.phase);
+      const { isAttacking } = getDiscussionConfig(battleProgress?.phase);
       const eventName = isAttacking ? 'battle:attack:vote' : 'battle:defense:vote';
 
       socket.emit(eventName, {
@@ -43,7 +43,7 @@ export function useBattleDiscussions() {
     (content: string) => {
       if (team === 'NONE' || !socket) return;
 
-      const { isAttacking } = getDiscussionConfig(team, battleProgress?.phase);
+      const { isAttacking } = getDiscussionConfig(battleProgress?.phase);
       const canSubmit = !isInputDisabled(team, battleProgress?.phase);
 
       if (!canSubmit) {

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -114,7 +114,7 @@ export default function BattlePage() {
 
         {/* DiscussionInput - 화면 중앙 하단에 fixed */}
         <div
-          className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 z-50 px-4 pb-4 transition-all duration-300 ease-out ${
+          className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 z-50 px-4 pb-4 transition-all duration-500 ease-out ${
             shouldShowInput ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0 pointer-events-none'
           }`}
         >

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -118,7 +118,9 @@ export default function BattlePage() {
             shouldShowInput ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0 pointer-events-none'
           }`}
         >
-          <div className="w-[590px]">{shouldShowInput && <DiscussionInput onSubmit={handleDiscussionSubmit} />}</div>
+          <div className="w-[590px]">
+            {shouldShowInput && <DiscussionInput key={phase} onSubmit={handleDiscussionSubmit} />}
+          </div>
         </div>
 
         {isTeamChangeModalOpen && (

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -6,6 +6,8 @@ import { useTeamVoteResult } from './hooks/useTeamVoteResult';
 import { useTutorial } from './hooks/useTutorial';
 import useModal from '@/commons/hooks/useModal';
 import { soundManager } from '@/commons/utils/soundManager';
+import { useBattleStore, selectBattleProgress, selectSelectedTeam } from './stores/battleStore';
+import { isInputDisabled } from './utils/battlePhase';
 
 import BattleHeader from './components/header';
 import CodeSection from './components/codeview/CodeSection';
@@ -59,6 +61,12 @@ export default function BattlePage() {
 
   const { voteResult, isModalOpen: isVoteResultModalOpen, closeModal: closeVoteResultModal } = useTeamVoteResult();
 
+  // Phase와 Team 정보 가져오기
+  const battleProgress = useBattleStore(selectBattleProgress);
+  const team = useBattleStore(selectSelectedTeam);
+  const phase = battleProgress?.phase;
+  const shouldShowInput = !isInputDisabled(team, phase);
+
   return (
     <div className="text-white relative min-h-screen">
       {/* 책갈피 버튼 */}
@@ -105,10 +113,12 @@ export default function BattlePage() {
         </main>
 
         {/* DiscussionInput - 화면 중앙 하단에 fixed */}
-        <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 z-50 px-4 pb-4">
-          <div className="w-[590px]">
-            <DiscussionInput onSubmit={handleDiscussionSubmit} />
-          </div>
+        <div
+          className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 z-50 px-4 pb-4 transition-all duration-300 ease-out ${
+            shouldShowInput ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0 pointer-events-none'
+          }`}
+        >
+          <div className="w-[590px]">{shouldShowInput && <DiscussionInput onSubmit={handleDiscussionSubmit} />}</div>
         </div>
 
         {isTeamChangeModalOpen && (

--- a/frontend/src/pages/battlePage/utils/battlePhase.ts
+++ b/frontend/src/pages/battlePage/utils/battlePhase.ts
@@ -1,6 +1,4 @@
 import type { BattlePhase, Team } from '@/commons/types/battle';
-import BattleIcon from '@/assets/icon/battle.svg?react';
-import ShieldIcon from '@/assets/icon/shield.svg?react';
 
 export const isMyTeamAttacking = (team: Team, phase?: BattlePhase): boolean => {
   if (!phase) return false;
@@ -18,18 +16,30 @@ export const isInputDisabled = (team: Team, phase?: BattlePhase, disabled = fals
   return false;
 };
 
-export const getDiscussionConfig = (team: Team, phase?: BattlePhase) => {
-  const isAttacking = isMyTeamAttacking(team, phase) || phase === 'ATTACK';
+export const getDiscussionConfig = (phase?: BattlePhase) => {
+  if (phase === 'ATTACK') {
+    return {
+      placeholderText: '상대 진영의 코드와 주장에 이의제기를 던지세요...',
+      buttonText: '이의제기하기',
+      isAttacking: true,
+      isActive: true
+    };
+  }
 
+  if (phase === 'DEFENSE') {
+    return {
+      placeholderText: '상대 진영의 이의제기에 반박하세요...',
+      buttonText: '반론하기',
+      isAttacking: false,
+      isActive: true
+    };
+  }
+
+  // ATTACK/DEFENSE가 아닌 경우 (사용되지 않지만 타입 안정성을 위해)
   return {
-    placeholderText:
-      phase === 'OPINION_SHARE'
-        ? '의견을 공유하세요...'
-        : isAttacking
-          ? '상대 진영에 이의제기...'
-          : '상대 진영에 반론...',
-    buttonText: isAttacking ? '이의제기' : '반론',
-    Icon: isAttacking ? BattleIcon : ShieldIcon,
-    isAttacking
+    placeholderText: '',
+    buttonText: '',
+    isAttacking: false,
+    isActive: false
   };
 };

--- a/frontend/src/pages/battlePage/utils/battlePhase.ts
+++ b/frontend/src/pages/battlePage/utils/battlePhase.ts
@@ -1,6 +1,4 @@
 import type { BattlePhase, Team } from '@/commons/types/battle';
-import BattleIcon from '@/assets/icon/battle.svg?react';
-import ShieldIcon from '@/assets/icon/shield.svg?react';
 
 export const isMyTeamAttacking = (team: Team, phase?: BattlePhase): boolean => {
   if (!phase) return false;
@@ -21,10 +19,9 @@ export const isInputDisabled = (team: Team, phase?: BattlePhase, disabled = fals
 export const getDiscussionConfig = (phase?: BattlePhase) => {
   if (phase === 'ATTACK') {
     return {
-      label: '공격',
-      placeholderText: '상대 진영의 코드와 주장에 이의제기를 던지세요...',
+      label: '이의제기',
+      placeholderText: '상대 코드의 허점을 찾아 이의 제기하세요',
       buttonText: '이의제기하기',
-      Icon: BattleIcon,
       isAttacking: true,
       isActive: true,
       colors: {
@@ -43,10 +40,9 @@ export const getDiscussionConfig = (phase?: BattlePhase) => {
 
   if (phase === 'DEFENSE') {
     return {
-      label: '방어',
-      placeholderText: '상대 진영의 이의제기에 반박하세요...',
+      label: '반론',
+      placeholderText: '상대 주장에 논리적으로 반박해 보세요',
       buttonText: '반론하기',
-      Icon: ShieldIcon,
       isAttacking: false,
       isActive: true,
       colors: {
@@ -56,7 +52,7 @@ export const getDiscussionConfig = (phase?: BattlePhase) => {
         glowBorder: 'border-blue-500',
         focusBorder: 'border-blue-500',
         focusRing: 'focus:ring-blue-500/30',
-        bg: 'bg-gradient-to-r from-blue-950/50 to-blue-900/30',
+        bg: 'bg-gradient-to-r ffrom-black/50 to-blue-900/30',
         badge: 'bg-blue-500/20 border-blue-500/40 text-blue-400',
         button: 'bg-gradient-to-r from-blue-500 to-blue-600 shadow-lg shadow-blue-500/25 text-white'
       }
@@ -68,7 +64,6 @@ export const getDiscussionConfig = (phase?: BattlePhase) => {
     placeholderText: '',
     buttonText: '',
     isAttacking: false,
-    Icon: null,
     isActive: false,
     colors: {
       iconBox: '',

--- a/frontend/src/pages/battlePage/utils/battlePhase.ts
+++ b/frontend/src/pages/battlePage/utils/battlePhase.ts
@@ -1,4 +1,6 @@
 import type { BattlePhase, Team } from '@/commons/types/battle';
+import BattleIcon from '@/assets/icon/battle.svg?react';
+import ShieldIcon from '@/assets/icon/shield.svg?react';
 
 export const isMyTeamAttacking = (team: Team, phase?: BattlePhase): boolean => {
   if (!phase) return false;
@@ -19,27 +21,65 @@ export const isInputDisabled = (team: Team, phase?: BattlePhase, disabled = fals
 export const getDiscussionConfig = (phase?: BattlePhase) => {
   if (phase === 'ATTACK') {
     return {
+      label: '공격',
       placeholderText: '상대 진영의 코드와 주장에 이의제기를 던지세요...',
       buttonText: '이의제기하기',
+      Icon: BattleIcon,
       isAttacking: true,
-      isActive: true
+      isActive: true,
+      colors: {
+        iconBox: 'bg-red-500/20 border-red-500/40',
+        icon: 'text-red-400',
+        border: 'border-red-500/30',
+        glowBorder: 'border-red-500',
+        focusBorder: 'border-red-500',
+        focusRing: 'focus:ring-red-500/30',
+        bg: 'bg-gradient-to-r from-black/50 to-red-900/30',
+        badge: 'bg-red-500/20 border-red-500/40 text-red-400',
+        button: 'bg-gradient-to-r from-red-500 to-red-600 shadow-lg shadow-red-500/25 text-white'
+      }
     };
   }
 
   if (phase === 'DEFENSE') {
     return {
+      label: '방어',
       placeholderText: '상대 진영의 이의제기에 반박하세요...',
       buttonText: '반론하기',
+      Icon: ShieldIcon,
       isAttacking: false,
-      isActive: true
+      isActive: true,
+      colors: {
+        iconBox: 'bg-blue-500/20 border-blue-500/40',
+        icon: 'text-blue-400',
+        border: 'border-blue-500/30',
+        glowBorder: 'border-blue-500',
+        focusBorder: 'border-blue-500',
+        focusRing: 'focus:ring-blue-500/30',
+        bg: 'bg-gradient-to-r from-blue-950/50 to-blue-900/30',
+        badge: 'bg-blue-500/20 border-blue-500/40 text-blue-400',
+        button: 'bg-gradient-to-r from-blue-500 to-blue-600 shadow-lg shadow-blue-500/25 text-white'
+      }
     };
   }
 
-  // ATTACK/DEFENSE가 아닌 경우 (사용되지 않지만 타입 안정성을 위해)
   return {
+    label: '',
     placeholderText: '',
     buttonText: '',
     isAttacking: false,
-    isActive: false
+    Icon: null,
+    isActive: false,
+    colors: {
+      iconBox: '',
+      icon: '',
+      border: '',
+      focusBorder: '',
+      focusRing: '',
+      glowBorder: '',
+      bg: '',
+      badge: '',
+      button: ''
+    }
   };
 };

--- a/frontend/src/pages/battlePage/utils/battlePhase.ts
+++ b/frontend/src/pages/battlePage/utils/battlePhase.ts
@@ -21,7 +21,7 @@ export const getDiscussionConfig = (phase?: BattlePhase) => {
     return {
       label: '이의제기',
       placeholderText: '상대 코드의 허점을 찾아 이의 제기하세요',
-      buttonText: '이의제기하기',
+      buttonText: '이의제기',
       isAttacking: true,
       isActive: true,
       colors: {
@@ -42,7 +42,7 @@ export const getDiscussionConfig = (phase?: BattlePhase) => {
     return {
       label: '반론',
       placeholderText: '상대 주장에 논리적으로 반박해 보세요',
-      buttonText: '반론하기',
+      buttonText: '반론',
       isAttacking: false,
       isActive: true,
       colors: {

--- a/frontend/src/pages/battlePage/utils/test/getDiscussionConfig.test.ts
+++ b/frontend/src/pages/battlePage/utils/test/getDiscussionConfig.test.ts
@@ -8,7 +8,7 @@ describe('getDiscussionConfig', () => {
 
     expect(config.label).toBe('이의제기');
     expect(config.placeholderText).toBe('상대 코드의 허점을 찾아 이의 제기하세요');
-    expect(config.buttonText).toBe('이의제기하기');
+    expect(config.buttonText).toBe('이의제기');
     expect(config.isAttacking).toBe(true);
     expect(config.isActive).toBe(true);
     expect(config.colors).toBeDefined();
@@ -21,7 +21,7 @@ describe('getDiscussionConfig', () => {
 
     expect(config.label).toBe('반론');
     expect(config.placeholderText).toBe('상대 주장에 논리적으로 반박해 보세요');
-    expect(config.buttonText).toBe('반론하기');
+    expect(config.buttonText).toBe('반론');
     expect(config.isAttacking).toBe(false);
     expect(config.isActive).toBe(true);
     expect(config.colors).toBeDefined();

--- a/frontend/src/pages/battlePage/utils/test/getDiscussionConfig.test.ts
+++ b/frontend/src/pages/battlePage/utils/test/getDiscussionConfig.test.ts
@@ -1,21 +1,25 @@
 import { describe, it, expect } from 'vitest';
 import { getDiscussionConfig } from '../battlePhase';
-import type { Team, BattlePhase } from '@/commons/types/battle';
+import type { BattlePhase } from '@/commons/types/battle';
 
 describe('getDiscussionConfig', () => {
   it('ATTACK 페이즈에는 이의제기 설정 반환', () => {
-    const config = getDiscussionConfig('A' as Team, 'ATTACK' as BattlePhase);
+    const config = getDiscussionConfig('ATTACK' as BattlePhase);
 
-    expect(config.placeholderText).toBe('상대 진영에 이의제기...');
+    expect(config.placeholderText).toBe('상대 진영의 코드와 주장에 이의제기를 던지세요...');
+    expect(config.hintText).toBe('상대 진영의 코드와 주장의 빈틈을 노려 반론을 던져보세요.');
     expect(config.buttonText).toBe('이의제기');
     expect(config.isAttacking).toBe(true);
+    expect(config.isActive).toBe(true);
   });
 
-  it('DEFENSE 페이즈에는 반론 설정 반환', () => {
-    const config = getDiscussionConfig('A' as Team, 'DEFENSE' as BattlePhase);
+  it('DEFENSE 페이즈에는 반박 설정 반환', () => {
+    const config = getDiscussionConfig('DEFENSE' as BattlePhase);
 
-    expect(config.placeholderText).toBe('상대 진영에 반론...');
+    expect(config.placeholderText).toBe('상대 진영의 이의제기에 반박하세요...');
+    expect(config.hintText).toBe('상대 진영의 이의제기에 대해 명확하게 반박해주세요.');
     expect(config.buttonText).toBe('반론');
     expect(config.isAttacking).toBe(false);
+    expect(config.isActive).toBe(true);
   });
 });

--- a/frontend/src/pages/battlePage/utils/test/getDiscussionConfig.test.ts
+++ b/frontend/src/pages/battlePage/utils/test/getDiscussionConfig.test.ts
@@ -6,20 +6,36 @@ describe('getDiscussionConfig', () => {
   it('ATTACK 페이즈에는 이의제기 설정 반환', () => {
     const config = getDiscussionConfig('ATTACK' as BattlePhase);
 
-    expect(config.placeholderText).toBe('상대 진영의 코드와 주장에 이의제기를 던지세요...');
-    expect(config.hintText).toBe('상대 진영의 코드와 주장의 빈틈을 노려 반론을 던져보세요.');
-    expect(config.buttonText).toBe('이의제기');
+    expect(config.label).toBe('이의제기');
+    expect(config.placeholderText).toBe('상대 코드의 허점을 찾아 이의 제기하세요');
+    expect(config.buttonText).toBe('이의제기하기');
     expect(config.isAttacking).toBe(true);
     expect(config.isActive).toBe(true);
+    expect(config.colors).toBeDefined();
+    expect(config.colors.iconBox).toContain('red');
+    expect(config.colors.glowBorder).toBe('border-red-500');
   });
 
   it('DEFENSE 페이즈에는 반박 설정 반환', () => {
     const config = getDiscussionConfig('DEFENSE' as BattlePhase);
 
-    expect(config.placeholderText).toBe('상대 진영의 이의제기에 반박하세요...');
-    expect(config.hintText).toBe('상대 진영의 이의제기에 대해 명확하게 반박해주세요.');
-    expect(config.buttonText).toBe('반론');
+    expect(config.label).toBe('반론');
+    expect(config.placeholderText).toBe('상대 주장에 논리적으로 반박해 보세요');
+    expect(config.buttonText).toBe('반론하기');
     expect(config.isAttacking).toBe(false);
     expect(config.isActive).toBe(true);
+    expect(config.colors).toBeDefined();
+    expect(config.colors.iconBox).toContain('blue');
+    expect(config.colors.glowBorder).toBe('border-blue-500');
+  });
+
+  it('ATTACK/DEFENSE 외 페이즈에는 비활성 설정 반환', () => {
+    const config = getDiscussionConfig('OPINION_SHARE' as BattlePhase);
+
+    expect(config.label).toBe('');
+    expect(config.placeholderText).toBe('');
+    expect(config.buttonText).toBe('');
+    expect(config.isAttacking).toBe(false);
+    expect(config.isActive).toBe(false);
   });
 });


### PR DESCRIPTION
## 🔗 관련 이슈
resolve #147

## ✅ 작업 내용

### 💡개선 사항
#### DiscussionInput UI 개선
`DiscussionInput`에 phase별 색상/아이콘/멘트 적용
- **공격(ATTACK) 페이즈**
  - 멘트: "상대 코드의 허점을 찾아 이의 제기하세요"
  - 빨간색 테마 적용
- **반론(DEFENSE) 페이즈**
  - 멘트: "상대 주장에 논리적으로 반박해 보세요"
  - 파란색 테마 적용
 
#### 애니메이션 추가
- 이의제기/반박 phase 시작 시 DiscussionInput 아래에서 위로 올라오는 애니메이션 추가
- 아이콘 박스와 라벨에 animate-pulse 애니메이션 추가
- border glow 및 버튼 hover 효과 추가

<br />

## 📸 참고 사항

https://github.com/user-attachments/assets/02f0d28e-331a-42fd-a2ab-bf041c71e980


<br />

## 💬 질문사항
- 디자인에서 좋은 아이디어가 있으면 공유해주시면 감사하겠습니다 (figma make활용이 어렵네요 ㅠ)
- 지금 애니메이션은 어떤지, 더 추가가 필요한 부분이 있는지?