### PR TITLE
[Feature] 사용자는 배틀 페이지에서 뒤로 갈 수 있다. 

### DIFF
--- a/backend/src/battles/dto/battleLeaveResponse.dto.ts
+++ b/backend/src/battles/dto/battleLeaveResponse.dto.ts
@@ -1,0 +1,27 @@
+import { ActiveBattleState } from '../types/battles.types'
+
+export class BattleLeaveResponseDto {
+  battleId: string
+  counts: {
+    teamA: number
+    teamB: number
+    teamNone: number
+  }
+
+  static fromEntity(payload: ActiveBattleState): BattleLeaveResponseDto {
+    const res = new BattleLeaveResponseDto()
+    const { teamA, teamB, participants } = payload
+
+    res.battleId = payload.battleId
+    res.counts = {
+      teamA: teamA.users.length,
+      teamB: teamB.users.length,
+      teamNone: participants.size - (teamA.users.length + teamB.users.length),
+    }
+    return res
+  }
+
+  static of(payload: ActiveBattleState): BattleLeaveResponseDto {
+    return BattleLeaveResponseDto.fromEntity(payload)
+  }
+}

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -108,6 +108,17 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     }
   }
 
+  @SubscribeMessage('battle:leave')
+  handleLeave(@MessageBody() dto: { battleId: string }, @ConnectedSocket() client: SocketWithUserId) {
+    const { battleId } = dto
+    const userId = this.getUserIdFromSocket(client)
+    const battleRoomId = this.battlesService.getBattleRoomId(battleId)
+
+    const result = this.battlesService.leaveBattle(userId, battleId)
+
+    this.server.to(battleRoomId).emit('battle:leaved', result)
+  }
+
   @SubscribeMessage('battle:start')
   handleStart(@MessageBody() dto: BattleStartDto) {
     const { battleId } = dto

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -209,8 +209,8 @@ export class BattlesService extends EventEmitter {
     if (!userId || !battleId) throw new BadRequestException('유효하지 않은 요청입니다.')
 
     const battleState = this.getBattleState(battleId)
-    battleState.teamA.users = [...battleState.teamA.users.filter(id => id !== userId)]
-    battleState.teamB.users = [...battleState.teamB.users.filter(id => id !== userId)]
+    battleState.teamA.users = battleState.teamA.users.filter(id => id !== userId)
+    battleState.teamB.users = battleState.teamB.users.filter(id => id !== userId)
 
     // battleState.guestInfoMap.delete(userId)
     battleState.teamVotes.delete(userId)

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -212,7 +212,7 @@ export class BattlesService extends EventEmitter {
     battleState.teamA.users = [...battleState.teamA.users.filter(id => id !== userId)]
     battleState.teamB.users = [...battleState.teamB.users.filter(id => id !== userId)]
 
-    battleState.guestInfoMap.delete(userId)
+    // battleState.guestInfoMap.delete(userId)
     battleState.teamVotes.delete(userId)
     battleState.participants.delete(userId)
 

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -41,6 +41,7 @@ import { BattleClosedResponseDto } from '../dto/battleClosedResponse.dto'
 import { BattleTeamUpdateAllResponseDto } from '../dto/battleTeamUpdateAllResponse.dto'
 import { BattleUserUpdateResponseDto } from '../dto/battleUserUpdateResponse.dto'
 import { GuestAccount } from '../types/auth.types'
+import { BattleLeaveResponseDto } from '../dto/battleLeaveResponse.dto'
 
 @Injectable()
 export class BattlesService extends EventEmitter {
@@ -202,6 +203,20 @@ export class BattlesService extends EventEmitter {
     this.addParticipant(battleId, userId, team)
 
     return { battleState, team }
+  }
+
+  leaveBattle(userId: string, battleId: string): BattleLeaveResponseDto {
+    if (!userId || !battleId) throw new BadRequestException('유효하지 않은 요청입니다.')
+
+    const battleState = this.getBattleState(battleId)
+    battleState.teamA.users = [...battleState.teamA.users.filter(id => id !== userId)]
+    battleState.teamB.users = [...battleState.teamB.users.filter(id => id !== userId)]
+
+    battleState.guestInfoMap.delete(userId)
+    battleState.teamVotes.delete(userId)
+    battleState.participants.delete(userId)
+
+    return BattleLeaveResponseDto.of(battleState)
   }
 
   setBattlesForTest(battles: Battle[]) {

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -88,6 +88,14 @@ export function useBattleSocket() {
       }
     });
 
+    newSocket.on('battle:leaved', (data) => {
+      setTeamCounts({
+        teamACount: data.counts.teamA,
+        teamBCount: data.counts.teamB,
+        none: data.counts.teamNone
+      });
+    });
+
     return () => {
       newSocket.off('connect');
       newSocket.off('battle:joined');

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -33,6 +33,7 @@ export default function BattlePage() {
   const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
   const sidebarOpenedForTutorial = useRef(false);
   const user = useAuthStore(selectUser);
+  const leaveBattle = useBattleStore((s) => s.leaveBattle);
 
   useEffect(() => {
     if (!user) {
@@ -95,6 +96,13 @@ export default function BattlePage() {
   const phase = battleProgress?.phase;
   const shouldShowInput = !isInputDisabled(team, phase);
 
+  const handleLeaveBattle = () => {
+    if (!user) return;
+    // TODO 추후에 서버에서 Disconnect 관리
+    navigate('/');
+    leaveBattle();
+  };
+
   return (
     <div className="text-white relative min-h-screen">
       {/* 책갈피 버튼 */}
@@ -125,6 +133,14 @@ export default function BattlePage() {
         <div
           className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'} -mt-[10px]`}
         >
+          <div className="flex items-center justify-between mt-10 mb-8">
+            <button
+              onClick={handleLeaveBattle}
+              className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors"
+            >
+              ← 돌아가기
+            </button>
+          </div>
           <BattleHeader />
         </div>
         <main className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'}`}>

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -55,9 +55,10 @@ interface BattleStore {
   setChatInitialized: (initialized: boolean) => void;
   setOpponentNoticePending: (notice: BattleChat | null) => void;
   commitOpponentNotice: () => void;
+  leaveBattle: () => void;
 }
 
-export const useBattleStore = create<BattleStore>((set) => ({
+export const useBattleStore = create<BattleStore>((set, get) => ({
   userId: '',
   battleId: '',
   socket: null,
@@ -154,7 +155,34 @@ export const useBattleStore = create<BattleStore>((set) => ({
     set((state) => ({
       opponentNotice: state.opponentNoticePending,
       opponentNoticePending: null
-    }))
+    })),
+  leaveBattle: () => {
+    const { socket, battleId } = get();
+    socket?.emit('battle:leave', { battleId });
+
+    socket?.removeAllListeners();
+    socket?.disconnect();
+
+    // 기존 Store 초기화 값으로 설정
+    set({
+      userId: '',
+      battleId: '',
+      socket: null,
+      isConnected: false,
+      currentStage: null,
+      battleProgress: null,
+      discussions: [],
+      teamCounts: { teamACount: 0, teamBCount: 0, none: 0 },
+      totalParticipants: 0,
+      timelines: null,
+      teamChats: [],
+      allChats: [],
+      selectedTeam: 'NONE',
+      chatInitialized: false,
+      opponentNotice: null,
+      opponentNoticePending: null
+    });
+  }
 }));
 
 export const selectUserId = (state: BattleStore) => state.userId;


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

closes #181 


## ✅ 작업 내용

- [x] 배틀 페이지 헤더 상단에 돌아가기 버튼을 클릭하면 메인 페이지로 이동한다.
- [x] 사용자가 배틀을 종료하면 `battle:leave` 이벤트를 발행하고 소켓을 정리한다.
- [x] 서버는 해당 이벤트를 받아 데이터를 제거한 후 `battle:leaved` 이벤트를 브로드캐스팅한다.
```ts
battleState.teamA.users = [...battleState.teamA.users.filter(id => id !== userId)]
battleState.teamB.users = [...battleState.teamB.users.filter(id => id !== userId)]

battleState.guestInfoMap.delete(userId)
battleState.teamVotes.delete(userId)
battleState.participants.delete(userId)
```
- [x] `battle:leaved` 이벤트를 받은 사용자들의 참여자 수를 업데이트 한다.

#### DTO

**`battle:leave` Request DTO**
: socket `auth`에 `userId`를 저장하여 이벤트를 발행하며 나간 배틀을 명시하기 위해 `battleId`를 전달합니다. 

```ts
{ battleId: string } 
```

**`battle:leaved` Response DTO**
: 배틀에 나간 후, 현재 참여자의 인원 수를 업데이트하기 위해 데이터를 응답합니다. ( `battle:joined` 포맷과 비슷하게 DTO를 구성하였습니다.)
```ts
{
  battleId: string
  counts: {
    teamA: number
    teamB: number
    teamNone: number
  }
}
```

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

- `battle:leave`, `battle:leaved` 이벤트를 구현하여 총 참여자 수 차감에 대한 이벤트를 기록하였습니다.
- 클라이언트에서 배틀을 나가면 명시적으로 `socket.disconnect()`를 통해 소켓 연결을 끊고 배틀 데이터를 초기화 시켜줍니다.
- 명시적으로 서버는 `battle:leave` 이벤트를 받아, 어떤 클라이언트가 배틀을 나갔는 지 확인할 수 있습니다.

<br />

## 📸 참고 사항
![123](https://github.com/user-attachments/assets/eb0147a0-0031-4cc3-a0c1-b9a9c44bac53)

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->

**개선 필요**
1. "돌아가기" 버튼을 제외한 방법으로 사용자가 배틀 페이지를 빠져나가면 서버에서 해당 클라이언트 데이터를 제거하지 못하고 있습니다. (#176 에서 작업 필요)'

2. '닉네임2'라는 유저가 채팅, 이의제기 및 반론을 제공하였다가, 배틀을 나가도 해당 채팅과 이의제기 및 반론은 '닉네임2'가 그대로 유지됩니다. 만약 다른 클라이언트가 '닉네임2'로 들어왔을 때, 사칭이 가능할 수도 있습니다. 

3. `battle:leaved`를 통해 배틀을 참여하고 있는 유저들에게 업데이트할 데이터는 `teamA`, `teamB`, `teamNone` 카운터 수를 제외하고 따로 생각하진 않았는데, 혹시 더 추가할 데이터가 필요할까요? 
