### PR TITLE
devops: ci에 test job을 추가한다.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,29 @@ env:
   IMAGE_FRONTEND: ${{ github.repository }}-frontend
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run backend tests
+        run: pnpm -C backend test
+
+      - name: Run frontend tests
+        run: pnpm -C frontend test
+
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->
Closes #179 

## ✅ 작업 내용

### CI에 test job을 추가하여 PR마다 backend/jest와 frontend/vitest가 실행되도록 수정했습니다.
-  Node 20 + pnpm 설치 후 pnpm -C backend test, pnpm -C frontend test 실행하는 test job을 추가


### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
