### PR TITLE
[Feature] 사용자는 타임라인에서 대주제를 확인할 수 있다.

### DIFF
--- a/frontend/src/pages/battlePage/components/modals/TeamChangeModal/TimelineSection.tsx
+++ b/frontend/src/pages/battlePage/components/modals/TeamChangeModal/TimelineSection.tsx
@@ -20,11 +20,11 @@ export default function TimelineSection({ topic, currentRound, timelines }: Time
       <div className="flex flex-col items-center gap-3">
         {/* 상단: Round + 주제 */}
         <div className="flex items-center gap-4">
-          <h3 className="text-[18px] font-bold">Round {currentRound} </h3>
+          <h3 className="text-lg font-bold">Round {currentRound} </h3>
 
-          <span className="px-2 py-1 rounded-full text-[13px] font-bold bg-purple-500 text-white">{topic}</span>
+          <span className="px-2 py-1 rounded-full text-xs font-bold bg-purple-500 text-white">{topic}</span>
         </div>
-        <p className="text-[14px] text-gray-400 mb-4">타임라인을 확인하고 진영을 변경하세요</p>
+        <p className="text-sm text-gray-400 mb-4">타임라인을 확인하고 진영을 변경하세요</p>
       </div>
       {/* 1차 공수: A 이의제기 → B 반론 */}
       <PhaseFlowCard

--- a/frontend/src/pages/battlePage/components/modals/TeamChangeModal/TimelineSection.tsx
+++ b/frontend/src/pages/battlePage/components/modals/TeamChangeModal/TimelineSection.tsx
@@ -12,13 +12,20 @@ import type { TimelineSectionProps } from './types';
  * - 2차 공수: A 이의제기 → B 반론
  * - 2차 역공: B 이의제기 → A 반론
  */
-export default function TimelineSection({ currentRound, timelines }: TimelineSectionProps) {
+export default function TimelineSection({ topic, currentRound, timelines }: TimelineSectionProps) {
   const timelineData = getTimelineData(currentRound, timelines);
 
   return (
     <div>
-      <h3 className="text-[18px] font-bold text-center mb-4">Round {currentRound} 진영 선택</h3>
+      <div className="flex flex-col items-center gap-3">
+        {/* 상단: Round + 주제 */}
+        <div className="flex items-center gap-4">
+          <h3 className="text-[18px] font-bold">Round {currentRound} </h3>
 
+          <span className="px-2 py-1 rounded-full text-[13px] font-bold bg-purple-500 text-white">{topic}</span>
+        </div>
+        <p className="text-[14px] text-gray-400 mb-4">타임라인을 확인하고 진영을 변경하세요</p>
+      </div>
       {/* 1차 공수: A 이의제기 → B 반론 */}
       <PhaseFlowCard
         attackTeam="A"

--- a/frontend/src/pages/battlePage/components/modals/TeamChangeModal/index.tsx
+++ b/frontend/src/pages/battlePage/components/modals/TeamChangeModal/index.tsx
@@ -11,6 +11,7 @@ import TimelineSection from './TimelineSection';
 import VotingSection from './VotingSection';
 
 interface TeamChangeModalProps {
+  topics: string[];
   handleTeamChange: (team: 'A' | 'B' | 'NONE') => void;
   onClose: () => void;
 }
@@ -22,7 +23,7 @@ interface TeamChangeModalProps {
  * TEAM_SWITCH 페이즈에서 사용자가 현재 라운드의 타임라인을 확인하고
  * 지지할 팀을 선택할 수 있는 모달입니다.
  */
-export default function TeamChangeModal({ handleTeamChange, onClose }: TeamChangeModalProps) {
+export default function TeamChangeModal({ topics, handleTeamChange, onClose }: TeamChangeModalProps) {
   // 데이터 페칭
   const { teamACount, teamBCount } = useBattleStore(selectTeamCounts);
   const currentTeam = useBattleStore(selectSelectedTeam);
@@ -35,6 +36,7 @@ export default function TeamChangeModal({ handleTeamChange, onClose }: TeamChang
 
   const noneTeamCount = 0;
   const currentRound = battleProgress?.round ?? 1;
+  const currentTopic = topics[currentRound - 1];
 
   const modalRoot = document.getElementById('modal-root');
   if (!modalRoot) return null;
@@ -52,7 +54,7 @@ export default function TeamChangeModal({ handleTeamChange, onClose }: TeamChang
         onClick={(e) => e.stopPropagation()}
       >
         {/* 타임라인 섹션 */}
-        <TimelineSection currentRound={currentRound} timelines={timelines} />
+        <TimelineSection topic={currentTopic} currentRound={currentRound} timelines={timelines} />
 
         {/* 투표 섹션 */}
         <VotingSection

--- a/frontend/src/pages/battlePage/components/modals/TeamChangeModal/types.ts
+++ b/frontend/src/pages/battlePage/components/modals/TeamChangeModal/types.ts
@@ -24,6 +24,7 @@ export interface PhaseFlowCardProps {
  */
 export interface TimelineSectionProps {
   currentRound: number;
+  topic: string;
   timelines: {
     attacks: BattleDiscussion[];
     defenses: BattleDefense[];

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/RoundHeader.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/RoundHeader.tsx
@@ -2,12 +2,13 @@ import { ChevronDown, ChevronUp } from 'lucide-react';
 
 interface RoundHeaderProps {
   round: string;
+  topic: string;
   isActive: boolean;
   isExpanded: boolean;
   onToggle: () => void;
 }
 
-export default function RoundHeader({ round, isActive, isExpanded, onToggle }: RoundHeaderProps) {
+export default function RoundHeader({ round, topic, isActive, isExpanded, onToggle }: RoundHeaderProps) {
   return (
     <button
       onClick={onToggle}
@@ -18,6 +19,12 @@ export default function RoundHeader({ round, isActive, isExpanded, onToggle }: R
           className={`px-2 py-1 rounded text-[10px] font-bold ${isActive ? 'bg-orange-500 text-white' : 'bg-gray-700/50 text-gray-400'}`}
         >
           Round {round}
+        </div>
+
+        <div
+          className={`px-2 py-1 rounded text-[10px] font-bold ${isActive ? 'bg-purple-500 text-white' : 'bg-gray-700/50 text-gray-400'}`}
+        >
+          {topic}
         </div>
       </div>
       <div className="text-gray-400">

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/index.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/index.tsx
@@ -6,6 +6,7 @@ import PhaseDivider from './PhaseDivider';
 
 interface SidebarTimelineSectionProps {
   isWide?: boolean;
+  topics: string[];
 }
 
 const FIRST_SUB_ROUND = 1;
@@ -14,7 +15,7 @@ const SUB_ROUNDS_PER_ROUND = [FIRST_SUB_ROUND, SECOND_SUB_ROUND];
 const TEAMS_PER_SUB_ROUND = 2;
 const DEFAULT_EXPANDED_ROUND = '1-1';
 
-export default function SidebarTimelineSection({ isWide = false }: SidebarTimelineSectionProps) {
+export default function SidebarTimelineSection({ isWide = false, topics }: SidebarTimelineSectionProps) {
   const timelines = useBattleStore(selectTimelines);
   const battleProgress = useBattleStore(selectBattleProgress);
   const [expandedRounds, setExpandedRounds] = useState<Set<string>>(new Set([DEFAULT_EXPANDED_ROUND]));
@@ -49,6 +50,7 @@ export default function SidebarTimelineSection({ isWide = false }: SidebarTimeli
 
         return {
           round: `${round}-${subIndex}`,
+          topic: topics[round - 1],
           attackA: attackList[pairIndex] || null,
           attackB: attackList[pairIndex + 1] || null,
           defenseB: defenseList[pairIndex] || null,
@@ -56,7 +58,7 @@ export default function SidebarTimelineSection({ isWide = false }: SidebarTimeli
         };
       });
     }).flat();
-  }, [attackList, defenseList, currentRound]);
+  }, [attackList, defenseList, currentRound, topics]);
 
   const toggleRound = (round: string) => {
     const newExpanded = new Set(expandedRounds);
@@ -85,6 +87,7 @@ export default function SidebarTimelineSection({ isWide = false }: SidebarTimeli
             >
               <RoundHeader
                 round={subRound.round}
+                topic={subRound.topic}
                 isActive={isActive}
                 isExpanded={isExpanded}
                 onToggle={() => toggleRound(subRound.round)}

--- a/frontend/src/pages/battlePage/components/sidebar/index.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/index.tsx
@@ -11,12 +11,21 @@ interface BattleSidebarProps {
   description: string;
   language: string;
   category: string;
+  topics: string[];
   raiseZIndex?: boolean;
 }
 
 type Tab = 'info' | 'timeline';
 
-export default function BattleSidebar({ isOpen, onClose, title, description, language, category }: BattleSidebarProps) {
+export default function BattleSidebar({
+  isOpen,
+  onClose,
+  title,
+  description,
+  language,
+  category,
+  topics
+}: BattleSidebarProps) {
   const [activeTab, setActiveTab] = useState<Tab>('info');
   const { width, isResizing, setIsResizing } = useResize({
     initialWidth: 400
@@ -51,7 +60,7 @@ export default function BattleSidebar({ isOpen, onClose, title, description, lan
           {activeTab === 'info' ? (
             <BattleInfoSection title={title} description={description} language={language} category={category} />
           ) : (
-            <SidebarTimelineSection isWide={isWideLayout} />
+            <SidebarTimelineSection isWide={isWideLayout} topics={topics} />
           )}
         </div>
         <div className="relative h-[calc(100vh-65px)]">

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -112,6 +112,7 @@ export default function BattlePage() {
         description={battleInfo.description}
         language={battleInfo.language}
         category={battleInfo.category}
+        topics={battleInfo.topics}
         raiseZIndex={isTutorialOpen && currentStep === 'sidebarPanel'}
       />
 
@@ -157,7 +158,11 @@ export default function BattlePage() {
         </div>
 
         {isTeamChangeModalOpen && (
-          <TeamChangeModal handleTeamChange={handleTeamChange} onClose={handleCloseTeamChangeModal} />
+          <TeamChangeModal
+            topics={battleInfo.topics}
+            handleTeamChange={handleTeamChange}
+            onClose={handleCloseTeamChangeModal}
+          />
         )}
 
         {effectModal.isOpen && effectModal.team !== 'NONE' && (


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

closes: #183 

## ✅ 작업 내용

- [x] 사이드바 타임라인 대주제 노출
- [x] 진영 변경 투표 타임라인 대주제 노출

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

크게 개선된 점은 없습니다.

<br />

## 📸 참고 사항

<img width="1447" height="773" alt="스크린샷 2026-01-18 오후 10 36 06" src="https://github.com/user-attachments/assets/383fcf7f-4742-4cc3-8024-2198692efaff" />


<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->

1. 피그마 디자인없이 일단 제 미적 감각⭐️으로 작업했는데 더 개선시킬 방법이 있으면 피드백 부탁드립니다!
2. 진영 선택 모달에서 선택을 안하고 다음 phase로 넘어가면 다음 Round에 대한 타임라인이 노출되는 버그를 발견하였습니다. 관련 이슈가 아니라 새로 이슈파서 개선하면 좋을 것 같습니당.
