### PR TITLE
[Refactor] 진영 선택 페이지 소켓 연결 제거 및 API 데이터 사용

### DIFF
--- a/backend/src/battles/dto/battleJoinResponse.dto.ts
+++ b/backend/src/battles/dto/battleJoinResponse.dto.ts
@@ -75,6 +75,8 @@ export class BattleJoinInfoResponseDto {
   currentRound: number
   totalRounds: number
   topics: string[]
+  currentPhase: BattlePhaseName
+  phaseCount: number
   timelines: { attacks: BattleDiscussion[]; defenses: BattleDefense[] }
 
   static fromEntity(battle: Battle, activeBattleState?: ActiveBattleState): BattleJoinInfoResponseDto {
@@ -92,6 +94,8 @@ export class BattleJoinInfoResponseDto {
     if (activeBattleState) {
       res.currentRound = activeBattleState.round
       res.totalRounds = battle.playTime.rounds
+      res.currentPhase = activeBattleState.phase
+      res.phaseCount = activeBattleState.phaseCount
       // 타임라인은 SELECTED 상태인 것만 포함
       res.timelines = {
         attacks: activeBattleState.all.attacks.filter((attack): attack is BattleDiscussion => attack !== null && attack.status === 'SELECTED'),
@@ -100,6 +104,8 @@ export class BattleJoinInfoResponseDto {
     } else {
       res.currentRound = battle.initialState.round
       res.totalRounds = battle.playTime.rounds
+      res.currentPhase = battle.initialState.phase
+      res.phaseCount = battle.initialState.phaseCount
       res.timelines = { attacks: [], defenses: [] }
     }
 

--- a/backend/src/battles/mock/battles.mock.ts
+++ b/backend/src/battles/mock/battles.mock.ts
@@ -21,6 +21,7 @@ export const MOCK_BATTLES: Battle[] = [
     initialState: {
       round: 1,
       phase: 'OPINION_SHARE',
+      phaseCount: 1,
       timeRemainingSeconds: 10 * 60,
     },
   },
@@ -44,6 +45,7 @@ export const MOCK_BATTLES: Battle[] = [
     initialState: {
       round: 1,
       phase: 'OPINION_SHARE',
+      phaseCount: 1,
       timeRemainingSeconds: 30 * 60,
     },
   },
@@ -66,6 +68,7 @@ export const MOCK_BATTLES: Battle[] = [
     initialState: {
       round: 3,
       phase: 'ATTACK',
+      phaseCount: 1,
       timeRemainingSeconds: 0,
     },
   },
@@ -88,6 +91,7 @@ export const MOCK_BATTLES: Battle[] = [
     initialState: {
       round: 5,
       phase: 'ATTACK',
+      phaseCount: 1,
       timeRemainingSeconds: 0,
     },
   },
@@ -111,6 +115,7 @@ export const MOCK_BATTLES: Battle[] = [
     initialState: {
       round: 1,
       phase: 'OPINION_SHARE',
+      phaseCount: 1,
       timeRemainingSeconds: 30 * 60,
     },
   },
@@ -134,6 +139,7 @@ export const MOCK_BATTLES: Battle[] = [
     initialState: {
       round: 2,
       phase: 'ATTACK',
+      phaseCount: 1,
       timeRemainingSeconds: 0,
     },
   },
@@ -156,6 +162,7 @@ export const MOCK_BATTLES: Battle[] = [
     initialState: {
       round: 2,
       phase: 'ATTACK',
+      phaseCount: 1,
       timeRemainingSeconds: 0,
     },
   },
@@ -178,6 +185,7 @@ export const MOCK_BATTLES: Battle[] = [
     initialState: {
       round: 1,
       phase: 'OPINION_SHARE',
+      phaseCount: 1,
       timeRemainingSeconds: 10 * 60,
     },
   },

--- a/backend/src/battles/service/battles.service.spec.ts
+++ b/backend/src/battles/service/battles.service.spec.ts
@@ -22,6 +22,7 @@ const createBattle = (overrides: Partial<Battle>): Battle => ({
   initialState: {
     round: 1,
     phase: BATTLE_PHASE.OPINION_SHARE.name,
+    phaseCount: 1,
     timeRemainingSeconds: 600,
   },
   ...overrides,

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -86,6 +86,7 @@ export class BattlesService extends EventEmitter {
       initialState: {
         round: 1,
         phase: BATTLE_PHASE.OPINION_SHARE.name,
+        phaseCount: 1,
         timeRemainingSeconds: playTime.time * 60,
       },
     }

--- a/backend/src/battles/types/battles.types.ts
+++ b/backend/src/battles/types/battles.types.ts
@@ -41,6 +41,7 @@ export interface Battle {
   initialState: {
     round: number
     phase: BattlePhaseName
+    phaseCount: number
     timeRemainingSeconds: number
   }
 

--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -22,6 +22,8 @@ export interface BattleInfo {
   currentRound: number;
   totalRounds: number;
   topics: string[];
+  currentPhase: BattlePhase;
+  phaseCount: number;
   timelines: {
     attacks: BattleDiscussion[];
     defenses: BattleDefense[];

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -148,7 +148,7 @@ export const useBattleStore = create<BattleStore>((set) => ({
       }
     }),
   setSelectedTeam: (team) => set({ selectedTeam: team }),
-  setChatInitialized: (initialized) => set({ chatInitialized: initialized })
+  setChatInitialized: (initialized) => set({ chatInitialized: initialized }),
   setOpponentNoticePending: (notice) => set({ opponentNoticePending: notice }),
   commitOpponentNotice: () =>
     set((state) => ({

--- a/frontend/src/pages/teamSelectPage/components/steps/Step3Timeline.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/Step3Timeline.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { ChevronDown, ChevronUp, ThumbsUp, Zap, Shield, Flame, ArrowRight, ArrowLeft, Clock } from 'lucide-react';
+import { ChevronDown, ChevronUp, ThumbsUp, Zap, Shield, Flame, ArrowRight, Clock } from 'lucide-react';
 import type { BattleDiscussion, BattleDefense } from '@/commons/types/battle';
 
 interface Step3TimelineProps {
@@ -14,13 +14,21 @@ interface RoundData {
   topic: string;
   isActive: boolean;
   isFuture: boolean;
-  challenge: {
+  challenge1: {
     teamA: BattleDiscussion | null;
-    teamB: BattleDiscussion | null;
-  };
-  rebuttal: {
-    teamA: BattleDefense | null;
     teamB: BattleDefense | null;
+  };
+  challenge2: {
+    teamB: BattleDiscussion | null;
+    teamA: BattleDefense | null;
+  };
+  challenge3: {
+    teamA: BattleDiscussion | null;
+    teamB: BattleDefense | null;
+  };
+  challenge4: {
+    teamB: BattleDiscussion | null;
+    teamA: BattleDefense | null;
   };
 }
 
@@ -47,29 +55,45 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
     const defenses = timelines.filter((item) => item.type === 'DEFENSE') as BattleDefense[];
 
     for (let i = 1; i <= totalRounds; i++) {
-      // 각 라운드는 A팀, B팀 순서로 2개씩 저장됨
-      const aAttackIdx = (i - 1) * 2;
-      const bAttackIdx = (i - 1) * 2 + 1;
-      const aDefenseIdx = (i - 1) * 2;
-      const bDefenseIdx = (i - 1) * 2 + 1;
+      // 각 라운드는 4개의 토론으로 구성됨
+      // 1. A 공격 -> B 수비
+      // 2. B 공격 -> A 수비
+      // 3. A 공격 -> B 수비 (2차)
+      // 4. B 공격 -> A 수비 (2차)
+      const baseIdx = (i - 1) * 4;
 
-      const challengeA = attacks[aAttackIdx] || null;
-      const challengeB = attacks[bAttackIdx] || null;
-      const rebuttalA = (defenses[aDefenseIdx] as BattleDefense) || null;
-      const rebuttalB = (defenses[bDefenseIdx] as BattleDefense) || null;
+      const aAttack1 = attacks[baseIdx] || null;
+      const bDefense1 = (defenses[baseIdx] as BattleDefense) || null;
+
+      const bAttack1 = attacks[baseIdx + 1] || null;
+      const aDefense1 = (defenses[baseIdx + 1] as BattleDefense) || null;
+
+      const aAttack2 = attacks[baseIdx + 2] || null;
+      const bDefense2 = (defenses[baseIdx + 2] as BattleDefense) || null;
+
+      const bAttack2 = attacks[baseIdx + 3] || null;
+      const aDefense2 = (defenses[baseIdx + 3] as BattleDefense) || null;
 
       rounds.push({
         round: i,
         topic: topics[i - 1],
         isActive: i === currentRound,
         isFuture: i > currentRound,
-        challenge: {
-          teamA: challengeA,
-          teamB: challengeB
+        challenge1: {
+          teamA: aAttack1,
+          teamB: bDefense1
         },
-        rebuttal: {
-          teamA: rebuttalA,
-          teamB: rebuttalB
+        challenge2: {
+          teamB: bAttack1,
+          teamA: aDefense1
+        },
+        challenge3: {
+          teamA: aAttack2,
+          teamB: bDefense2
+        },
+        challenge4: {
+          teamB: bAttack2,
+          teamA: aDefense2
         }
       });
     }
@@ -176,10 +200,14 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
             {roundsData.map((roundData) => {
               const isExpanded = expandedRounds.has(roundData.round);
               const hasContent =
-                roundData.challenge.teamA ||
-                roundData.challenge.teamB ||
-                roundData.rebuttal.teamA ||
-                roundData.rebuttal.teamB;
+                roundData.challenge1.teamA ||
+                roundData.challenge1.teamB ||
+                roundData.challenge2.teamA ||
+                roundData.challenge2.teamB ||
+                roundData.challenge3.teamA ||
+                roundData.challenge3.teamB ||
+                roundData.challenge4.teamA ||
+                roundData.challenge4.teamB;
 
               return (
                 <div
@@ -249,15 +277,14 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
                   {/* Round Content */}
                   {isExpanded && !roundData.isFuture && (
                     <div className="border-t border-[#2d2d3f]">
-                      {/* Challenge Phase: A 이의제기 → B 반론 */}
+                      {/* Challenge 1: A 이의제기 → B 반론 (1차) */}
                       <div className="relative">
-                        {/* Phase Header */}
                         <div className="px-6 py-3 bg-gradient-to-r from-orange-900/20 to-blue-900/20 border-b border-[#2d2d3f]">
                           <div className="flex items-center justify-center gap-3">
                             <div className="flex items-center gap-2">
                               <Zap className="w-4 h-4 text-orange-400" />
                               <span className="text-orange-400 font-bold text-xs uppercase tracking-wider">
-                                A 이의제기
+                                A 이의제기 (1차)
                               </span>
                             </div>
                             <ArrowRight className="w-5 h-5 text-gray-500" />
@@ -267,15 +294,10 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
                             </div>
                           </div>
                         </div>
-
-                        {/* VS Layout */}
                         <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_1fr]">
-                          {/* Team A Challenge */}
                           <div className="border-r border-[#2d2d3f] bg-gradient-to-r from-orange-500/5 to-transparent">
-                            {renderMessage(roundData.challenge.teamA, 'A', 'challenge')}
+                            {renderMessage(roundData.challenge1.teamA, 'A', 'challenge')}
                           </div>
-
-                          {/* Arrow Badge */}
                           <div className="hidden md:flex items-center justify-center px-4 bg-[#0a0a1a] border-r border-[#2d2d3f]">
                             <div className="relative">
                               <div className="absolute inset-0 bg-orange-500/20 blur-lg rounded-full" />
@@ -284,53 +306,113 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
                               </div>
                             </div>
                           </div>
-
-                          {/* Team B Rebuttal */}
                           <div className="bg-gradient-to-l from-blue-500/5 to-transparent border-t md:border-t-0 border-[#2d2d3f]">
-                            {renderMessage(roundData.rebuttal.teamB, 'B', 'rebuttal')}
+                            {renderMessage(roundData.challenge1.teamB, 'B', 'rebuttal')}
                           </div>
                         </div>
                       </div>
 
-                      {/* Rebuttal Phase: B 이의제기 → A 반론 */}
+                      {/* Challenge 2: B 이의제기 → A 반론 (1차) */}
                       <div className="relative border-t-2 border-[#2d2d3f]">
-                        {/* Phase Header */}
-                        <div className="px-6 py-3 bg-gradient-to-r from-blue-900/20 to-red-900/20 border-b border-[#2d2d3f]">
+                        <div className="px-6 py-3 bg-gradient-to-r from-red-900/20 to-blue-900/20 border-b border-[#2d2d3f]">
                           <div className="flex items-center justify-center gap-3">
+                            <div className="flex items-center gap-2">
+                              <Zap className="w-4 h-4 text-red-400" />
+                              <span className="text-red-400 font-bold text-xs uppercase tracking-wider">
+                                B 이의제기 (1차)
+                              </span>
+                            </div>
+                            <ArrowRight className="w-5 h-5 text-gray-500" />
                             <div className="flex items-center gap-2">
                               <Shield className="w-4 h-4 text-blue-400" />
                               <span className="text-blue-400 font-bold text-xs uppercase tracking-wider">A 반론</span>
                             </div>
-                            <ArrowLeft className="w-5 h-5 text-gray-500" />
-                            <div className="flex items-center gap-2">
-                              <Zap className="w-4 h-4 text-red-400" />
-                              <span className="text-red-400 font-bold text-xs uppercase tracking-wider">
-                                B 이의제기
-                              </span>
-                            </div>
                           </div>
                         </div>
-
-                        {/* VS Layout */}
                         <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_1fr]">
-                          {/* Team A Rebuttal */}
-                          <div className="border-r border-[#2d2d3f] bg-gradient-to-r from-blue-500/5 to-transparent">
-                            {renderMessage(roundData.rebuttal.teamA, 'A', 'rebuttal')}
+                          <div className="border-r border-[#2d2d3f] bg-gradient-to-r from-red-500/5 to-transparent">
+                            {renderMessage(roundData.challenge2.teamB, 'B', 'challenge')}
                           </div>
-
-                          {/* Arrow Badge */}
                           <div className="hidden md:flex items-center justify-center px-4 bg-[#0a0a1a] border-r border-[#2d2d3f]">
                             <div className="relative">
                               <div className="absolute inset-0 bg-red-500/20 blur-lg rounded-full" />
-                              <div className="relative bg-gradient-to-l from-red-500 to-blue-600 w-12 h-12 rounded-full flex items-center justify-center border-2 border-red-400/50 shadow-lg">
-                                <ArrowLeft className="w-5 h-5 text-white font-bold" />
+                              <div className="relative bg-gradient-to-r from-red-500 to-blue-600 w-12 h-12 rounded-full flex items-center justify-center border-2 border-red-400/50 shadow-lg">
+                                <ArrowRight className="w-5 h-5 text-white font-bold" />
                               </div>
                             </div>
                           </div>
+                          <div className="bg-gradient-to-l from-blue-500/5 to-transparent border-t md:border-t-0 border-[#2d2d3f]">
+                            {renderMessage(roundData.challenge2.teamA, 'A', 'rebuttal')}
+                          </div>
+                        </div>
+                      </div>
 
-                          {/* Team B Challenge */}
-                          <div className="bg-gradient-to-l from-red-500/5 to-transparent border-t md:border-t-0 border-[#2d2d3f]">
-                            {renderMessage(roundData.challenge.teamB, 'B', 'challenge')}
+                      {/* Challenge 3: A 이의제기 → B 반론 (2차) */}
+                      <div className="relative border-t-2 border-[#2d2d3f]">
+                        <div className="px-6 py-3 bg-gradient-to-r from-orange-900/20 to-blue-900/20 border-b border-[#2d2d3f]">
+                          <div className="flex items-center justify-center gap-3">
+                            <div className="flex items-center gap-2">
+                              <Zap className="w-4 h-4 text-orange-400" />
+                              <span className="text-orange-400 font-bold text-xs uppercase tracking-wider">
+                                A 이의제기 (2차)
+                              </span>
+                            </div>
+                            <ArrowRight className="w-5 h-5 text-gray-500" />
+                            <div className="flex items-center gap-2">
+                              <Shield className="w-4 h-4 text-blue-400" />
+                              <span className="text-blue-400 font-bold text-xs uppercase tracking-wider">B 반론</span>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_1fr]">
+                          <div className="border-r border-[#2d2d3f] bg-gradient-to-r from-orange-500/5 to-transparent">
+                            {renderMessage(roundData.challenge3.teamA, 'A', 'challenge')}
+                          </div>
+                          <div className="hidden md:flex items-center justify-center px-4 bg-[#0a0a1a] border-r border-[#2d2d3f]">
+                            <div className="relative">
+                              <div className="absolute inset-0 bg-orange-500/20 blur-lg rounded-full" />
+                              <div className="relative bg-gradient-to-r from-orange-500 to-blue-600 w-12 h-12 rounded-full flex items-center justify-center border-2 border-orange-400/50 shadow-lg">
+                                <ArrowRight className="w-5 h-5 text-white font-bold" />
+                              </div>
+                            </div>
+                          </div>
+                          <div className="bg-gradient-to-l from-blue-500/5 to-transparent border-t md:border-t-0 border-[#2d2d3f]">
+                            {renderMessage(roundData.challenge3.teamB, 'B', 'rebuttal')}
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Challenge 4: B 이의제기 → A 반론 (2차) */}
+                      <div className="relative border-t-2 border-[#2d2d3f]">
+                        <div className="px-6 py-3 bg-gradient-to-r from-red-900/20 to-blue-900/20 border-b border-[#2d2d3f]">
+                          <div className="flex items-center justify-center gap-3">
+                            <div className="flex items-center gap-2">
+                              <Zap className="w-4 h-4 text-red-400" />
+                              <span className="text-red-400 font-bold text-xs uppercase tracking-wider">
+                                B 이의제기 (2차)
+                              </span>
+                            </div>
+                            <ArrowRight className="w-5 h-5 text-gray-500" />
+                            <div className="flex items-center gap-2">
+                              <Shield className="w-4 h-4 text-blue-400" />
+                              <span className="text-blue-400 font-bold text-xs uppercase tracking-wider">A 반론</span>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_1fr]">
+                          <div className="border-r border-[#2d2d3f] bg-gradient-to-r from-red-500/5 to-transparent">
+                            {renderMessage(roundData.challenge4.teamB, 'B', 'challenge')}
+                          </div>
+                          <div className="hidden md:flex items-center justify-center px-4 bg-[#0a0a1a] border-r border-[#2d2d3f]">
+                            <div className="relative">
+                              <div className="absolute inset-0 bg-red-500/20 blur-lg rounded-full" />
+                              <div className="relative bg-gradient-to-r from-red-500 to-blue-600 w-12 h-12 rounded-full flex items-center justify-center border-2 border-red-400/50 shadow-lg">
+                                <ArrowRight className="w-5 h-5 text-white font-bold" />
+                              </div>
+                            </div>
+                          </div>
+                          <div className="bg-gradient-to-l from-blue-500/5 to-transparent border-t md:border-t-0 border-[#2d2d3f]">
+                            {renderMessage(roundData.challenge4.teamA, 'A', 'rebuttal')}
                           </div>
                         </div>
                       </div>

--- a/frontend/src/pages/teamSelectPage/index.tsx
+++ b/frontend/src/pages/teamSelectPage/index.tsx
@@ -18,9 +18,9 @@ export default function TeamSelectPage() {
   const { currentStep, goToNext, goToPrev, canGoNext } = useStepFlow();
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
 
-  // API 데이터 사용
-  const attacks = battleInfo.timelines.attacks;
-  const defenses = battleInfo.timelines.defenses;
+  // API 데이터 사용 - type 필드 추가
+  const attacks = battleInfo.timelines.attacks.map((attack) => ({ ...attack, type: 'ATTACK' as const }));
+  const defenses = battleInfo.timelines.defenses.map((defense) => ({ ...defense, type: 'DEFENSE' as const }));
 
   const handleSubmit = () => {
     if (selectedTeam && id) {

--- a/frontend/src/pages/teamSelectPage/index.tsx
+++ b/frontend/src/pages/teamSelectPage/index.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { useNavigate, useLoaderData, useParams } from 'react-router-dom';
+import { useState } from 'react';
+import { useNavigate, useLoaderData } from 'react-router-dom';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type { BattleInfo } from '@/commons/types/battle';
 import { useStepFlow } from './hooks/useStepFlow';
@@ -10,56 +10,20 @@ import Step2CodeCompare from './components/steps/Step2CodeCompare';
 import Step3Timeline from './components/steps/Step3Timeline';
 import Step4TeamSelect from './components/steps/Step4TeamSelect';
 import type { Team } from '@/commons/types/battle';
-import {
-  useBattleStore,
-  selectTimelines,
-  selectTeamCounts,
-  selectBattleProgress
-} from '@/pages/battlePage/stores/battleStore';
 
 export default function TeamSelectPage() {
   const navigate = useNavigate();
-  const { id } = useParams<{ id: string }>();
   const battleInfo = useLoaderData<BattleInfo>();
   const { currentStep, goToNext, goToPrev, canGoNext } = useStepFlow();
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
 
-  // WebSocket을 통해 실시간 타임라인과 참여자 수 가져오기
-  const timelines = useBattleStore(selectTimelines);
-  const teamCounts = useBattleStore(selectTeamCounts);
-  const battleProgress = useBattleStore(selectBattleProgress);
-
-  // 배틀 스토어 초기화 (NONE 팀으로 연결)
-  useEffect(() => {
-    if (!id) return;
-
-    let userId = sessionStorage.getItem('testUserId');
-    if (!userId) {
-      userId = `user-${Math.random().toString(36).substr(2, 9)}`;
-      sessionStorage.setItem('testUserId', userId);
-    }
-
-    useBattleStore.getState().initializeBattle({
-      userId,
-      battleId: id
-    });
-
-    // 진영 선택 전이므로 NONE으로 설정
-    useBattleStore.getState().setSelectedTeam('NONE');
-  }, [id]);
-
-  // @TODO : 타임라인 데이터 가져오는 API 추가필요
-
-  const attacks = timelines?.attacks || battleInfo.timelines.attacks;
-  const defenses = timelines?.defenses || battleInfo.timelines.defenses;
-
-  // 실시간 참여자 수 계산
-  const totalParticipants = (teamCounts?.teamACount || 0) + (teamCounts?.teamBCount || 0);
+  // API 데이터 사용
+  const attacks = battleInfo.timelines.attacks;
+  const defenses = battleInfo.timelines.defenses;
 
   const handleSubmit = () => {
-    if (selectedTeam && id) {
-      useBattleStore.getState().setSelectedTeam(selectedTeam);
-      navigate(`/battle/${id}`, { state: { selectedTeam } });
+    if (selectedTeam) {
+      navigate(`/battle/${battleInfo.title}`, { state: { selectedTeam } });
     }
   };
 
@@ -75,9 +39,9 @@ export default function TeamSelectPage() {
             currentRound={battleInfo.currentRound}
             totalRounds={battleInfo.totalRounds}
             topics={battleInfo.topics}
-            totalParticipants={totalParticipants || battleInfo.participantCount}
-            currentPhase={battleProgress?.phase}
-            phaseCount={battleProgress?.phaseCount}
+            totalParticipants={battleInfo.participantCount}
+            currentPhase={battleInfo.currentPhase}
+            phaseCount={battleInfo.phaseCount}
           />
         );
       case 2:

--- a/frontend/src/pages/teamSelectPage/index.tsx
+++ b/frontend/src/pages/teamSelectPage/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate, useLoaderData } from 'react-router-dom';
+import { useNavigate, useLoaderData, useParams } from 'react-router-dom';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type { BattleInfo } from '@/commons/types/battle';
 import { useStepFlow } from './hooks/useStepFlow';
@@ -13,6 +13,7 @@ import type { Team } from '@/commons/types/battle';
 
 export default function TeamSelectPage() {
   const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
   const battleInfo = useLoaderData<BattleInfo>();
   const { currentStep, goToNext, goToPrev, canGoNext } = useStepFlow();
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
@@ -22,8 +23,8 @@ export default function TeamSelectPage() {
   const defenses = battleInfo.timelines.defenses;
 
   const handleSubmit = () => {
-    if (selectedTeam) {
-      navigate(`/battle/${battleInfo.title}`, { state: { selectedTeam } });
+    if (selectedTeam && id) {
+      navigate(`/battle/${id}`, { state: { selectedTeam } });
     }
   };
 


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #169

## ✅ 작업 내용

### 💡개선 사항
진영 선택 페이지에서 불필요한 WebSocket 연결을 제거하고 REST API 데이터만 사용하도록 리팩토링했습니다.

**Backend**
- `Battle` 타입 `initialState`에 `phaseCount` 필드 추가
- `BattleJoinInfoResponseDto`에 `currentPhase`, `phaseCount` 필드 추가
- 모든 mock 데이터에 `phaseCount` 추가

**Frontend**
- 진영 선택 페이지에서 `useBattleStore` 및 소켓 초기화 로직 제거
- `useLoaderData`로 받은 API 데이터만 사용
- `BattleInfo` 타입에 `currentPhase`, `phaseCount` 필드 추가
- 진영 선택 후 네비게이션 경로 수정 (battleId 사용)
- 타임라인 컴포넌트를 라운드당 4개 토론 표시로 수정 (A 이의제기/B 반론 × 2회)
- `battleStore.ts` 문법 오류 수정

<br />

## 📸 참고 사항
- 진영 선택 페이지는 정적 데이터(스냅샷), 배틀 페이지는 실시간 데이터(WebSocket)로 명확히 구분
- Backend DTO → Frontend Type → Component Props 완전한 타입 체인 구축
- 개발자 도구 Network 탭에서 진영 선택 페이지 접근 시 WebSocket 연결이 없는지 확인 필요

<img width="1262" height="944" alt="image" src="https://github.com/user-attachments/assets/1d1e29f7-00af-4d04-b744-ddfb1c1b3b25" />

<img width="1188" height="781" alt="image" src="https://github.com/user-attachments/assets/b86a2719-98b4-4d2f-a7cf-96f5de50f32d" />

<br />

## 💬 질문사항 (고민했던 부분)
당장의 타임라인이 한 라운드에 A공격 -> B수비 / B수비 -> A공격 // A공격 -> B수비 / B수비 -> A공격 형태로 구성되어 있는데 추후 전체적으로 타임라인 수정필요함 1-1, 1-2 형태로 나누어야함