### PR TITLE
[Fix] : 사용자 뷰포트 크기마다 UI크기가 조절되어야한다

### DIFF
--- a/frontend/src/commons/components/CodeViewer.tsx
+++ b/frontend/src/commons/components/CodeViewer.tsx
@@ -16,7 +16,7 @@ export default function CodeViewer({
   code,
   language,
   containerClassName,
-  minHeight = '460px',
+  minHeight = '300px',
   maxHeight = '600px',
   'data-testid': dataTestId
 }: CodeViewerProps) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -149,7 +149,8 @@
 /* Custom styles */
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-
+  font-size: 12px;
+  
   --sidebar-width: 320px;
   --main-closed: 1220px;
   --main-open: 960px;
@@ -159,6 +160,8 @@
 
 @media (min-width: 1600px) {
   :root {
+    font-size: 14px;
+
     --sidebar-width: 360px;
     --main-closed: 1500px;
     --main-open: 1240px;
@@ -169,6 +172,8 @@
 
 @media (min-width: 1920px) {
   :root {
+    font-size: 16px;
+
     --sidebar-width: 400px;
     --main-closed: 1800px;
     --main-open: 1400px;
@@ -190,7 +195,7 @@
     width: var(--main-open);
   }
 
-  .lounge-width-closed {
+  .aside-width {
     width: var(--lounge-closed);
   }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -149,18 +149,31 @@
 /* Custom styles */
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-size: 12px;
 
-  /* 배틀 페이지 레이아웃 크기 */
   --sidebar-width: 320px;
-  --main-closed: 1440px;
-  --main-open: 1120px;
-  --lounge-closed: 472px;
-  --lounge-open: 360px;
+  --main-closed: 1220px;
+  --main-open: 960px;
+  --lounge-closed: 420px;
+  --lounge-open: 340px;
 }
 
-/* FHD 모니터 */
+@media (min-width: 1600px) {
+  :root {
+  font-size: 14px;
+
+    --sidebar-width: 360px;
+    --main-closed: 1500px;
+    --main-open: 1240px;
+    --lounge-closed: 520px;
+    --lounge-open: 400px;
+  }
+}
+
 @media (min-width: 1920px) {
   :root {
+  font-size: 16px;
+
     --sidebar-width: 400px;
     --main-closed: 1800px;
     --main-open: 1400px;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -183,6 +183,16 @@
   --team-card-padding: 1rem;
   --team-card-title-size: 1.125rem;
   --team-card-desc-size: 0.75rem;
+  
+  --battle-info-icon-size: 40px;
+  --battle-info-title-size: 1.25rem;
+  --battle-info-desc-size: 0.875rem;
+  --battle-info-card-padding: 1rem;
+  --battle-info-stat-icon-size: 48px;
+  --battle-info-stat-value-size: 2rem;
+  --battle-info-swords-size: 20px;
+  --battle-info-users-size: 24px;
+  --battle-info-target-size: 20px;
 }
 
 @media (min-width: 1600px) {
@@ -209,7 +219,17 @@
     --team-card-gap: 1rem;
     --team-card-padding: 1.25rem;
     --team-card-title-size: 1.25rem;
-    --team-card-desc-size: 0.875rem;  }
+    --team-card-desc-size: 0.875rem;
+    
+    --battle-info-icon-size: 48px;
+    --battle-info-title-size: 1.5rem;
+    --battle-info-desc-size: 1rem;
+    --battle-info-card-padding: 1.5rem;
+    --battle-info-stat-icon-size: 56px;
+    --battle-info-stat-value-size: 2.5rem;
+    --battle-info-swords-size: 22px;
+    --battle-info-users-size: 28px;
+    --battle-info-target-size: 24px;  }
 }
 
 @media (min-width: 1920px) {
@@ -236,7 +256,17 @@
     --team-card-gap: 1.5rem;
     --team-card-padding: 1.5rem;
     --team-card-title-size: 1.5rem;
-    --team-card-desc-size: 0.875rem;  }
+    --team-card-desc-size: 0.875rem;
+    
+    --battle-info-icon-size: 64px;
+    --battle-info-title-size: 1.5rem;
+    --battle-info-desc-size: 1rem;
+    --battle-info-card-padding: 2rem;
+    --battle-info-stat-icon-size: 64px;
+    --battle-info-stat-value-size: 2.25rem;
+    --battle-info-swords-size: 24px;
+    --battle-info-users-size: 32px;
+    --battle-info-target-size: 28px;  }
 }
 
 @layer components {
@@ -336,6 +366,47 @@
 
   .team-card-desc-size {
     font-size: var(--team-card-desc-size);
+  }
+
+  .battle-info-icon-size {
+    width: var(--battle-info-icon-size);
+    height: var(--battle-info-icon-size);
+  }
+
+  .battle-info-title-size {
+    font-size: var(--battle-info-title-size);
+  }
+
+  .battle-info-desc-size {
+    font-size: var(--battle-info-desc-size);
+  }
+
+  .battle-info-card-padding {
+    padding: var(--battle-info-card-padding);
+  }
+
+  .battle-info-stat-icon-size {
+    width: var(--battle-info-stat-icon-size);
+    height: var(--battle-info-stat-icon-size);
+  }
+
+  .battle-info-stat-value-size {
+    font-size: var(--battle-info-stat-value-size);
+  }
+
+  .battle-info-swords-size {
+    width: var(--battle-info-swords-size);
+    height: var(--battle-info-swords-size);
+  }
+
+  .battle-info-users-size {
+    width: var(--battle-info-users-size);
+    height: var(--battle-info-users-size);
+  }
+
+  .battle-info-target-size {
+    width: var(--battle-info-target-size);
+    height: var(--battle-info-target-size);
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -168,7 +168,7 @@
   --header-height: 10rem;
   --chat-height: 30rem;
   --code-height: 30rem;
-  --discussion-input-width: 500px;
+  --discussion-input-width: 450px;
 }
 
 @media (min-width: 1600px) {
@@ -251,7 +251,8 @@ body {
   background-color: #0a0a1a;
   margin: 0;
   padding: 0;
-  overflow-x: hidden;
+  overflow: hidden;
+  height: 100vh;
 
   font-size: 14px;
   font-weight: 400;
@@ -259,7 +260,8 @@ body {
 }
 
 #root {
-  min-height: 100vh;
+  height: 100vh;
+  overflow-y: auto;
 }
 
 /* Custom scrollbar styles */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -169,6 +169,11 @@
   --chat-height: 30rem;
   --code-height: 30rem;
   --discussion-input-width: 450px;
+  --create-max-width: 960px;
+  --create-padding: 1.5rem;
+  --create-title-size: 1.5rem;
+  --create-input-height: 2.75rem;
+  --create-textarea-height: 14rem;
 }
 
 @media (min-width: 1600px) {
@@ -182,8 +187,11 @@
     --lounge-open: 400px;    --header-height: 11.1875rem;    --header-height: 10.5rem;
     --chat-height: 33rem;
     --code-height: 33rem;
-    --discussion-input-width: 580px;
-  }
+    --discussion-input-width: 580px;    --create-max-width: 1120px;
+    --create-padding: 1.75rem;
+    --create-title-size: 1.75rem;
+    --create-input-height: 3rem;
+    --create-textarea-height: 16rem;  }
 }
 
 @media (min-width: 1920px) {
@@ -197,8 +205,11 @@
     --header-height: 11.1875rem;
     --chat-height: 36rem;
     --code-height: 36rem;
-    --discussion-input-width: 650px;
-  }
+    --discussion-input-width: 650px;    --create-max-width: 1280px;
+    --create-padding: 2rem;
+    --create-title-size: 2rem;
+    --create-input-height: 3.25rem;
+    --create-textarea-height: 18rem;  }
 }
 
 @layer components {
@@ -245,14 +256,33 @@
   .discussion-input-width {
     width: var(--discussion-input-width);
   }
+
+  .create-max-width {
+    max-width: var(--create-max-width);
+  }
+
+  .create-padding {
+    padding: var(--create-padding);
+  }
+
+  .create-title-size {
+    font-size: var(--create-title-size);
+  }
+
+  .create-input-height {
+    height: var(--create-input-height);
+  }
+
+  .create-textarea-height {
+    height: var(--create-textarea-height);
+  }
 }
 
 body {
   background-color: #0a0a1a;
   margin: 0;
   padding: 0;
-  overflow: hidden;
-  height: 100vh;
+  overflow-x: hidden;
 
   font-size: 14px;
   font-weight: 400;
@@ -260,8 +290,7 @@ body {
 }
 
 #root {
-  height: 100vh;
-  overflow-y: auto;
+  min-height: 100vh;
 }
 
 /* Custom scrollbar styles */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -149,17 +149,24 @@
 /* Custom styles */
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  min-width: 1440px;
 
-  /* 배틀 페이지 레이아웃 크기 */
   --sidebar-width: 320px;
-  --main-closed: 1440px;
-  --main-open: 1120px;
-  --lounge-closed: 472px;
-  --lounge-open: 360px;
+  --main-closed: 1220px;
+  --main-open: 960px;
+  --lounge-closed: 420px;
+  --lounge-open: 340px;
 }
 
-/* FHD 모니터 */
+@media (min-width: 1600px) {
+  :root {
+    --sidebar-width: 360px;
+    --main-closed: 1500px;
+    --main-open: 1240px;
+    --lounge-closed: 520px;
+    --lounge-open: 400px;
+  }
+}
+
 @media (min-width: 1920px) {
   :root {
     --sidebar-width: 400px;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -149,31 +149,18 @@
 /* Custom styles */
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  font-size: 12px;
-  
+
+  /* 배틀 페이지 레이아웃 크기 */
   --sidebar-width: 320px;
-  --main-closed: 1220px;
-  --main-open: 960px;
-  --lounge-closed: 420px;
-  --lounge-open: 340px;
+  --main-closed: 1440px;
+  --main-open: 1120px;
+  --lounge-closed: 472px;
+  --lounge-open: 360px;
 }
 
-@media (min-width: 1600px) {
-  :root {
-    font-size: 14px;
-
-    --sidebar-width: 360px;
-    --main-closed: 1500px;
-    --main-open: 1240px;
-    --lounge-closed: 520px;
-    --lounge-open: 400px;
-  }
-}
-
+/* FHD 모니터 */
 @media (min-width: 1920px) {
   :root {
-    font-size: 16px;
-
     --sidebar-width: 400px;
     --main-closed: 1800px;
     --main-open: 1400px;
@@ -195,7 +182,7 @@
     width: var(--main-open);
   }
 
-  .aside-width {
+  .lounge-width-closed {
     width: var(--lounge-closed);
   }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -174,6 +174,15 @@
   --create-title-size: 1.5rem;
   --create-input-height: 2.75rem;
   --create-textarea-height: 14rem;
+  
+  --team-card-width: 255px;
+  --team-card-height: 215px;
+  --team-card-icon-size: 64px;
+  --team-card-icon-inner-size: 32px;
+  --team-card-gap: 0.75rem;
+  --team-card-padding: 1rem;
+  --team-card-title-size: 1.125rem;
+  --team-card-desc-size: 0.75rem;
 }
 
 @media (min-width: 1600px) {
@@ -191,7 +200,16 @@
     --create-padding: 1.75rem;
     --create-title-size: 1.75rem;
     --create-input-height: 3rem;
-    --create-textarea-height: 16rem;  }
+    --create-textarea-height: 16rem;
+    
+    --team-card-width: 290px;
+    --team-card-height: 290px;
+    --team-card-icon-size: 80px;
+    --team-card-icon-inner-size: 40px;
+    --team-card-gap: 1rem;
+    --team-card-padding: 1.25rem;
+    --team-card-title-size: 1.25rem;
+    --team-card-desc-size: 0.875rem;  }
 }
 
 @media (min-width: 1920px) {
@@ -209,7 +227,16 @@
     --create-padding: 2rem;
     --create-title-size: 2rem;
     --create-input-height: 3.25rem;
-    --create-textarea-height: 18rem;  }
+    --create-textarea-height: 18rem;
+    
+    --team-card-width: 330px;
+    --team-card-height: 350px;
+    --team-card-icon-size: 96px;
+    --team-card-icon-inner-size: 48px;
+    --team-card-gap: 1.5rem;
+    --team-card-padding: 1.5rem;
+    --team-card-title-size: 1.5rem;
+    --team-card-desc-size: 0.875rem;  }
 }
 
 @layer components {
@@ -275,6 +302,40 @@
 
   .create-textarea-height {
     height: var(--create-textarea-height);
+  }
+
+  .team-card-width {
+    width: var(--team-card-width);
+  }
+
+  .team-card-height {
+    height: var(--team-card-height);
+  }
+
+  .team-card-icon-size {
+    width: var(--team-card-icon-size);
+    height: var(--team-card-icon-size);
+  }
+
+  .team-card-icon-inner-size {
+    width: var(--team-card-icon-inner-size);
+    height: var(--team-card-icon-inner-size);
+  }
+
+  .team-card-gap {
+    gap: var(--team-card-gap);
+  }
+
+  .team-card-padding {
+    padding: var(--team-card-padding);
+  }
+
+  .team-card-title-size {
+    font-size: var(--team-card-title-size);
+  }
+
+  .team-card-desc-size {
+    font-size: var(--team-card-desc-size);
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -94,6 +94,15 @@
   animation: bounce-scale 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
+@keyframes shrink {
+  from {
+    width: 100%;
+  }
+  to {
+    width: 0%;
+  }
+}
+
 /* 스크롤바 */
 .custom-scrollbar::-webkit-scrollbar {
   width: 8px;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -193,6 +193,12 @@
   --battle-info-swords-size: 20px;
   --battle-info-users-size: 24px;
   --battle-info-target-size: 20px;
+  
+  --code-compare-icon-size: 40px;
+  --code-compare-title-size: 1.25rem;
+  --code-compare-desc-size: 0.875rem;
+  --code-compare-container-padding: 1rem;
+  --code-compare-min-height: 300px;
 }
 
 @media (min-width: 1600px) {
@@ -229,7 +235,13 @@
     --battle-info-stat-value-size: 2.5rem;
     --battle-info-swords-size: 22px;
     --battle-info-users-size: 28px;
-    --battle-info-target-size: 24px;  }
+    --battle-info-target-size: 24px;
+    
+    --code-compare-icon-size: 48px;
+    --code-compare-title-size: 1.5rem;
+    --code-compare-desc-size: 1rem;
+    --code-compare-container-padding: 1.5rem;
+    --code-compare-min-height: 400px;  }
 }
 
 @media (min-width: 1920px) {
@@ -266,7 +278,13 @@
     --battle-info-stat-value-size: 2.25rem;
     --battle-info-swords-size: 24px;
     --battle-info-users-size: 32px;
-    --battle-info-target-size: 28px;  }
+    --battle-info-target-size: 28px;
+    
+    --code-compare-icon-size: 64px;
+    --code-compare-title-size: 1.5rem;
+    --code-compare-desc-size: 1rem;
+    --code-compare-container-padding: 2rem;
+    --code-compare-min-height: 500px;  }
 }
 
 @layer components {
@@ -407,6 +425,27 @@
   .battle-info-target-size {
     width: var(--battle-info-target-size);
     height: var(--battle-info-target-size);
+  }
+
+  .code-compare-icon-size {
+    width: var(--code-compare-icon-size);
+    height: var(--code-compare-icon-size);
+  }
+
+  .code-compare-title-size {
+    font-size: var(--code-compare-title-size);
+  }
+
+  .code-compare-desc-size {
+    font-size: var(--code-compare-desc-size);
+  }
+
+  .code-compare-container-padding {
+    padding: var(--code-compare-container-padding);
+  }
+
+  .code-compare-min-height {
+    min-height: var(--code-compare-min-height);
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -156,6 +156,9 @@
   --main-open: 960px;
   --lounge-closed: 420px;
   --lounge-open: 340px;
+  --header-height: 10rem;
+  --chat-height: 30rem;
+  --code-height: 30rem;
 }
 
 @media (min-width: 1600px) {
@@ -166,7 +169,9 @@
     --main-closed: 1500px;
     --main-open: 1240px;
     --lounge-closed: 520px;
-    --lounge-open: 400px;
+    --lounge-open: 400px;    --header-height: 11.1875rem;    --header-height: 10.5rem;
+    --chat-height: 33rem;
+    --code-height: 33rem;
   }
 }
 
@@ -179,6 +184,9 @@
     --main-open: 1400px;
     --lounge-closed: 590px;
     --lounge-open: 450px;
+    --header-height: 11.1875rem;
+    --chat-height: 36rem;
+    --code-height: 36rem;
   }
 }
 
@@ -201,6 +209,22 @@
 
   .lounge-width-open {
     width: var(--lounge-open);
+  }
+
+  .header-height {
+    height: var(--header-height);
+  }
+
+  .chat-height {
+    height: var(--chat-height);
+  }
+
+  .code-height {
+    height: var(--code-height);
+  }
+
+  .min-code-height {
+    min-height: var(--code-height);
   }
 
   .ml-sidebar {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -209,10 +209,12 @@
     --main-closed: 1500px;
     --main-open: 1240px;
     --lounge-closed: 520px;
-    --lounge-open: 400px;    --header-height: 11.1875rem;    --header-height: 10.5rem;
+    --lounge-open: 400px;   
+    --header-height: 10.5rem;
     --chat-height: 33rem;
     --code-height: 33rem;
-    --discussion-input-width: 580px;    --create-max-width: 1120px;
+    --discussion-input-width: 580px;    
+    --create-max-width: 1120px;
     --create-padding: 1.75rem;
     --create-title-size: 1.75rem;
     --create-input-height: 3rem;
@@ -255,7 +257,8 @@
     --header-height: 11.1875rem;
     --chat-height: 36rem;
     --code-height: 36rem;
-    --discussion-input-width: 650px;    --create-max-width: 1280px;
+    --discussion-input-width: 650px;    
+    --create-max-width: 1280px;
     --create-padding: 2rem;
     --create-title-size: 2rem;
     --create-input-height: 3.25rem;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -168,6 +168,7 @@
   --header-height: 10rem;
   --chat-height: 30rem;
   --code-height: 30rem;
+  --discussion-input-width: 500px;
 }
 
 @media (min-width: 1600px) {
@@ -181,13 +182,13 @@
     --lounge-open: 400px;    --header-height: 11.1875rem;    --header-height: 10.5rem;
     --chat-height: 33rem;
     --code-height: 33rem;
+    --discussion-input-width: 580px;
   }
 }
 
 @media (min-width: 1920px) {
   :root {
   font-size: 16px;
-
     --sidebar-width: 400px;
     --main-closed: 1800px;
     --main-open: 1400px;
@@ -196,6 +197,7 @@
     --header-height: 11.1875rem;
     --chat-height: 36rem;
     --code-height: 36rem;
+    --discussion-input-width: 650px;
   }
 }
 
@@ -238,6 +240,10 @@
 
   .ml-sidebar {
     margin-left: var(--sidebar-width);
+  }
+
+  .discussion-input-width {
+    width: var(--discussion-input-width);
   }
 }
 

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -106,7 +106,7 @@ export default function BattleCreatePage() {
 
   return (
     <div className="min-h-screen w-full px-6 py-8">
-      <div className="mx-auto max-w-6xl">
+      <div className="mx-auto create-max-width">
         <button
           type="button"
           onClick={() => navigate(-1)}
@@ -118,10 +118,10 @@ export default function BattleCreatePage() {
         <div className="mt-4 rounded-2xl border border-[#2b2b3e] bg-[#121226] shadow-[0_18px_35px_rgba(0,0,0,0.35)]">
           <div className="h-1 w-full rounded-t-2xl bg-orange-500" />
 
-          <div className="p-6">
+          <div className="create-padding">
             <div className="mb-6">
               <p className="text-xs tracking-[0.24em] text-orange-500">CREATE NEW BATTLE</p>
-              <h1 className="mt-2 text-2xl font-bold text-white">새 배틀 생성</h1>
+              <h1 className="mt-2 create-title-size font-bold text-white">새 배틀 생성</h1>
             </div>
 
             <div className="space-y-6">
@@ -157,7 +157,7 @@ export default function BattleCreatePage() {
                     value={aCode}
                     onChange={(e) => setACode(e.target.value)}
                     placeholder="첫 번째 코드를 입력하세요"
-                    className="h-56 w-full resize-y rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 font-mono text-sm text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/60"
+                    className="create-textarea-height w-full resize-y rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 font-mono text-sm text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/60"
                   />
                 </div>
 
@@ -172,7 +172,7 @@ export default function BattleCreatePage() {
                     value={bCode}
                     onChange={(e) => setBCode(e.target.value)}
                     placeholder="두 번째 코드를 입력하세요"
-                    className="h-56 w-full resize-y rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 font-mono text-sm text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/60"
+                    className="create-textarea-height w-full resize-y rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 font-mono text-sm text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/60"
                   />
                 </div>
               </div>

--- a/frontend/src/pages/battlePage/components/chatting/ChatInput.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatInput.tsx
@@ -30,7 +30,7 @@ export default function ChatInput({ onSend }: ChatInputProps) {
           onChange={(e) => setInputValue(e.target.value)}
           onKeyPress={handleKeyPress}
           placeholder="메시지를 입력하세요..."
-          className="flex-1 bg-[#2D2D3F] border border-[#3D3D4F] rounded-md px-3 py-2.5 text-[13px] text-white placeholder-[#666] focus:outline-none focus:border-[#FF6900]"
+          className="flex-1 bg-[#2D2D3F] border border-[#3D3D4F] rounded-md px-3 py-2.5 text-xs text-white placeholder-[#666] focus:outline-none focus:border-[#FF6900]"
         />
         <button onClick={handleSend} className="p-2.5 rounded-md bg-[#3D3D4F] hover:bg-[#4D4D5F] transition-colors">
           <SendIcon />

--- a/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
@@ -36,21 +36,17 @@ export default function ChatMessage({ user, team, content, timestamp, showTeamBa
   return (
     <div className={`flex ${isYou ? 'flex-col items-end' : 'flex-col items-start'} mb-3`}>
       <div className="flex items-center gap-2 mb-1">
-        {!isYou && (
-          <>
-            <span className={`text-[13px] font-medium ${nickNameColor}`}>{user}</span>
-            {showTeamBadge && (
-              <span className={`px-1.5 py-0.5 ${TEAM_BADGE_COLORS[team]} rounded text-[10px] font-medium text-white`}>
-                {TEAM_LABELS[team]}
-              </span>
-            )}
-          </>
+        <span className={`text-xs font-medium ${nickNameColor}`}>{user}</span>
+        {showTeamBadge && (
+          <span className={`px-1.5 py-0.5 ${TEAM_BADGE_COLORS[team]} rounded text-[0.625rem] font-medium text-white`}>
+            {TEAM_LABELS[team]}
+          </span>
         )}
-        <span className="text-[11px] text-[#666]">{getTimeAgo(timestamp)}</span>
+        <span className="text-[0.688rem] text-[#666]">{getTimeAgo(timestamp)}</span>
       </div>
       <div className={`flex items-center gap-2 ${isYou ? 'flex-row-reverse' : ''}`}>
-        <div className={`${isYou ? 'bg-[#6B3410]' : 'bg-[#2D2D3F]'}  rounded-lg px-3 py-2 max-w-[280px]`}>
-          <p className="text-[13px] text-white">{content}</p>
+        <div className={`${isYou ? 'bg-[#6B3410]' : 'bg-[#2D2D3F]'}  rounded-lg px-3 py-2 max-w-[17.5rem]`}>
+          <p className="text-xs text-white">{content}</p>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -46,7 +46,7 @@ export default function ChatSection() {
   };
 
   return (
-    <section className="w-full flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden" data-tutorial="chat">
+    <section className="w-full chat-height flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden" data-tutorial="chat">
       <div className="px-4 pt-3 pb-2 border-b border-[#2D2D3F]">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -46,14 +46,14 @@ export default function ChatSection() {
   };
 
   return (
-    <section className="w-full flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden mb-48" data-tutorial="chat">
+    <section className="w-full flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden" data-tutorial="chat">
       <div className="px-4 pt-3 pb-2 border-b border-[#2D2D3F]">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
             <MessageIcon />
-            <h3 className="text-[14px] font-medium text-white">라운지</h3>
+            <h3 className="text-sm font-medium text-white">라운지</h3>
           </div>
-          <span className="text-[12px] text-[#99A1AF] flex items-center gap-1">
+          <span className="text-xs text-[#99A1AF] flex items-center gap-1">
             <PeoplesIcons />
             {currentMemberCount}
           </span>
@@ -79,7 +79,7 @@ export default function ChatSection() {
         />
       )}
 
-      <div ref={chatContainerRef} className="h-[422px] px-4 py-2 overflow-y-auto scrollbar-thin">
+      <div ref={chatContainerRef} className="h-[26.375rem] px-4 py-2 overflow-y-auto scrollbar-thin">
         {currentMessages.map((message) =>
           message.type === 'attack' || message.type === 'defense' ? (
             <DiscussionMessage

--- a/frontend/src/pages/battlePage/components/chatting/ChatTabs.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatTabs.tsx
@@ -16,12 +16,12 @@ export default function ChatTabs({ activeTab, onTabChange, team, unreadTeamCount
 
   if (team === 'NONE') {
     return (
-      <div className="flex-1 py-3 w-full text-[13px] font-medium rounded-t-lg bg-[#FF6900] text-white">
+      <div className="flex-1 py-3 w-full text-xs font-medium rounded-t-lg bg-[#FF6900] text-white">
         <span className="flex items-center justify-center gap-1">
-          <WordIcon className="w-[20px] h-[20px]" />
+          <WordIcon className="w-5 h-5" />
           <span className="">전체 라운지</span>
           {showAllCount && (
-            <span className="min-w-[18px] px-1.5 py-[1px] text-[11px] rounded-full bg-white/20 text-white">
+            <span className="min-w-[1.125rem] px-1.5 py-px text-[0.688rem] rounded-full bg-white/20 text-white">
               {unreadAllCount}
             </span>
           )}
@@ -34,15 +34,15 @@ export default function ChatTabs({ activeTab, onTabChange, team, unreadTeamCount
     <div className="flex gap-0 bg-[#2D2D3F] rounded-lg p-1">
       <button
         onClick={() => onTabChange('team')}
-        className={`flex-1 py-3 px-3 text-[13px] font-medium rounded-md transition-colors ${
+        className={`flex-1 py-3 px-3 text-xs font-medium rounded-md transition-colors ${
           activeTab === 'team' ? `${teamColor} text-white` : 'bg-transparent text-[#99A1AF] hover:text-white'
         }`}
       >
         <span className="flex items-center justify-center gap-1">
-          <PeopleIcon className="w-[20px] h-[20px]" />
+          <PeopleIcon className="w-5 h-5" />
           <span className="">팀 라운지</span>
           {showTeamCount && (
-            <span className="min-w-[18px] px-1.5 py-[1px] text-[11px] rounded-full bg-black/30 text-white">
+            <span className="min-w-[1.125rem] px-1.5 py-px text-[0.688rem] rounded-full bg-black/30 text-white">
               {unreadTeamCount}
             </span>
           )}
@@ -50,15 +50,15 @@ export default function ChatTabs({ activeTab, onTabChange, team, unreadTeamCount
       </button>
       <button
         onClick={() => onTabChange('all')}
-        className={`flex-1 py-3 px-3 text-[13px] font-medium rounded-md transition-colors ${
+        className={`flex-1 py-3 px-3 text-xs font-medium rounded-md transition-colors ${
           activeTab === 'all' ? 'bg-[#FF6900] text-white' : 'bg-transparent text-[#99A1AF] hover:text-white'
         }`}
       >
         <span className="flex items-center justify-center gap-1">
-          <WordIcon className="w-[20px] h-[20px]" />
+          <WordIcon className="w-5 h-5" />
           <span className="">전체 라운지</span>
           {showAllCount && (
-            <span className="min-w-[18px] px-1.5 py-[1px] text-[11px] rounded-full bg-black/30 text-white">
+            <span className="min-w-[1.125rem] px-1.5 py-px text-[0.688rem] rounded-full bg-black/30 text-white">
               {unreadAllCount}
             </span>
           )}

--- a/frontend/src/pages/battlePage/components/codeview/CodeHeader.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/CodeHeader.tsx
@@ -10,7 +10,7 @@ export default function CodeHeader({ onViewChange, currentView, currentTab, onTa
     <div className="flex items-center gap-2 px-4 py-3 border-b border-[#2D2D3F]">
       <button
         onClick={() => onViewChange('split')}
-        className={`px-4 py-2 rounded-md text-[14px] transition-colors ${
+        className={`px-4 py-2 rounded-md text-sm transition-colors ${
           currentView === 'split' ? 'bg-[#FF6900] text-white' : 'text-[#99A1AF]'
         }`}
       >
@@ -18,7 +18,7 @@ export default function CodeHeader({ onViewChange, currentView, currentTab, onTa
       </button>
       <button
         onClick={() => onViewChange('tab')}
-        className={`px-4 py-2 rounded-md text-[14px] transition-colors ${
+        className={`px-4 py-2 rounded-md text-sm transition-colors ${
           currentView === 'tab' ? 'bg-[#FF6900] text-white' : 'text-[#99A1AF]'
         }`}
       >
@@ -29,7 +29,7 @@ export default function CodeHeader({ onViewChange, currentView, currentTab, onTa
         <div className="flex items-center gap-2 ml-4 border-l border-[#2D2D3F] pl-4">
           <button
             onClick={() => onTabChange('A')}
-            className={`px-3 py-1.5 rounded-md text-[13px] transition-colors ${
+            className={`px-3 py-1.5 rounded-md text-xs transition-colors ${
               currentTab === 'A' ? 'bg-[#2B7FFF] text-white' : 'text-[#51A2FF] hover:bg-[#1C2B4A]'
             }`}
           >
@@ -37,7 +37,7 @@ export default function CodeHeader({ onViewChange, currentView, currentTab, onTa
           </button>
           <button
             onClick={() => onTabChange('B')}
-            className={`px-3 py-1.5 rounded-md text-[13px] transition-colors ${
+            className={`px-3 py-1.5 rounded-md text-xs transition-colors ${
               currentTab === 'B' ? 'bg-[#FB2C36] text-white' : 'text-[#FF5A5F] hover:bg-[#2D1F2B]'
             }`}
           >

--- a/frontend/src/pages/battlePage/components/codeview/CodeSection.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/CodeSection.tsx
@@ -15,7 +15,7 @@ export default function CodeSection({ onViewChange, currentView, codeA, codeB, l
 
   return (
     <section
-      className="w-full max-w-full h-fit flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden"
+      className="w-full max-w-full min-code-height flex flex-col bg-[#1E1E2F] rounded-lg overflow-hidden"
       data-tutorial="code-section"
     >
       <CodeHeader
@@ -24,7 +24,7 @@ export default function CodeSection({ onViewChange, currentView, codeA, codeB, l
         currentTab={currentTab}
         onTabChange={setCurrentTab}
       />
-      <div className="flex gap-4 p-4 flex-1 min-w-0">
+      <div className="flex gap-4 p-4 min-w-0">
         {currentView === 'split' ? (
           <>
             <CodeViewer team="A" language={language} code={codeA} />

--- a/frontend/src/pages/battlePage/components/codeview/CodeViewer.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/CodeViewer.tsx
@@ -27,8 +27,8 @@ export default function BattleCodeViewer({ team, language, code }: CodeViewerPro
   return (
     <div className={`flex-1 min-w-0 ${styles.bg} rounded-lg overflow-hidden border-2 ${styles.border}`}>
       <div className={`${styles.header} px-4 py-2 flex justify-between items-center`}>
-        <span className="text-[14px] text-white">{language}</span>
-        <span className={`text-[16px] font-bold ${styles.text}`}>구현 {team}</span>
+        <span className="text-sm text-white">{language}</span>
+        <span className={`text-base font-bold ${styles.text}`}>구현 {team}</span>
       </div>
       <CodeViewer code={code} language={language} team={team} containerClassName="w-full" />
     </div>

--- a/frontend/src/pages/battlePage/components/codeview/CodeViewer.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/CodeViewer.tsx
@@ -25,12 +25,19 @@ export default function BattleCodeViewer({ team, language, code }: CodeViewerPro
   const styles = TEAM_STYLES[team];
 
   return (
-    <div className={`flex-1 min-w-0 ${styles.bg} rounded-lg overflow-hidden border-2 ${styles.border}`}>
+    <div className={`flex-1 min-w-0 ${styles.bg} rounded-lg overflow-hidden border-2 ${styles.border} h-full`}>
       <div className={`${styles.header} px-4 py-2 flex justify-between items-center`}>
         <span className="text-sm text-white">{language}</span>
         <span className={`text-base font-bold ${styles.text}`}>구현 {team}</span>
       </div>
-      <CodeViewer code={code} language={language} team={team} containerClassName="w-full" />
+      <CodeViewer
+        code={code}
+        language={language}
+        team={team}
+        containerClassName="w-full"
+        minHeight="var(--code-height)"
+        maxHeight="none"
+      />
     </div>
   );
 }

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -35,7 +35,7 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
 
   return (
     <section
-      className={`relative w-full rounded-xl overflow-visible border-2 transition-all duration-500 ${config.colors.bg} ${config.colors.glowBorder} ${
+      className={`discussion-input-width relative rounded-xl overflow-visible border-2 transition-all duration-500 ${config.colors.bg} ${config.colors.glowBorder} ${
         isFocused ? 'scale-[1.01]' : ''
       }`}
     >
@@ -48,7 +48,7 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
         </span>
       </div>
 
-      <div className="relative px-5 py-6 pt-8">
+      <div className=" relative px-5 py-6 pt-8">
         <div className="flex items-center gap-4">
           <div
             className={`rounded-xl flex items-center justify-center shrink-0 w-16 h-16 border-2 ${config.colors.iconBox}

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionVote.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionVote.tsx
@@ -46,11 +46,11 @@ export default function DiscussionVote({ onVote }: DiscussionVoteProps) {
     <section className="w-full bg-[#1E1E2F] rounded-lg overflow-hidden">
       <div className="bg-gradient-to-r from-[#59168B] to-[#1C398E] p-4">
         <div className="flex items-center gap-2 mb-2">
-          <ScaleIcon className="w-[20px] h-[20px]" />
-          <h3 className="text-[14px] font-medium text-white">{headerText}</h3>
+          <ScaleIcon className="w-5 h-5" />
+          <h3 className="text-sm font-medium text-white">{headerText}</h3>
         </div>
 
-        <div className="text-[11px] text-white flex items-center gap-1">
+        <div className="text-xs text-white flex items-center gap-1">
           <span className="inline-block w-1 h-1 rounded-full bg-white"></span>
           {infoText}
         </div>
@@ -72,7 +72,7 @@ export default function DiscussionVote({ onVote }: DiscussionVoteProps) {
           ))}
         </div>
       </div>
-      <div className="py-4 bg-gradient-to-r from-[#1C398E] to-[#59168B] border-t border-[#2D2D3F] flex items-center justify-center gap-2 text-[13px]">
+      <div className="py-4 bg-gradient-to-r from-[#1C398E] to-[#59168B] border-t border-[#2D2D3F] flex items-center justify-center gap-2 text-sm">
         <span className="text-[#FFB800]">⚡</span>
         <span className="text-white font-medium">
           총 {discussions.length}개의 {summaryText}

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionVoteItem.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionVoteItem.tsx
@@ -32,18 +32,18 @@ export default function DiscussionVoteItem({
     >
       <div className="flex items-start justify-between mb-2">
         <div className="flex items-center gap-2">
-          <span className={`text-[13px] font-medium ${team === 'A' ? 'text-[#51A2FF]' : 'text-[#FF5A5F]'}`}>
-            {user}
-          </span>
-          {hasVoted && <span className="text-[10px] px-1.5 py-0.5 bg-[#2ECC71] text-white rounded">✓ 투표완료</span>}
+          <span className={`text-sm font-medium ${team === 'A' ? 'text-[#51A2FF]' : 'text-[#FF5A5F]'}`}>{user}</span>
+          {hasVoted && (
+            <span className="text-[0.625rem] px-1.5 py-0.5 bg-[#2ECC71] text-white rounded">✓ 투표완료</span>
+          )}
         </div>
         <div className="flex items-center gap-1">
-          <span className={`text-[18px] font-bold ${hasVoted ? 'text-[#2ECC71]' : 'text-white'}`}>{votes}</span>
-          <span className="text-[11px] text-[#99A1AF]">표</span>
+          <span className={`text-lg font-bold ${hasVoted ? 'text-[#2ECC71]' : 'text-white'}`}>{votes}</span>
+          <span className="text-xs text-[#99A1AF]">표</span>
         </div>
       </div>
 
-      <p className="text-[13px] text-white mb-3">{content}</p>
+      <p className="text-sm text-white mb-3">{content}</p>
 
       <div className="space-y-2">
         <div className="flex items-center gap-2">

--- a/frontend/src/pages/battlePage/components/effects/TeamVoteResultModal.tsx
+++ b/frontend/src/pages/battlePage/components/effects/TeamVoteResultModal.tsx
@@ -67,11 +67,11 @@ export default function TeamVoteResultModal({
         className={`relative flex flex-col items-center transition-all duration-500 ${scaleClass}`}
         onClick={handleClose}
       >
-        <div className="absolute inset-0 blur-[100px] bg-gradient-to-r from-orange-500 to-red-500 opacity-25 animate-pulse scale-125" />
+        <div className="absolute inset-0 blur-[6.25rem] bg-gradient-to-r from-orange-500 to-red-500 opacity-25 animate-pulse scale-125" />
 
-        <div className="flex flex-col items-center gap-16 min-w-[800px]">
+        <div className="flex flex-col items-center gap-16 min-w-[50rem]">
           <div
-            className={`px-6 py-2 rounded-full border-[#FF6900]/30 border-[1px] bg-gradient-to-r from-[#FF8900]/20 to-[#FF6900]/20 shadow-lg transition-all duration-500 ${badgeClass}`}
+            className={`px-6 py-2 rounded-full border-[#FF6900]/30 border bg-gradient-to-r from-[#FF8900]/20 to-[#FF6900]/20 shadow-lg transition-all duration-500 ${badgeClass}`}
           >
             <span className="text-[#FF8904] font-bold text-lg tracking-wider">ROUND {round} 결과</span>
           </div>
@@ -81,18 +81,18 @@ export default function TeamVoteResultModal({
               className={`relative transition-all duration-500 ${leadingTeam === 'A' ? 'scale-[1.15]' : 'scale-100'}`}
             >
               <div
-                className={`w-[413px] h-[255px] p-6 rounded-2xl border-2 backdrop-blur-sm flex flex-col justify-between ${
+                className={`max-w-md h-64 p-6 rounded-2xl border-2 backdrop-blur-sm flex flex-col justify-between ${
                   leadingTeam === 'A'
                     ? 'bg-blue-500/20 border-blue-400 shadow-lg shadow-blue-500/50'
                     : 'bg-gray-800/50 border-gray-600'
                 }`}
               >
                 <div className="flex flex-col items-start gap-1">
-                  <h3 className="text-[#51A2FF] font-bold text-[30px]">TEAM A</h3>
-                  {leadingTeam === 'A' && <span className="text-[12px] text-blue-300 font-bold">⚡ Leading</span>}
+                  <h3 className="text-[#51A2FF] font-bold text-3xl">TEAM A</h3>
+                  {leadingTeam === 'A' && <span className="text-xs text-blue-300 font-bold">⚡ Leading</span>}
                 </div>
                 <div className="flex flex-col items-start gap-1">
-                  <div className="text-[56px] font-black text-blue-400 leading-none">{teamACount}</div>
+                  <div className="text-6xl font-black text-blue-400 leading-none">{teamACount}</div>
                   <div className="text-gray-400">
                     이전 <span className="text-sm">{teamABefore}</span>{' '}
                     <span className={teamACount - teamABefore >= 0 ? 'text-green-400' : 'text-red-400'}>
@@ -110,7 +110,7 @@ export default function TeamVoteResultModal({
               </div>
             </div>
 
-            <div className="flex-shrink-0 border-[1px] border-[#FF8904]/50 w-[96px] h-[96px] rounded-full bg-gradient-to-b from-[#FF6900] to-[#FF4900] flex items-center justify-center text-white font-black text-[24px] shadow-lg z-10">
+            <div className="flex-shrink-0 border border-[#FF8904]/50 w-24 h-24 rounded-full bg-gradient-to-b from-[#FF6900] to-[#FF4900] flex items-center justify-center text-white font-black text-2xl shadow-lg z-10">
               VS
             </div>
 
@@ -118,18 +118,18 @@ export default function TeamVoteResultModal({
               className={`relative transition-all duration-500 ${leadingTeam === 'B' ? 'scale-[1.15]' : 'scale-100'}`}
             >
               <div
-                className={`w-[413px] h-[255px] p-6 rounded-2xl border-2 backdrop-blur-sm flex flex-col justify-between ${
+                className={`max-w-md h-64 p-6 rounded-2xl border-2 backdrop-blur-sm flex flex-col justify-between ${
                   leadingTeam === 'B'
                     ? 'bg-red-500/20 border-red-400 shadow-lg shadow-red-500/50'
                     : 'bg-gray-800/50 border-gray-600'
                 }`}
               >
                 <div className="flex flex-col items-start gap-1">
-                  <h3 className="text-[#FF6467] font-bold text-[30px]">TEAM B</h3>
-                  {leadingTeam === 'B' && <span className="text-[12px] text-red-300 font-bold">⚡ Leading</span>}
+                  <h3 className="text-[#FF6467] font-bold text-3xl">TEAM B</h3>
+                  {leadingTeam === 'B' && <span className="text-xs text-red-300 font-bold">⚡ Leading</span>}
                 </div>
                 <div className="flex flex-col items-start gap-1">
-                  <div className="text-[56px] font-black text-red-400 leading-none">{teamBCount}</div>
+                  <div className="text-6xl font-black text-red-400 leading-none">{teamBCount}</div>
                   <div className="text-gray-400">
                     이전 <span className="text-sm">{teamBBefore}</span>{' '}
                     <span className={teamBCount - teamBBefore >= 0 ? 'text-green-400' : 'text-red-400'}>
@@ -152,7 +152,7 @@ export default function TeamVoteResultModal({
             className={`w-full bg-gray-800/80 backdrop-blur-sm rounded-2xl border-2 border-gray-700 p-6 transition-all duration-500 delay-400 ${cardClass}`}
           >
             <p
-              className={`text-center font-bold text-[30px] mb-6 ${
+              className={`text-center font-bold text-3xl mb-6 ${
                 leadingTeam === 'A' ? 'text-blue-400' : 'text-red-400'
               }`}
             >
@@ -169,8 +169,8 @@ export default function TeamVoteResultModal({
                   style={{ width: `${teamBPercentage}%` }}
                 />
                 <div className="absolute inset-0 flex justify-between items-center px-4">
-                  <span className="text-white font-bold text-[20px]">{teamACount}</span>
-                  <span className="text-white font-bold text-[20px]">{teamBCount}</span>
+                  <span className="text-white font-bold text-xl">{teamACount}</span>
+                  <span className="text-white font-bold text-xl">{teamBCount}</span>
                 </div>
               </div>
               <div className="flex justify-between px-2 text-sm font-bold">

--- a/frontend/src/pages/battlePage/components/header/BattleTimer.tsx
+++ b/frontend/src/pages/battlePage/components/header/BattleTimer.tsx
@@ -26,7 +26,7 @@ export default function BattleTimer() {
 
   return (
     <div
-      className={`text-8xl font-bold tracking-wider ${isUrgent ? 'text-red-500 animate-timer-shake' : 'text-white'}`}
+      className={`text-7xl font-bold tracking-wider mb-2 ${isUrgent ? 'text-red-500 animate-timer-shake' : 'text-white'}`}
     >
       {formattedTime}
     </div>

--- a/frontend/src/pages/battlePage/components/header/BattleTimer.tsx
+++ b/frontend/src/pages/battlePage/components/header/BattleTimer.tsx
@@ -26,7 +26,7 @@ export default function BattleTimer() {
 
   return (
     <div
-      className={`text-[72px] font-bold tracking-wider ${isUrgent ? 'text-red-500 animate-timer-shake' : 'text-white'}`}
+      className={`text-8xl font-bold tracking-wider ${isUrgent ? 'text-red-500 animate-timer-shake' : 'text-white'}`}
     >
       {formattedTime}
     </div>

--- a/frontend/src/pages/battlePage/components/header/ParticipantRatioBar.tsx
+++ b/frontend/src/pages/battlePage/components/header/ParticipantRatioBar.tsx
@@ -9,7 +9,7 @@ export default function ParticipantRatioBar() {
   const teamBProgress = (teamBCount / total) * 100;
 
   return (
-    <div className="flex h-[12px]">
+    <div className="flex h-3">
       <div className="bg-blue-500 transition-all duration-500 ease-in-out" style={{ width: `${teamAProgress}%` }}></div>
       {none > 0 && (
         <div

--- a/frontend/src/pages/battlePage/components/header/StageIndicator.tsx
+++ b/frontend/src/pages/battlePage/components/header/StageIndicator.tsx
@@ -20,28 +20,28 @@ const PHASE_CONFIG: Record<BattlePhase, PhaseStyle> = {
     category: '대기 중',
     message: '배틀이 시작되기를 기다리고 있습니다.',
     container: 'bg-[#2B3440] border-[#9CA3AF]',
-    icon: 'text-[#E5E7EB] w-[28px] h-[28px]',
+    icon: 'text-[#E5E7EB] w-7 h-7',
     IconComponent: TimerIcon
   },
   OPINION_SHARE: {
     category: '의견 공유',
     message: '자유롭게 의견을 공유합니다.',
     container: 'bg-[#2E1F0A] border-[#FFA200]',
-    icon: 'text-[#FFA200] w-[24px] h-[24px]',
+    icon: 'text-[#FFA200] w-6 h-6',
     IconComponent: MessageIcon
   },
   ATTACK: {
     category: '이의제기',
     message: '양 진영이 서로의 코드에 대해 공격합니다.',
     container: 'bg-[#3B1414] border-[#E33F12]',
-    icon: 'text-[#FF3B30] w-[24px] h-[24px]',
+    icon: 'text-[#FF3B30] w-6 h-6',
     IconComponent: BattleIcon
   },
   DEFENSE: {
     category: '반박',
     message: '상대방의 공격을 방어합니다.',
     container: 'bg-[#0F2A4D] border-[#2B7FFF]',
-    icon: 'text-[#4F8CFF] w-[28px] h-[28px]',
+    icon: 'text-[#4F8CFF] w-7 h-7',
     IconComponent: ShieldIcon
   },
 
@@ -49,7 +49,7 @@ const PHASE_CONFIG: Record<BattlePhase, PhaseStyle> = {
     category: '팀 전환',
     message: '자신의 진영을 변경합니다.',
     container: 'bg-[#2B0F3F] border-[#B300FF]',
-    icon: 'text-[#C84DFF] w-[28px] h-[28px]',
+    icon: 'text-[#C84DFF] w-7 h-7',
     IconComponent: SwitchIcon
   }
 };
@@ -66,9 +66,9 @@ export default function StageIndicator() {
   const phaseName = ['ATTACK', 'DEFENSE'].includes(phase) ? `${phaseCount}차 ${category}` : category;
 
   return (
-    <div className="flex items-center gap-6 min-w-[200px]">
+    <div className="flex items-center gap-6 min-w-[12.5rem]">
       <div
-        className={`w-[56px] h-[56px] rounded-xl flex items-center justify-center border-2 transition-all duration-300 ${container}`}
+        className={`w-14 h-14 rounded-xl flex items-center justify-center border-2 transition-all duration-300 ${container}`}
       >
         <IconComponent className={icon} />
       </div>
@@ -76,24 +76,22 @@ export default function StageIndicator() {
       <div className="text-left">
         <div className="flex items-center gap-2">
           {/* Round */}
-          <span className="px-3 py-1 rounded-lg bg-[#253041] text-[#B6BDC9] text-[14px] font-semibold">
-            {round} Round
-          </span>
+          <span className="px-3 py-1 rounded-lg bg-[#253041] text-[#B6BDC9] text-sm font-semibold">{round} Round</span>
 
           {/* Topic */}
           {topics.length > 0 && (
-            <span className="px-3 py-1 rounded-lg bg-[#1E293B] text-[#C7D2FE] text-[14px] font-semibold">
+            <span className="px-3 py-1 rounded-lg bg-[#1E293B] text-[#C7D2FE] text-sm font-semibold">
               {topics[round - 1]}
             </span>
           )}
 
           {/* Phase (메인) */}
-          <span className="px-3 py-1 rounded-lg bg-[#0B1220] text-[#F9FAFB] text-[14px] font-semibold border border-[#2B7FFF]/30">
+          <span className="px-3 py-1 rounded-lg bg-[#0B1220] text-[#F9FAFB] text-sm font-semibold border border-[#2B7FFF]/30">
             {phaseName}
           </span>
         </div>
 
-        <p className="text-[20px] font-bold text-white leading-tight mt-0.5">{message}</p>
+        <p className="text-xl font-bold text-white leading-tight mt-0.5">{message}</p>
       </div>
     </div>
   );

--- a/frontend/src/pages/battlePage/components/header/TeamCounter.tsx
+++ b/frontend/src/pages/battlePage/components/header/TeamCounter.tsx
@@ -63,30 +63,30 @@ export default function TeamCounter() {
   }, [teamBCount]);
 
   return (
-    <div className="flex items-center gap-8 max-w-[200px]" data-tutorial="team-status">
+    <div className="flex items-center gap-8 max-w-xs" data-tutorial="team-status">
       <div className="text-center">
         <div
-          className={`text-[46px] font-bold text-[#3B82F6] ${
+          className={`text-5xl font-bold text-[#3B82F6] ${
             animateA === 'increase' ? 'animate-bounce-scale' : animateA === 'decrease' ? 'animate-shake-fade-out' : ''
           }`}
         >
           {teamACount}
         </div>
-        <div className="text-[12px] text-[#6A7282]">A팀</div>
+        <div className="text-xs text-[#6A7282]">A팀</div>
       </div>
       <div className="text-center">
-        <div className="text-[46px] font-bold text-[#6A7282]">{teamNoneCount}</div>
-        <div className="text-[12px] text-[#6A7282]">중립</div>
+        <div className="text-5xl font-bold text-[#6A7282]">{teamNoneCount}</div>
+        <div className="text-xs text-[#6A7282]">중립</div>
       </div>
       <div className="text-center">
         <div
-          className={`text-[46px] font-bold text-[#FF6467] ${
+          className={`text-5xl font-bold text-[#FF6467] ${
             animateB === 'increase' ? 'animate-bounce-scale' : animateB === 'decrease' ? 'animate-shake-fade-out' : ''
           }`}
         >
           {teamBCount}
         </div>
-        <div className="text-[12px] text-[#6A7282]">B팀</div>
+        <div className="text-xs text-[#6A7282]">B팀</div>
       </div>
     </div>
   );

--- a/frontend/src/pages/battlePage/components/header/TimeProgressBar.tsx
+++ b/frontend/src/pages/battlePage/components/header/TimeProgressBar.tsx
@@ -19,12 +19,6 @@ export default function TimeProgressBar() {
           animationFillMode: 'forwards'
         }}
       />
-      <style>{`
-        @keyframes shrink {
-          from { width: 100%; }
-          to { width: 0%; }
-        }
-      `}</style>
     </div>
   );
 }

--- a/frontend/src/pages/battlePage/components/header/TimeProgressBar.tsx
+++ b/frontend/src/pages/battlePage/components/header/TimeProgressBar.tsx
@@ -10,7 +10,7 @@ export default function TimeProgressBar() {
   }, [battleProgress?.expiredAt, battleProgress?.startedAt]);
 
   return (
-    <div className="h-[6px] bg-gray-700 overflow-hidden">
+    <div className="h-1.5 bg-gray-700 overflow-hidden">
       <div
         key={`${battleProgress?.expiredAt}-${battleProgress?.startedAt}`}
         className="h-full bg-blue-500"

--- a/frontend/src/pages/battlePage/components/header/VoteStatus.tsx
+++ b/frontend/src/pages/battlePage/components/header/VoteStatus.tsx
@@ -11,23 +11,23 @@ export default function VoteStatus({ teamACounts, teamBCounts, teamNoneCounts }:
   const bPercent = total > 0 ? (teamBCounts / total) * 100 : 33.33;
 
   return (
-    <div className="border-[1px] border-[#2D2D3F] rounded-md px-4 py-2">
-      <p className="text-[12px] text-[#99A1AF] mb-2 text-left">실시간 투표</p>
+    <div className="border border-[#2D2D3F] rounded-md px-4 py-2">
+      <p className="text-xs text-[#99A1AF] mb-2 text-left">실시간 투표</p>
       <div className="flex items-center gap-3 mb-2">
         <div className="text-center">
-          <p className="text-[16px] font-bold text-[#51A2FF]">{teamACounts}</p>
-          <p className="text-[12px] text-[#99A1AF]">A</p>
+          <p className="text-base font-bold text-[#51A2FF]">{teamACounts}</p>
+          <p className="text-xs text-[#99A1AF]">A</p>
         </div>
         <div className="text-center">
-          <p className="text-[16px] font-bold text-[#99A1AF]">{teamNoneCounts}</p>
-          <p className="text-[12px] text-[#99A1AF]">중립</p>
+          <p className="text-base font-bold text-[#99A1AF]">{teamNoneCounts}</p>
+          <p className="text-xs text-[#99A1AF]">중립</p>
         </div>
         <div className="text-center">
-          <p className="text-[16px] font-bold text-[#FF5A5F]">{teamBCounts}</p>
-          <p className="text-[12px] text-[#99A1AF]">B</p>
+          <p className="text-base font-bold text-[#FF5A5F]">{teamBCounts}</p>
+          <p className="text-xs text-[#99A1AF]">B</p>
         </div>
       </div>
-      <div className="flex gap-0.5 h-1.5 w-[140px]">
+      <div className="flex gap-0.5 h-1.5 w-36">
         <div className="bg-[#51A2FF] rounded-full" style={{ width: `${aPercent}%` }} />
         <div className="bg-[#99A1AF] rounded-full" style={{ width: `${nonePercent}%` }} />
         <div className="bg-[#FF5A5F] rounded-full" style={{ width: `${bPercent}%` }} />

--- a/frontend/src/pages/battlePage/components/header/index.tsx
+++ b/frontend/src/pages/battlePage/components/header/index.tsx
@@ -32,7 +32,7 @@ export default function BattleHeader() {
 
   return (
     <header
-      className="h-[11rem] main-width-closed bg-[#1E1E2F] rounded-lg mb-2 overflow-hidden flex flex-col"
+      className="header-height main-width-closed bg-[#1E1E2F] rounded-lg mb-2 overflow-hidden flex flex-col"
       data-tutorial="phase-guide"
     >
       <div className="px-8 flex-1 grid grid-cols-3 items-center">

--- a/frontend/src/pages/battlePage/components/header/index.tsx
+++ b/frontend/src/pages/battlePage/components/header/index.tsx
@@ -32,7 +32,7 @@ export default function BattleHeader() {
 
   return (
     <header
-      className="h-[179px] main-width-closed bg-[#1E1E2F] rounded-lg mb-2 overflow-hidden flex flex-col"
+      className="h-44 w-full bg-[#1E1E2F] rounded-lg mb-2 overflow-hidden flex flex-col"
       data-tutorial="phase-guide"
     >
       <div className="px-8 flex-1 grid grid-cols-3 items-center">

--- a/frontend/src/pages/battlePage/components/header/index.tsx
+++ b/frontend/src/pages/battlePage/components/header/index.tsx
@@ -32,7 +32,7 @@ export default function BattleHeader() {
 
   return (
     <header
-      className="h-44 w-full bg-[#1E1E2F] rounded-lg mb-2 overflow-hidden flex flex-col"
+      className="h-[11rem] main-width-closed bg-[#1E1E2F] rounded-lg mb-2 overflow-hidden flex flex-col"
       data-tutorial="phase-guide"
     >
       <div className="px-8 flex-1 grid grid-cols-3 items-center">

--- a/frontend/src/pages/battlePage/components/header/index.tsx
+++ b/frontend/src/pages/battlePage/components/header/index.tsx
@@ -32,7 +32,7 @@ export default function BattleHeader() {
 
   return (
     <header
-      className="h-[179px] w-[1800px] bg-[#1E1E2F] rounded-lg mb-2 overflow-hidden flex flex-col"
+      className="h-[179px] main-width-closed bg-[#1E1E2F] rounded-lg mb-2 overflow-hidden flex flex-col"
       data-tutorial="phase-guide"
     >
       <div className="px-8 flex-1 grid grid-cols-3 items-center">

--- a/frontend/src/pages/battlePage/components/modals/TeamChangeModal/VotingSection.tsx
+++ b/frontend/src/pages/battlePage/components/modals/TeamChangeModal/VotingSection.tsx
@@ -22,8 +22,8 @@ export default function VotingSection({
   return (
     <div className="flex flex-col items-center gap-2 border-t border-[#2d2d3f] pt-4">
       {/* 타이머 */}
-      <div className="text-[#FF8904] text-[24px] font-bold my-2 flex items-center">
-        <TimerIcon className="w-[24px] h-[24px] mr-2" />
+      <div className="text-[#FF8904] text-2xl font-bold my-2 flex items-center">
+        <TimerIcon className="w-6 h-6 mr-2" />
         <span>{remainingTime}</span>
       </div>
 
@@ -33,10 +33,10 @@ export default function VotingSection({
         <button
           type="button"
           onClick={() => onTeamChange('A')}
-          className="w-[200px] h-[150px] rounded-lg border border-[#155DFC] bg-[#1C398E] hover:bg-[#155DFC] flex flex-col justify-center items-center gap-2 transition-colors relative"
+          className="w-50 h-38 rounded-lg border border-[#155DFC] bg-[#1C398E] hover:bg-[#155DFC] flex flex-col justify-center items-center gap-2 transition-colors relative"
         >
-          {currentTeam === 'A' && <span className="absolute top-2 right-2 text-[#155DFC] text-[24px]">✓</span>}
-          <span className="text-[18px] font-bold">A팀</span>
+          {currentTeam === 'A' && <span className="absolute top-2 right-2 text-[#155DFC] text-2xl">✓</span>}
+          <span className="text-lg font-bold">A팀</span>
           <span>{teamACount}명</span>
         </button>
 
@@ -44,10 +44,10 @@ export default function VotingSection({
         <button
           type="button"
           onClick={() => onTeamChange('NONE')}
-          className="w-[200px] h-[150px] rounded-lg border border-[#6A7282] bg-[#364153] hover:bg-[#6A7282] flex flex-col justify-center items-center gap-2 transition-colors relative"
+          className="w-50 h-38 rounded-lg border border-[#6A7282] bg-[#364153] hover:bg-[#6A7282] flex flex-col justify-center items-center gap-2 transition-colors relative"
         >
-          {currentTeam === 'NONE' && <span className="absolute top-2 right-2 text-[#6A7282] text-[24px]">✓</span>}
-          <span className="text-[18px] font-bold">중립</span>
+          {currentTeam === 'NONE' && <span className="absolute top-2 right-2 text-[#6A7282] text-2xl">✓</span>}
+          <span className="text-lg font-bold">중립</span>
           <span>{noneTeamCount}명</span>
         </button>
 
@@ -55,16 +55,16 @@ export default function VotingSection({
         <button
           type="button"
           onClick={() => onTeamChange('B')}
-          className="w-[200px] h-[150px] rounded-lg border border-[#FB2C36] bg-[#82181A] hover:bg-[#FB2C36] flex flex-col justify-center items-center gap-2 transition-colors relative"
+          className="w-50 h-38 rounded-lg border border-[#FB2C36] bg-[#82181A] hover:bg-[#FB2C36] flex flex-col justify-center items-center gap-2 transition-colors relative"
         >
-          {currentTeam === 'B' && <span className="absolute top-2 right-2 text-[#FB2C36] text-[24px]">✓</span>}
-          <span className="text-[18px] font-bold">B팀</span>
+          {currentTeam === 'B' && <span className="absolute top-2 right-2 text-[#FB2C36] text-2xl">✓</span>}
+          <span className="text-lg font-bold">B팀</span>
           <span>{teamBCount}명</span>
         </button>
       </div>
 
       {/* 안내 문구 */}
-      <p className="text-[#6A7282] text-[14px]">💡투표 후에도 다음 투표 시간에 팀을 변경할 수 있어요</p>
+      <p className="text-[#6A7282] text-sm">💡투표 후에도 다음 투표 시간에 팀을 변경할 수 있어요</p>
     </div>
   );
 }

--- a/frontend/src/pages/battlePage/components/modals/TeamChangeModal/index.tsx
+++ b/frontend/src/pages/battlePage/components/modals/TeamChangeModal/index.tsx
@@ -50,7 +50,7 @@ export default function TeamChangeModal({ topics, handleTeamChange, onClose }: T
   return createPortal(
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4 overflow-y-auto">
       <div
-        className="w-full max-w-[900px] rounded-lg bg-[#1E1E2F] border-[3px] border-[#FF6900] shadow-2xl flex flex-col gap-4 p-6 text-white my-8"
+        className="w-full max-w-4xl rounded-lg bg-[#1E1E2F] border-[0.188rem] border-[#FF6900] shadow-2xl flex flex-col gap-4 p-6 text-white my-8"
         onClick={(e) => e.stopPropagation()}
       >
         {/* 타임라인 섹션 */}

--- a/frontend/src/pages/battlePage/components/progressBoard/CollapseButton.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/CollapseButton.tsx
@@ -1,0 +1,30 @@
+interface CollapseButtonProps {
+  onClick: () => void;
+}
+
+export function CollapseButton({ onClick }: CollapseButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="
+        absolute right-1 top-3
+        w-8 h-8
+        rounded-full
+        bg-[#FF6900]
+        shadow-[0px_10px_15px_-3px_rgba(0,0,0,0.1),0px_4px_6px_-4px_rgba(0,0,0,0.1)]
+        flex items-center justify-center
+        transition-all duration-200 ease-out
+        hover:scale-110 hover:bg-[#FF5200]
+        active:scale-95
+      "
+    >
+      <div
+        className="
+          w-2.5 h-2.5
+          border-r-2 border-b-2 border-white
+          -rotate-135
+        "
+      />
+    </button>
+  );
+}

--- a/frontend/src/pages/battlePage/components/progressBoard/ExpandButton.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ExpandButton.tsx
@@ -1,0 +1,30 @@
+interface ExpandButtonProps {
+  onClick: () => void;
+}
+
+export function ExpandButton({ onClick }: ExpandButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="
+        absolute left-1/2 -translate-x-1/2 top-[calc(100%+6rem)]
+        w-8 h-8
+        rounded-full
+        bg-[#FF6900]
+        shadow-[0px_10px_15px_-3px_rgba(0,0,0,0.1),0px_4px_6px_-4px_rgba(0,0,0,0.1)]
+        flex items-center justify-center
+        transition-all duration-200 ease-out
+        hover:scale-110 hover:bg-[#FF5200]
+        active:scale-95
+      "
+    >
+      <div
+        className="
+          w-2.5 h-2.5
+          border-r-2 border-b-2 border-white
+          rotate-45
+        "
+      />
+    </button>
+  );
+}

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBar.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBar.tsx
@@ -1,0 +1,27 @@
+interface ProgressBarProps {
+  expiredAt: number;
+  startedAt: number;
+}
+
+export function ProgressBar({ expiredAt, startedAt }: ProgressBarProps) {
+  const duration = Math.max(0, (expiredAt - startedAt) / 1000);
+
+  return (
+    <div className="mt-1.5 h-1.5 bg-[#0A0A1A] rounded-full overflow-hidden">
+      <div
+        key={`${expiredAt}-${startedAt}`}
+        className="h-full bg-gradient-to-r from-[#FF6900] via-[#FF8904] to-[#F54900]"
+        style={{
+          animation: `shrink ${duration}s linear`,
+          animationFillMode: 'forwards'
+        }}
+      />
+      <style>{`
+        @keyframes shrink {
+          from { width: 100%; }
+          to { width: 0%; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBar.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBar.tsx
@@ -16,12 +16,6 @@ export function ProgressBar({ expiredAt, startedAt }: ProgressBarProps) {
           animationFillMode: 'forwards'
         }}
       />
-      <style>{`
-        @keyframes shrink {
-          from { width: 100%; }
-          to { width: 0%; }
-        }
-      `}</style>
     </div>
   );
 }

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -14,7 +14,7 @@ export default function BattleProgressBoard() {
     (battleProgress.phase as string) !== 'PENDING' &&
     battleProgress.expiredAt != null &&
     battleProgress.startedAt != null;
-  console.log(battleProgress);
+
   return (
     <div className="fixed top-0 left-0 right-0 z-10 flex justify-center pointer-events-none">
       {shouldShow && (

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -121,21 +121,21 @@ export default function BattleProgressBoard() {
         className={`
           pointer-events-auto
           relative
-          w-[750px]
+          max-w-3xl
           rounded-lg
           bg-[#1a1a2ef2]
           border-b-[1.333px] border-b-[#1E2939]
           shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.25)]
           transition-all duration-300 ease-in-out
-          ${collapsed ? '-translate-y-[120px] h-[32px]' : 'h-[100px] pb-3'}
+          ${collapsed ? '-translate-y-[7.5rem] h-8' : 'h-24 pb-3'}
         `}
       >
         {!collapsed && (
           <button
             onClick={() => setCollapsed(true)}
             className="
-              absolute right-[3px] top-[12px]
-              w-[32px] h-[32px]
+              absolute right-1 top-3
+              w-8 h-8
               rounded-full
               bg-[#FF6900]
               shadow-[0px_10px_15px_-3px_rgba(0,0,0,0.1),0px_4px_6px_-4px_rgba(0,0,0,0.1)]
@@ -149,7 +149,7 @@ export default function BattleProgressBoard() {
           >
             <div
               className="
-                w-[10px] h-[10px]
+                w-2.5 h-2.5
                 border-r-2 border-b-2 border-white
                 -rotate-135
               "
@@ -162,7 +162,7 @@ export default function BattleProgressBoard() {
             onClick={() => setCollapsed(false)}
             className="
               absolute left-1/2 -translate-x-1/2 top-[calc(100%+96px)]
-              w-[32px] h-[32px]
+              w-8 h-8
               rounded-full
               bg-[#FF6900]
               shadow-[0px_10px_15px_-3px_rgba(0,0,0,0.1),0px_4px_6px_-4px_rgba(0,0,0,0.1)]
@@ -176,7 +176,7 @@ export default function BattleProgressBoard() {
           >
             <div
               className="
-                w-[10px] h-[10px]
+                w-2.5 h-2.5
                 border-r-2 border-b-2 border-white
                 rotate-45
               "
@@ -186,15 +186,15 @@ export default function BattleProgressBoard() {
 
         <div
           className={`
-            absolute left-[26.21px] top-[12px]
-            w-[700px]
+            absolute left-[1.638rem] top-3
+            max-w-2xl
             flex flex-col gap-1.5
             transition-opacity duration-200
             ${collapsed ? 'opacity-0 pointer-events-none' : 'opacity-100'}
           `}
         >
           <div className="flex items-center gap-4 px-4">
-            <div className="text-[22px] font-bold text-[#FF6900] min-w-[100px] flex items-center justify-center h-[56px]">
+            <div className="text-2xl font-bold text-[#FF6900] min-w-[6.25rem] flex items-center justify-center h-14">
               {getCurrentStageNumber()}
             </div>
             {STAGES.map((stage, index) => (
@@ -211,7 +211,7 @@ export default function BattleProgressBoard() {
             ))}
           </div>
 
-          <div className="mt-1.5 h-[6px] bg-[#0A0A1A] rounded-full overflow-hidden">
+          <div className="mt-1.5 h-1.5 bg-[#0A0A1A] rounded-full overflow-hidden">
             <div
               key={`${battleProgress?.expiredAt}-${battleProgress?.startedAt}`}
               className="h-full bg-gradient-to-r from-[#FF6900] via-[#FF8904] to-[#F54900]"

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -1,54 +1,54 @@
-import { useState } from 'react';
-import { selectBattleProgress, useBattleStore } from '../../stores/battleStore';
+import { selectBattleProgress, selectProgressBoardCollapsed, useBattleStore } from '../../stores/battleStore';
 import { CollapseButton } from './CollapseButton';
 import { ExpandButton } from './ExpandButton';
 import { ProgressBar } from './ProgressBar';
 import { StageList } from './StageList';
 
 export default function BattleProgressBoard() {
-  const [collapsed, setCollapsed] = useState(false);
   const battleProgress = useBattleStore(selectBattleProgress);
+  const collapsed = useBattleStore(selectProgressBoardCollapsed);
+  const setCollapsed = useBattleStore((state) => state.setProgressBoardCollapsed);
 
-  if (!battleProgress) return null;
-
-  const { round, phase, phaseCount, expiredAt, startedAt } = battleProgress;
-
-  if ((phase as string) === 'PENDING') {
-    return null;
-  }
-
-  if (!expiredAt || !startedAt) {
-    return null;
-  }
-
+  const shouldShow =
+    battleProgress &&
+    (battleProgress.phase as string) !== 'PENDING' &&
+    battleProgress.expiredAt != null &&
+    battleProgress.startedAt != null;
+  console.log(battleProgress);
   return (
-    <div className="sticky top-0 z-10 flex justify-center pointer-events-none animate-slideDown">
-      <div
-        data-tutorial="progress-board"
-        className={`
-          pointer-events-auto relative max-w-3xl rounded-lg bg-[#1a1a2ef2]
-          border-b-[1.333px] border-b-[#1E2939]
-          shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.25)]
-          transition-all duration-300 ease-in-out
-          ${collapsed ? '-translate-y-[7.5rem] h-8' : 'h-24 pb-3'}
-        `}
-      >
-        {!collapsed && <CollapseButton onClick={() => setCollapsed(true)} />}
-        {collapsed && <ExpandButton onClick={() => setCollapsed(false)} />}
-
+    <div className="fixed top-0 left-0 right-0 z-10 flex justify-center pointer-events-none">
+      {shouldShow && (
         <div
+          data-tutorial="progress-board"
           className={`
-            absolute left-[1.638rem] top-3
-            max-w-2xl
-            flex flex-col gap-1.5
-            transition-opacity duration-200
-            ${collapsed ? 'opacity-0 pointer-events-none' : 'opacity-100'}
+            pointer-events-auto relative w-full max-w-3xl rounded-lg bg-[#1a1a2ef2]
+            border-b-[1.333px] border-b-[#1E2939]
+            shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.25)]
+            transition-all duration-300 ease-in-out animate-slideDown
+            ${collapsed ? '-translate-y-[7.5rem] h-8' : 'h-24 pb-3'}
           `}
         >
-          <StageList round={round} phase={phase} phaseCount={phaseCount} />
-          <ProgressBar expiredAt={expiredAt} startedAt={startedAt} />
+          {!collapsed && <CollapseButton onClick={() => setCollapsed(true)} />}
+          {collapsed && <ExpandButton onClick={() => setCollapsed(false)} />}
+
+          <div
+            className={`
+              absolute left-[1.638rem] top-3
+              max-w-2xl
+              flex flex-col gap-1.5
+              transition-opacity duration-200
+              ${collapsed ? 'opacity-0 pointer-events-none' : 'opacity-100'}
+            `}
+          >
+            <StageList
+              round={battleProgress.round}
+              phase={battleProgress.phase}
+              phaseCount={battleProgress.phaseCount}
+            />
+            <ProgressBar expiredAt={battleProgress.expiredAt!} startedAt={battleProgress.startedAt!} />
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -1,188 +1,40 @@
-import { useState, useMemo } from 'react';
-import { StageIcon } from './StageIcon';
-import DownArrowIcon from '@/assets/icon/downArrow.svg?react';
+import { useState } from 'react';
 import { selectBattleProgress, useBattleStore } from '../../stores/battleStore';
-import type { BattlePhase } from '@/commons/types/battle';
-
-const COLOR_MAP = {
-  BASE: { bg: '#0A0A1A', border: '#364153', text: '#99A1AF' },
-  OPINION_SHARE: { bg: '#de932333', border: '#ffa200ff', text: '#ffa200ff' },
-  ATTACK: { bg: '#f7414133', border: '#e33f12ff', text: '#de1f1fff' },
-  DEFENSE: { bg: '#2b7fff33', border: '#2B7FFF', text: '#2B7FFF' },
-  TEAM_SWITCH: { bg: '#bd5efc33', border: '#9500ffff', text: '#b300ffff' },
-  PENDING: { bg: '#0A0A1A', border: '#364153', text: '#99A1AF' }
-};
-
-// 6단계 정의 (한 라운드당 6개 페이즈)
-const STAGES = [
-  {
-    step: 1,
-    phase: 'OPINION_SHARE',
-    icon: 'message',
-    label: '의견공유',
-    description:
-      '의견공유 시간입니다. 현재 라운드의 대주제를 확인하고 라운지에서 자유롭게 의견을 나누며 이의제기를 준비해주세요!'
-  },
-  {
-    step: 2,
-    phase: 'ATTACK',
-    icon: 'battle',
-    label: '공격(1차)',
-    description:
-      '1차 이의제기 시간입니다. 주어진 3분 동안 상대 코드의 문제점을 찾고 투표를 통해 공격할 내용을 선정해보세요!'
-  },
-  {
-    step: 3,
-    phase: 'DEFENSE',
-    icon: 'shield',
-    label: '수비(1차)',
-    description:
-      '1차 반론 시간입니다. 주어진 4분 동안 상대의 공격에 대한 반박 논리를 작성하고 투표를 통해 방어할 내용을 선정해보세요!'
-  },
-  {
-    step: 4,
-    phase: 'ATTACK',
-    icon: 'battle',
-    label: '공격(2차)',
-    description:
-      '2차 이의제기 시간입니다. 주어진 3분 동안 상대 코드 혹은 반론에 대한 문제점을 찾고 투표를 통해 공격할 내용을 선정해보세요!'
-  },
-  {
-    step: 5,
-    phase: 'DEFENSE',
-    icon: 'shield',
-    label: '수비(2차)',
-    description:
-      '2차 반론 시간입니다. 주어진 4분 동안 상대의 공격에 대한 반박 논리를 작성하고 투표를 통해 최종적으로 방어할 내용을 선정해보세요!'
-  },
-  {
-    step: 6,
-    phase: 'TEAM_SWITCH',
-    icon: 'switch',
-    label: '팀변경',
-    description:
-      '진영 선택 시간입니다. 라운드를 진행하며 나눈 공격과 수비를 다시 확인해보고 지지하시는 팀으로 변경하실 수 있습니다!'
-  }
-] as const;
+import { CollapseButton } from './CollapseButton';
+import { ExpandButton } from './ExpandButton';
+import { ProgressBar } from './ProgressBar';
+import { StageList } from './StageList';
 
 export default function BattleProgressBoard() {
   const [collapsed, setCollapsed] = useState(false);
   const battleProgress = useBattleStore(selectBattleProgress);
 
-  // 프로그레스 바 duration 계산
-  const duration = useMemo(() => {
-    if (!battleProgress?.expiredAt || !battleProgress?.startedAt) return 60;
-    return Math.max(0, (battleProgress.expiredAt - battleProgress.startedAt) / 1000);
-  }, [battleProgress?.expiredAt, battleProgress?.startedAt]);
-
   if (!battleProgress) return null;
 
-  const { round, phase, phaseCount } = battleProgress;
+  const { round, phase, phaseCount, expiredAt, startedAt } = battleProgress;
 
-  // PENDING 상태일 때는 아예 렌더링하지 않음
   if ((phase as string) === 'PENDING') {
     return null;
   }
 
-  // 현재 페이즈의 step 번호 계산 (1-6)
-  const getCurrentPhaseStep = () => {
-    // phaseCount는 ATTACK/DEFENSE 반복 횟수 (1~BATTLE_MAX_PHASE_COUNT)
-    // phase와 phaseCount로 step 계산
-    if (phase === 'OPINION_SHARE') return 1;
-    if (phase === 'ATTACK') return phaseCount * 2; // 1차: 2, 2차: 4
-    if (phase === 'DEFENSE') return phaseCount * 2 + 1; // 1차: 3, 2차: 5
-    if (phase === 'TEAM_SWITCH') return 6;
-    return 1;
-  };
-
-  // 현재 활성 단계인지 확인
-  const isActiveStage = (stageStep: number) => {
-    return getCurrentPhaseStep() === stageStep;
-  };
-
-  // 현재 라운드 번호 표시
-  const getCurrentStageNumber = () => {
-    return `Round ${round}`;
-  };
-
-  const getStageColor = (stage: BattlePhase) => COLOR_MAP[stage] || COLOR_MAP.BASE;
+  if (!expiredAt || !startedAt) {
+    return null;
+  }
 
   return (
-    <div
-      className="
-        sticky top-0 z-10
-        flex justify-center
-        pointer-events-none
-        animate-slideDown
-      "
-    >
+    <div className="sticky top-0 z-10 flex justify-center pointer-events-none animate-slideDown">
       <div
         data-tutorial="progress-board"
         className={`
-          pointer-events-auto
-          relative
-          max-w-3xl
-          rounded-lg
-          bg-[#1a1a2ef2]
+          pointer-events-auto relative max-w-3xl rounded-lg bg-[#1a1a2ef2]
           border-b-[1.333px] border-b-[#1E2939]
           shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.25)]
           transition-all duration-300 ease-in-out
           ${collapsed ? '-translate-y-[7.5rem] h-8' : 'h-24 pb-3'}
         `}
       >
-        {!collapsed && (
-          <button
-            onClick={() => setCollapsed(true)}
-            className="
-              absolute right-1 top-3
-              w-8 h-8
-              rounded-full
-              bg-[#FF6900]
-              shadow-[0px_10px_15px_-3px_rgba(0,0,0,0.1),0px_4px_6px_-4px_rgba(0,0,0,0.1)]
-              flex items-center justify-center
-
-              transition-all duration-200 ease-out
-              hover:scale-110
-              hover:bg-[#FF5200]
-              active:scale-95
-            "
-          >
-            <div
-              className="
-                w-2.5 h-2.5
-                border-r-2 border-b-2 border-white
-                -rotate-135
-              "
-            />
-          </button>
-        )}
-
-        {collapsed && (
-          <button
-            onClick={() => setCollapsed(false)}
-            className="
-              absolute left-1/2 -translate-x-1/2 top-[calc(100%+96px)]
-              w-8 h-8
-              rounded-full
-              bg-[#FF6900]
-              shadow-[0px_10px_15px_-3px_rgba(0,0,0,0.1),0px_4px_6px_-4px_rgba(0,0,0,0.1)]
-              flex items-center justify-center
-              transition-all duration-200 ease-out
-              hover:scale-110
-              hover:bg-[#FF5200]
-              active:scale-95
-
-            "
-          >
-            <div
-              className="
-                w-2.5 h-2.5
-                border-r-2 border-b-2 border-white
-                rotate-45
-              "
-            />
-          </button>
-        )}
+        {!collapsed && <CollapseButton onClick={() => setCollapsed(true)} />}
+        {collapsed && <ExpandButton onClick={() => setCollapsed(false)} />}
 
         <div
           className={`
@@ -193,41 +45,11 @@ export default function BattleProgressBoard() {
             ${collapsed ? 'opacity-0 pointer-events-none' : 'opacity-100'}
           `}
         >
-          <div className="flex items-center gap-4 px-4">
-            <div className="text-2xl font-bold text-[#FF6900] min-w-[6.25rem] flex items-center justify-center h-14">
-              {getCurrentStageNumber()}
-            </div>
-            {STAGES.map((stage, index) => (
-              <div key={stage.step} className="flex items-center gap-3">
-                <StageIcon
-                  icon={stage.icon as 'message' | 'battle' | 'shield' | 'switch'}
-                  {...getStageColor(stage.phase as BattlePhase)}
-                  active={isActiveStage(stage.step)}
-                  small={true}
-                  tooltip={stage.description}
-                />
-                {index < STAGES.length - 1 && <DownArrowIcon className="-rotate-90 opacity-40" />}
-              </div>
-            ))}
-          </div>
-
-          <div className="mt-1.5 h-1.5 bg-[#0A0A1A] rounded-full overflow-hidden">
-            <div
-              key={`${battleProgress?.expiredAt}-${battleProgress?.startedAt}`}
-              className="h-full bg-gradient-to-r from-[#FF6900] via-[#FF8904] to-[#F54900]"
-              style={{
-                animation: `shrink ${duration}s linear`,
-                animationFillMode: 'forwards'
-              }}
-            />
-          </div>
+          <StageList round={round} phase={phase} phaseCount={phaseCount} />
+          <ProgressBar expiredAt={expiredAt} startedAt={startedAt} />
         </div>
       </div>
       <style>{`
-        @keyframes shrink {
-          from { width: 100%; }
-          to { width: 0%; }
-        }
         @keyframes slideDown {
           from {
             transform: translateY(-100%);

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -49,21 +49,6 @@ export default function BattleProgressBoard() {
           <ProgressBar expiredAt={expiredAt} startedAt={startedAt} />
         </div>
       </div>
-      <style>{`
-        @keyframes slideDown {
-          from {
-            transform: translateY(-100%);
-            opacity: 0;
-          }
-          to {
-            transform: translateY(0);
-            opacity: 1;
-          }
-        }
-        .animate-slideDown {
-          animation: slideDown 0.5s ease-out;
-        }
-      `}</style>
     </div>
   );
 }

--- a/frontend/src/pages/battlePage/components/progressBoard/StageIcon.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/StageIcon.tsx
@@ -20,11 +20,11 @@ export function StageIcon({
   small?: boolean;
   tooltip?: string;
 }) {
-  const baseSize = small ? 48 : 52.8;
-  const activeSize = small ? 56 : 60;
+  const baseSize = small ? 3 : 3.3; // rem
+  const activeSize = small ? 3.5 : 3.75; // rem
   const size = active ? activeSize : baseSize;
 
-  const iconClass = `w-[20px] h-[20px] transition-all`;
+  const iconClass = `w-5 h-5 transition-all`;
   const iconStyle = active ? { color: text } : { color: '#99A1AF' };
 
   const renderIcon = () => {
@@ -46,15 +46,15 @@ export function StageIcon({
     <div className="relative flex flex-col items-center gap-1 group">
       <div
         className={`
-          rounded-[12px]
+          rounded-xl
           flex items-center justify-center
           border-[1.333px]
           transition-all duration-300 ease-in-out
           ${active ? 'shadow-[0px_20px_25px_-5px_rgba(0,0,0,0.25)]' : ''}
         `}
         style={{
-          width: `${size}px`,
-          height: `${size}px`,
+          width: `${size}rem`,
+          height: `${size}rem`,
           background: active ? bg : '#0A0A1A',
           borderColor: active ? border : '#364153'
         }}
@@ -79,9 +79,9 @@ export function StageIcon({
             className="
               absolute bottom-full left-1/2 -translate-x-1/2 translate-y-[0.5px]
               w-0 h-0
-              border-l-[8px] border-l-transparent
-              border-r-[8px] border-r-transparent
-              border-b-[8px] border-b-[#364153]
+              border-l-8 border-l-transparent
+              border-r-8 border-r-transparent
+              border-b-8 border-b-[#364153]
             "
           />
           {/* 배경색 화살표 (작게, 위에 겹침) */}
@@ -89,9 +89,9 @@ export function StageIcon({
             className="
               absolute bottom-full left-1/2 -translate-x-1/2
               w-0 h-0
-              border-l-[6px] border-l-transparent
-              border-r-[6px] border-r-transparent
-              border-b-[6px] border-b-[#1E1E2F]
+              border-l-[1.5rem] border-l-transparent
+              border-r-[1.5rem] border-r-transparent
+              border-b-[1.5rem] border-b-[#1E1E2F]
             "
           />
         </div>

--- a/frontend/src/pages/battlePage/components/progressBoard/StageIcon.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/StageIcon.tsx
@@ -20,8 +20,8 @@ export function StageIcon({
   small?: boolean;
   tooltip?: string;
 }) {
-  const baseSize = small ? 3 : 3.3; // rem
-  const activeSize = small ? 3.5 : 3.75; // rem
+  const baseSize = small ? 3 : 3.3;
+  const activeSize = small ? 3.5 : 3.75;
   const size = active ? activeSize : baseSize;
 
   const iconClass = `w-5 h-5 transition-all`;
@@ -74,26 +74,8 @@ export function StageIcon({
           "
         >
           {tooltip}
-          {/* 테두리용 화살표 (더 크게) */}
-          <div
-            className="
-              absolute bottom-full left-1/2 -translate-x-1/2 translate-y-[0.5px]
-              w-0 h-0
-              border-l-8 border-l-transparent
-              border-r-8 border-r-transparent
-              border-b-8 border-b-[#364153]
-            "
-          />
-          {/* 배경색 화살표 (작게, 위에 겹침) */}
-          <div
-            className="
-              absolute bottom-full left-1/2 -translate-x-1/2
-              w-0 h-0
-              border-l-[1.5rem] border-l-transparent
-              border-r-[1.5rem] border-r-transparent
-              border-b-[1.5rem] border-b-[#1E1E2F]
-            "
-          />
+          <div className="absolute bottom-full left-1/2 -translate-x-1/2 translate-y-[0.5px] w-0 h-0 border-l-8 border-l-transparent border-r-8 border-r-transparent border-b-8 border-b-[#364153]" />
+          <div className="absolute bottom-full left-1/2 -translate-x-1/2 w-0 h-0 border-l-[1.5rem] border-l-transparent border-r-[1.5rem] border-r-transparent border-b-[1.5rem] border-b-[#1E1E2F]" />
         </div>
       )}
     </div>

--- a/frontend/src/pages/battlePage/components/progressBoard/StageList.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/StageList.tsx
@@ -1,0 +1,105 @@
+import { StageIcon } from './StageIcon';
+import DownArrowIcon from '@/assets/icon/downArrow.svg?react';
+import type { BattlePhase } from '@/commons/types/battle';
+
+const COLOR_MAP = {
+  BASE: { bg: '#0A0A1A', border: '#364153', text: '#99A1AF' },
+  OPINION_SHARE: { bg: '#de932333', border: '#ffa200ff', text: '#ffa200ff' },
+  ATTACK: { bg: '#f7414133', border: '#e33f12ff', text: '#de1f1fff' },
+  DEFENSE: { bg: '#2b7fff33', border: '#2B7FFF', text: '#2B7FFF' },
+  TEAM_SWITCH: { bg: '#bd5efc33', border: '#9500ffff', text: '#b300ffff' },
+  PENDING: { bg: '#0A0A1A', border: '#364153', text: '#99A1AF' }
+};
+
+const STAGES = [
+  {
+    step: 1,
+    phase: 'OPINION_SHARE',
+    icon: 'message',
+    label: '의견공유',
+    description:
+      '의견공유 시간입니다. 현재 라운드의 대주제를 확인하고 라운지에서 자유롭게 의견을 나누며 이의제기를 준비해주세요!'
+  },
+  {
+    step: 2,
+    phase: 'ATTACK',
+    icon: 'battle',
+    label: '공격(1차)',
+    description:
+      '1차 이의제기 시간입니다. 주어진 3분 동안 상대 코드의 문제점을 찾고 투표를 통해 공격할 내용을 선정해보세요!'
+  },
+  {
+    step: 3,
+    phase: 'DEFENSE',
+    icon: 'shield',
+    label: '수비(1차)',
+    description:
+      '1차 반론 시간입니다. 주어진 4분 동안 상대의 공격에 대한 반박 논리를 작성하고 투표를 통해 방어할 내용을 선정해보세요!'
+  },
+  {
+    step: 4,
+    phase: 'ATTACK',
+    icon: 'battle',
+    label: '공격(2차)',
+    description:
+      '2차 이의제기 시간입니다. 주어진 3분 동안 상대 코드 혹은 반론에 대한 문제점을 찾고 투표를 통해 공격할 내용을 선정해보세요!'
+  },
+  {
+    step: 5,
+    phase: 'DEFENSE',
+    icon: 'shield',
+    label: '수비(2차)',
+    description:
+      '2차 반론 시간입니다. 주어진 4분 동안 상대의 공격에 대한 반박 논리를 작성하고 투표를 통해 최종적으로 방어할 내용을 선정해보세요!'
+  },
+  {
+    step: 6,
+    phase: 'TEAM_SWITCH',
+    icon: 'switch',
+    label: '팀변경',
+    description:
+      '진영 선택 시간입니다. 라운드를 진행하며 나눈 공격과 수비를 다시 확인해보고 지지하시는 팀으로 변경하실 수 있습니다!'
+  }
+] as const;
+
+interface StageListProps {
+  round: number;
+  phase: BattlePhase;
+  phaseCount: number;
+}
+
+export function StageList({ round, phase, phaseCount }: StageListProps) {
+  const getCurrentPhaseStep = () => {
+    if (phase === 'OPINION_SHARE') return 1;
+    if (phase === 'ATTACK') return phaseCount * 2;
+    if (phase === 'DEFENSE') return phaseCount * 2 + 1;
+    if (phase === 'TEAM_SWITCH') return 6;
+    return 1;
+  };
+
+  const isActiveStage = (stageStep: number) => {
+    return getCurrentPhaseStep() === stageStep;
+  };
+
+  const getStageColor = (stage: BattlePhase) => COLOR_MAP[stage] || COLOR_MAP.BASE;
+
+  return (
+    <div className="flex items-center gap-4 px-4">
+      <div className="text-2xl font-bold text-[#FF6900] min-w-[6.25rem] flex items-center justify-center h-14">
+        Round {round}
+      </div>
+      {STAGES.map((stage, index) => (
+        <div key={stage.step} className="flex items-center gap-3">
+          <StageIcon
+            icon={stage.icon as 'message' | 'battle' | 'shield' | 'switch'}
+            {...getStageColor(stage.phase as BattlePhase)}
+            active={isActiveStage(stage.step)}
+            small={true}
+            tooltip={stage.description}
+          />
+          {index < STAGES.length - 1 && <DownArrowIcon className="-rotate-90 opacity-40" />}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/battlePage/components/sidebar/BattleInfoSection.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/BattleInfoSection.tsx
@@ -21,11 +21,11 @@ export default function BattleInfoSection({ title, description, language, catego
       <div className="flex gap-4">
         <div className="bg-[#1E1E2F] rounded-lg px-4 py-3 shadow w-1/2 flex flex-col  gap-2 items-start">
           <h3 className="text-gray-400  text-sm">언어</h3>
-          <p className="text-white text-[14px] font-semibold break-words">{language}</p>
+          <p className="text-white text-sm font-semibold break-words">{language}</p>
         </div>
         <div className="bg-[#1E1E2F] rounded-lg px-4 py-3 shadow w-1/2 flex flex-col  gap-2 items-start">
           <h3 className="text-gray-400  text-sm">카테고리</h3>
-          <p className="text-white text-[14px] font-semibold break-words">{category}</p>
+          <p className="text-white text-sm font-semibold break-words">{category}</p>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarHeader.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarHeader.tsx
@@ -15,7 +15,7 @@ export default function SidebarHeader({ activeTab, onTabChange, onClose }: Sideb
         <div className="flex gap-6 flex-1">
           <button
             onClick={() => onTabChange('info')}
-            className={`flex items-center gap-2 px-2 py-2 text-[15px] font-bold transition-colors ${
+            className={`flex items-center gap-2 px-2 py-2 text-base font-bold transition-colors ${
               activeTab === 'info' ? 'text-white' : 'text-gray-400 hover:text-white'
             }`}
           >
@@ -24,7 +24,7 @@ export default function SidebarHeader({ activeTab, onTabChange, onClose }: Sideb
           </button>
           <button
             onClick={() => onTabChange('timeline')}
-            className={`flex items-center gap-2 px-2 py-2 text-[15px] font-bold transition-colors ${
+            className={`flex items-center gap-2 px-2 py-2 text-base font-bold transition-colors ${
               activeTab === 'timeline' ? 'text-white' : 'text-gray-400 hover:text-white'
             }`}
           >
@@ -38,7 +38,7 @@ export default function SidebarHeader({ activeTab, onTabChange, onClose }: Sideb
       </div>
       {/* 활성 탭 밑줄 */}
       <div
-        className={`h-[2px] transition-all duration-300 ${
+        className={`h-0.5 transition-all duration-300 ${
           activeTab === 'info'
             ? 'bg-linear-to-r from-[#FF6900] to-[#FF8533]'
             : 'bg-linear-to-r from-[#AD46FF] to-[#6BA3FF]'

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/MessageCard.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/MessageCard.tsx
@@ -11,28 +11,30 @@ export default function MessageCard({ message, team, type }: MessageCardProps) {
 
   if (!message) {
     return (
-      <div className="p-3 min-h-[72px] flex items-center justify-center">
+      <div className="p-3 min-h-[4.5rem] flex items-center justify-center">
         <div className="text-gray-600 text-xs">{type === 'challenge' ? '이의제기 대기 중' : '반론 대기 중'}</div>
       </div>
     );
   }
 
   return (
-    <div className="p-3 min-h-[72px] animate-message-appear">
+    <div className="p-3 min-h-[4.5rem] animate-message-appear">
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-1">
           <span
-            className={`px-1.5 py-0.5 rounded text-[10px] font-bold ${isTeamA ? 'bg-blue-600 text-white' : 'bg-red-600 text-white'}`}
+            className={`px-1.5 py-0.5 rounded text-[0.625rem] font-bold ${isTeamA ? 'bg-blue-600 text-white' : 'bg-red-600 text-white'}`}
           >
             {isTeamA ? 'A팀' : 'B팀'}
           </span>
-          <span className="text-white font-medium text-[11px] break-all">{message.author?.nickname ?? 'SYSTEM'}</span>
+          <span className="text-white font-medium text-[0.688rem] break-all">
+            {message.author?.nickname ?? 'SYSTEM'}
+          </span>
         </div>
         <div className="flex items-center gap-1">
-          <span className="text-gray-500 text-[10px]">{message.upvotes}명 지지</span>
+          <span className="text-gray-500 text-[0.625rem]">{message.upvotes}명 지지</span>
         </div>
       </div>
-      <p className="text-gray-300 mb-2 leading-relaxed text-[11px] break-words">{message.content}</p>
+      <p className="text-gray-300 mb-2 leading-relaxed text-[0.688rem] break-words">{message.content}</p>
     </div>
   );
 }

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/PhaseDivider.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/PhaseDivider.tsx
@@ -1,8 +1,8 @@
 export default function PhaseDivider() {
   return (
     <div className="relative py-3 bg-gradient-to-r from-orange-950/30 via-orange-900/50 to-orange-950/30">
-      <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 h-[4px] bg-gradient-to-r from-transparent via-orange-500 to-transparent shadow-lg shadow-orange-500/50"></div>
-      <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 h-[8px] bg-gradient-to-r from-transparent via-orange-400/60 to-transparent blur-md"></div>
+      <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 h-1 bg-gradient-to-r from-transparent via-orange-500 to-transparent shadow-lg shadow-orange-500/50"></div>
+      <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 h-2 bg-gradient-to-r from-transparent via-orange-400/60 to-transparent blur-md"></div>
       <div className="relative z-10 flex items-center justify-center gap-2">
         <div className="w-2 h-2 rounded-full bg-orange-500 shadow-lg shadow-orange-500/80 animate-pulse"></div>
         <div className="w-3 h-3 rounded-full bg-orange-400 shadow-lg shadow-orange-400/80"></div>

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/PhaseHeader.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/PhaseHeader.tsx
@@ -11,12 +11,12 @@ export default function PhaseHeader({ phase }: PhaseHeaderProps) {
         <div className="flex items-center justify-center gap-2">
           <div className="flex items-center gap-1">
             <Zap className="w-3 h-3 text-orange-400" />
-            <span className="text-blue-400 font-bold text-[9px] uppercase">A팀 이의제기</span>
+            <span className="text-blue-400 font-bold text-[0.563rem] uppercase">A팀 이의제기</span>
           </div>
           <ArrowRight className="w-3 h-3 text-gray-500" />
           <div className="flex items-center gap-1">
             <Shield className="w-3 h-3 text-blue-400" />
-            <span className="text-red-400 font-bold text-[9px] uppercase">B팀 반론</span>
+            <span className="text-red-400 font-bold text-[0.563rem] uppercase">B팀 반론</span>
           </div>
         </div>
       </div>
@@ -28,12 +28,12 @@ export default function PhaseHeader({ phase }: PhaseHeaderProps) {
       <div className="flex items-center justify-center gap-2">
         <div className="flex items-center gap-1">
           <Zap className="w-3 h-3 text-red-400" />
-          <span className="text-red-400 font-bold text-[9px] uppercase">B팀 이의제기</span>
+          <span className="text-red-400 font-bold text-[0.563rem] uppercase">B팀 이의제기</span>
         </div>
         <ArrowRight className="w-3 h-3 text-gray-500" />
         <div className="flex items-center gap-1">
           <Shield className="w-3 h-3 text-blue-400" />
-          <span className="text-blue-400 font-bold text-[9px] uppercase">A팀 반론</span>
+          <span className="text-blue-400 font-bold text-[0.563rem] uppercase">A팀 반론</span>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/RoundHeader.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/RoundHeader.tsx
@@ -16,7 +16,7 @@ export default function RoundHeader({ round, topic, isActive, isExpanded, onTogg
     >
       <div className="flex items-center gap-2">
         <div
-          className={`px-2 py-1 rounded text-[10px] font-bold ${isActive ? 'bg-orange-500 text-white' : 'bg-gray-700/50 text-gray-400'}`}
+          className={`px-2 py-1 rounded text-[0.625rem] font-bold ${isActive ? 'bg-orange-500 text-white' : 'bg-gray-700/50 text-gray-400'}`}
         >
           Round {round}
         </div>

--- a/frontend/src/pages/battlePage/components/sidebar/index.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/index.tsx
@@ -66,9 +66,9 @@ export default function BattleSidebar({
         <div className="relative h-[calc(100vh-65px)]">
           <button
             onMouseDown={() => setIsResizing(true)}
-            className="peer absolute right-0 top-1/2 -translate-y-1/2 w-[4px] h-[80px] bg-orange-400 hover:bg-orange-500 cursor-ew-resize transition-colors z-10"
+            className="peer absolute right-0 top-1/2 -translate-y-1/2 w-1 h-20 bg-orange-400 hover:bg-orange-500 cursor-ew-resize transition-colors z-10"
           />
-          <div className="absolute inset-y-0 right-0 w-[8px] bg-orange-400/30 opacity-0 peer-hover:opacity-100 transition-opacity pointer-events-none" />
+          <div className="absolute inset-y-0 right-0 w-2 bg-orange-400/30 opacity-0 peer-hover:opacity-100 transition-opacity pointer-events-none" />
         </div>
       </div>
     </aside>

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialModal.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialModal.tsx
@@ -27,16 +27,16 @@ export default function TutorialModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-      <div className="relative w-[420px] rounded-2xl bg-[#1E2432] border border-[#2D3648] shadow-2xl p-8">
+      <div className="relative max-w-md rounded-2xl bg-[#1E2432] border border-[#2D3648] shadow-2xl p-8">
         <div className="flex justify-center mb-6">
-          <div className="w-[60px] h-[60px] rounded-full bg-gradient-to-br from-[#FF6900] to-[#FB2C36] flex items-center justify-center">
+          <div className="w-15 h-15 rounded-full bg-gradient-to-br from-[#FF6900] to-[#FB2C36] flex items-center justify-center">
             <QuestionIcon className="w-10 h-10 text-white" />
           </div>
         </div>
 
-        <h2 className="text-center text-[24px] font-bold text-white mb-4">배틀 페이지 튜토리얼</h2>
+        <h2 className="text-center text-2xl font-bold text-white mb-4">배틀 페이지 튜토리얼</h2>
 
-        <p className="text-center text-[14px] text-[#99A1AF] leading-relaxed mb-6">
+        <p className="text-center text-sm text-[#99A1AF] leading-relaxed mb-6">
           처음이신가요? 배틀 페이지 사용법을 안내해드릴게요!
           <br />
           7단계의 가이드로 쉽게 배워보세요.
@@ -49,28 +49,28 @@ export default function TutorialModal({
             onChange={(e) => onDontShowAgainChange(e.target.checked)}
             className="w-4 h-4 rounded border-[#4A5568] bg-[#0A0A1A] checked:bg-[#FF6900] checked:border-[#FF6900] cursor-pointer"
           />
-          <span className="text-[13px] text-[#99A1AF]">다시 보지 않기</span>
+          <span className="text-xs text-[#99A1AF]">다시 보지 않기</span>
         </label>
 
         <div className="flex gap-3">
           <button
             onClick={handleClose}
-            className="flex-1 h-[48px] rounded-lg bg-[#2D3648] hover:bg-[#3A4255] text-white text-[15px] font-medium transition-colors"
+            className="flex-1 h-12 rounded-lg bg-[#2D3648] hover:bg-[#3A4255] text-white text-base font-medium transition-colors"
           >
             건너뛰기
           </button>
           <button
             onClick={handleStart}
-            className="flex-1 h-[48px] rounded-lg bg-gradient-to-r from-[#FF6900] to-[#FB2C36] hover:from-[#FF7A1A] hover:to-[#FC3D47] text-white text-[15px] font-bold transition-all shadow-lg shadow-orange-500/30"
+            className="flex-1 h-12 rounded-lg bg-gradient-to-r from-[#FF6900] to-[#FB2C36] hover:from-[#FF7A1A] hover:to-[#FC3D47] text-white text-base font-bold transition-all shadow-lg shadow-orange-500/30"
           >
             시작하기
           </button>
         </div>
 
         <div className="flex items-center justify-center gap-1 mt-4">
-          <span className="text-[10px] text-[#6A7282]">💡 우측 상단</span>
-          <span className="text-[10px] text-white">? </span>
-          <span className="text-[10px] text-[#6A7282]">버튼을 클릭하면 언제든지 튜토리얼을 다시 볼 수 있어요.</span>
+          <span className="text-[0.625rem] text-[#6A7282]">💡 우측 상단</span>
+          <span className="text-[0.625rem] text-white">? </span>
+          <span className="text-[0.625rem] text-[#6A7282]">버튼을 클릭하면 언제든지 튜토리얼을 다시 볼 수 있어요.</span>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
@@ -40,7 +40,7 @@ export default function TutorialStepModal({
 
       {/* Mock Vote UI - vote 단계에서만 표시 */}
       {currentStep === 'vote' && (
-        <div data-tutorial="vote" className="absolute right-[155px] top-[205px] z-[99]">
+        <div data-tutorial="vote" className="absolute right-[9.688rem] top-[12.813rem] z-[99]">
           <TutorialVoteExample />
         </div>
       )}
@@ -49,11 +49,11 @@ export default function TutorialStepModal({
         className="absolute pointer-events-auto transition-all duration-300"
         style={
           spotlight && spotlight.top > 400
-            ? { top: '80px', left: '50%', transform: 'translateX(-50%)' }
-            : { bottom: '80px', left: '50%', transform: 'translateX(-50%)' }
+            ? { top: '5rem', left: '50%', transform: 'translateX(-50%)' }
+            : { bottom: '5rem', left: '50%', transform: 'translateX(-50%)' }
         }
       >
-        <div className="relative w-[420px] rounded-2xl bg-[#1E2432] border-2 border-[#FF6900] shadow-2xl p-6">
+        <div className="relative max-w-md rounded-2xl bg-[#1E2432] border-2 border-[#FF6900] shadow-2xl p-6">
           <button
             onClick={onClose}
             className="absolute top-4 right-4 w-8 h-8 flex items-center justify-center text-[#99A1AF] hover:text-white transition-colors"
@@ -62,19 +62,19 @@ export default function TutorialStepModal({
           </button>
 
           <div className="flex justify-center mb-4">
-            <div className="w-[56px] h-[56px] rounded-full bg-gradient-to-br from-[#FF6900] to-[#FB2C36] flex items-center justify-center">
+            <div className="w-14 h-14 rounded-full bg-gradient-to-br from-[#FF6900] to-[#FB2C36] flex items-center justify-center">
               <QuestionIcon className="w-8 h-8 text-white" />
             </div>
           </div>
 
           <div className="text-center mb-2">
-            <h3 className="text-[22px] font-bold text-white mb-1">{title}</h3>
-            <span className="text-[13px] font-medium text-[#FF6900]">
+            <h3 className="text-2xl font-bold text-white mb-1">{title}</h3>
+            <span className="text-xs font-medium text-[#FF6900]">
               {stepNumber} / {TOTAL_STEPS}
             </span>
           </div>
 
-          <p className="text-center text-[14px] text-[#99A1AF] leading-relaxed mb-6 px-2">{description}</p>
+          <p className="text-center text-sm text-[#99A1AF] leading-relaxed mb-6 px-2">{description}</p>
 
           <div className="flex justify-center gap-2 mb-6">
             {Array.from({ length: TOTAL_STEPS }, (_, i) => (
@@ -95,20 +95,20 @@ export default function TutorialStepModal({
             <button
               onClick={onPrev}
               disabled={stepNumber === 1}
-              className="px-4 h-[44px] rounded-lg bg-[#2D3648] hover:bg-[#3A4255] disabled:opacity-50 disabled:cursor-not-allowed text-white text-[14px] font-medium transition-colors flex items-center gap-1"
+              className="px-4 h-11 rounded-lg bg-[#2D3648] hover:bg-[#3A4255] disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors flex items-center gap-1"
             >
               <span>←</span>
               <span>이전</span>
             </button>
             <button
               onClick={onSkip}
-              className="flex-1 h-[44px] rounded-lg bg-[#2D3648] hover:bg-[#3A4255] text-white text-[14px] font-medium transition-colors"
+              className="flex-1 h-11 rounded-lg bg-[#2D3648] hover:bg-[#3A4255] text-white text-sm font-medium transition-colors"
             >
               건너뛰기
             </button>
             <button
               onClick={onNext}
-              className="px-6 h-[44px] rounded-lg bg-gradient-to-r from-[#FF6900] to-[#FB2C36] hover:from-[#FF7A1A] hover:to-[#FC3D47] text-white text-[14px] font-bold transition-all shadow-lg shadow-orange-500/30 flex items-center gap-1"
+              className="px-6 h-11 rounded-lg bg-gradient-to-r from-[#FF6900] to-[#FB2C36] hover:from-[#FF7A1A] hover:to-[#FC3D47] text-white text-sm font-bold transition-all shadow-lg shadow-orange-500/30 flex items-center gap-1"
             >
               <span>{isLastStep ? '완료' : '다음'}</span>
               <span>→</span>

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialVoteExample.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialVoteExample.tsx
@@ -4,14 +4,14 @@ import { MOCK_DISCUSSIONS } from './const/tutorialSteps';
 
 export default function TutorialVoteExample() {
   return (
-    <section className="w-[590px] bg-[#1E1E2F] rounded-lg overflow-hidden">
+    <section className="max-w-xl bg-[#1E1E2F] rounded-lg overflow-hidden">
       <div className="bg-gradient-to-r from-[#59168B] to-[#1C398E] p-4">
         <div className="flex items-center gap-2 mb-2">
-          <ScaleIcon className="w-[20px] h-[20px]" />
-          <h3 className="text-[14px] font-medium text-white">제출된 이의제기 목록</h3>
+          <ScaleIcon className="w-5 h-5" />
+          <h3 className="text-sm font-medium text-white">제출된 이의제기 목록</h3>
         </div>
 
-        <div className="text-[11px] text-white flex items-center gap-1">
+        <div className="text-[0.688rem] text-white flex items-center gap-1">
           <span className="inline-block w-1 h-1 rounded-full bg-white"></span>
           이의제기가 실시간으로 추가되며, 바로 투표 가능합니다!
         </div>
@@ -34,7 +34,7 @@ export default function TutorialVoteExample() {
         </div>
       </div>
 
-      <div className="py-4 bg-gradient-to-r from-[#1C398E] to-[#59168B] border-t border-[#2D2D3F] flex items-center justify-center gap-2 text-[13px]">
+      <div className="py-4 bg-gradient-to-r from-[#1C398E] to-[#59168B] border-t border-[#2D2D3F] flex items-center justify-center gap-2 text-xs">
         <span className="text-[#FFB800]">⚡</span>
         <span className="text-white font-medium">총 {MOCK_DISCUSSIONS.length}개의 이의제기</span>
         <span className="text-[#99A1AF]">/ 투표 가능</span>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -131,7 +131,6 @@ export default function BattlePage() {
         }`}
       >
         <BattleProgressBoard />
-
         <div
           className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'} -mt-2.5`}
         >

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -104,7 +104,7 @@ export default function BattlePage() {
   };
 
   return (
-    <div className="text-white relative min-h-screen">
+    <div className="text-white relative">
       {/* 책갈피 버튼 */}
       <BookmarkButton
         onOpen={handleOpenSidebar}
@@ -131,8 +131,9 @@ export default function BattlePage() {
         }`}
       >
         <BattleProgressBoard />
+
         <div
-          className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'} -mt-[10px]`}
+          className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'} -mt-2.5`}
         >
           <div className="flex items-center justify-between mt-10 mb-8">
             <button
@@ -155,7 +156,7 @@ export default function BattlePage() {
                 codeB={battleInfo.bCode}
               />
             </div>
-            <aside className="flex flex-col gap-4 w-[590px]">
+            <aside className="flex flex-col gap-4 aside-width">
               <DiscussionVote onVote={handleVote} />
               <ChatSection />
             </aside>
@@ -168,7 +169,7 @@ export default function BattlePage() {
             shouldShowInput ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0 pointer-events-none'
           }`}
         >
-          <div className="w-[590px]">
+          <div className="w-full max-w-xl">
             {shouldShowInput && <DiscussionInput key={phase} onSubmit={handleDiscussionSubmit} />}
           </div>
         </div>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -181,7 +181,7 @@ export default function BattlePage() {
 
         {/* DiscussionInput - 화면 중앙 하단에 fixed */}
         <div
-          className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 z-50 px-4 pb-4 transition-all duration-500 ease-out ${
+          className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 z-[9999] px-4 pb-4 transition-all duration-500 ease-out ${
             shouldShowInput ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0 pointer-events-none'
           }`}
         >

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -138,10 +138,9 @@ export default function BattlePage() {
             battleProgress &&
             (battleProgress.phase as string) !== 'PENDING' &&
             battleProgress.expiredAt != null &&
-            battleProgress.startedAt != null
-              ? !progressBoardCollapsed
-                ? 'mt-24'
-                : 'mt-6'
+            battleProgress.startedAt &&
+            !progressBoardCollapsed
+              ? 'mt-24'
               : 'mt-6'
           }`}
         >

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -131,14 +131,10 @@ export default function BattlePage() {
       />
 
       {/* 메인 콘텐츠 */}
-      <div
-        className={`flex flex-col items-center transition-all duration-300 ease-in-out ${
-          isSidebarOpen ? 'ml-sidebar' : 'ml-0'
-        }`}
-      >
+      <div className="flex flex-col items-center">
         <BattleProgressBoard />
         <div
-          className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'} ${
+          className={`transition-all duration-300 main-width-closed ${
             battleProgress &&
             (battleProgress.phase as string) !== 'PENDING' &&
             battleProgress.expiredAt != null &&
@@ -159,7 +155,7 @@ export default function BattlePage() {
           </div>
           <BattleHeader />
         </div>
-        <main className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'}`}>
+        <main className="main-width-closed">
           <div className="flex gap-2 py-4">
             <div className="flex-1 min-w-0">
               <CodeSection

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -155,7 +155,7 @@ export default function BattlePage() {
                 codeB={battleInfo.bCode}
               />
             </div>
-            <aside className="flex flex-col gap-4 aside-width">
+            <aside className="flex flex-col gap-4 w-[590px]">
               <DiscussionVote onVote={handleVote} />
               <ChatSection />
             </aside>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -155,7 +155,9 @@ export default function BattlePage() {
                 codeB={battleInfo.bCode}
               />
             </div>
-            <aside className="flex flex-col gap-4 w-[590px]">
+            <aside
+              className={`flex flex-col gap-4 transition-all duration-300 ${isSidebarOpen ? 'lounge-width-open' : 'lounge-width-closed'}`}
+            >
               <DiscussionVote onVote={handleVote} />
               <ChatSection />
             </aside>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -185,7 +185,7 @@ export default function BattlePage() {
             shouldShowInput ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0 pointer-events-none'
           }`}
         >
-          <div className="w-full max-w-xl">
+          <div className="discussion-input-width">
             {shouldShowInput && <DiscussionInput key={phase} onSubmit={handleDiscussionSubmit} />}
           </div>
         </div>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -6,7 +6,12 @@ import { useTeamVoteResult } from './hooks/useTeamVoteResult';
 import { useTutorial } from './hooks/useTutorial';
 import useModal from '@/commons/hooks/useModal';
 import { soundManager } from '@/commons/utils/soundManager';
-import { useBattleStore, selectBattleProgress, selectSelectedTeam } from './stores/battleStore';
+import {
+  useBattleStore,
+  selectBattleProgress,
+  selectSelectedTeam,
+  selectProgressBoardCollapsed
+} from './stores/battleStore';
 import { isInputDisabled } from './utils/battlePhase';
 
 import BattleHeader from './components/header';
@@ -34,6 +39,8 @@ export default function BattlePage() {
   const sidebarOpenedForTutorial = useRef(false);
   const user = useAuthStore(selectUser);
   const leaveBattle = useBattleStore((s) => s.leaveBattle);
+  const progressBoardCollapsed = useBattleStore(selectProgressBoardCollapsed);
+  const battleProgress = useBattleStore(selectBattleProgress);
 
   useEffect(() => {
     if (!user) {
@@ -91,7 +98,6 @@ export default function BattlePage() {
   const { voteResult, isModalOpen: isVoteResultModalOpen, closeModal: closeVoteResultModal } = useTeamVoteResult();
 
   // Phase와 Team 정보 가져오기
-  const battleProgress = useBattleStore(selectBattleProgress);
   const team = useBattleStore(selectSelectedTeam);
   const phase = battleProgress?.phase;
   const shouldShowInput = !isInputDisabled(team, phase);
@@ -132,7 +138,16 @@ export default function BattlePage() {
       >
         <BattleProgressBoard />
         <div
-          className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'} -mt-2.5`}
+          className={`transition-all duration-300 ${isSidebarOpen ? 'main-width-open' : 'main-width-closed'} ${
+            battleProgress &&
+            (battleProgress.phase as string) !== 'PENDING' &&
+            battleProgress.expiredAt != null &&
+            battleProgress.startedAt != null
+              ? !progressBoardCollapsed
+                ? 'mt-24'
+                : 'mt-6'
+              : 'mt-6'
+          }`}
         >
           <div className="flex items-center justify-between mt-10 mb-8">
             <button

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -34,6 +34,7 @@ interface BattleStore {
   chatInitialized: boolean;
   opponentNotice: BattleChat | null;
   opponentNoticePending: BattleChat | null;
+  progressBoardCollapsed: boolean;
 
   initializeBattle: (config: { userId: string; battleId: string }) => void;
   setSocket: (socket: Socket | null) => void;
@@ -56,6 +57,7 @@ interface BattleStore {
   setOpponentNoticePending: (notice: BattleChat | null) => void;
   commitOpponentNotice: () => void;
   leaveBattle: () => void;
+  setProgressBoardCollapsed: (collapsed: boolean) => void;
 }
 
 export const useBattleStore = create<BattleStore>((set, get) => ({
@@ -75,6 +77,7 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
   chatInitialized: false,
   opponentNotice: null,
   opponentNoticePending: null,
+  progressBoardCollapsed: false,
 
   initializeBattle: (config) => set({ userId: config.userId, battleId: config.battleId, chatInitialized: false }),
   setSocket: (socket) => set({ socket }),
@@ -182,7 +185,8 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
       opponentNotice: null,
       opponentNoticePending: null
     });
-  }
+  },
+  setProgressBoardCollapsed: (collapsed) => set({ progressBoardCollapsed: collapsed })
 }));
 
 export const selectUserId = (state: BattleStore) => state.userId;
@@ -199,3 +203,4 @@ export const selectAllChats = (state: BattleStore) => state.allChats;
 export const selectSelectedTeam = (state: BattleStore) => state.selectedTeam;
 export const selectChatInitialized = (state: BattleStore) => state.chatInitialized;
 export const selectOpponentNotice = (state: BattleStore) => state.opponentNotice;
+export const selectProgressBoardCollapsed = (state: BattleStore) => state.progressBoardCollapsed;

--- a/frontend/src/pages/teamSelectPage/components/CodeViewer.tsx
+++ b/frontend/src/pages/teamSelectPage/components/CodeViewer.tsx
@@ -8,5 +8,13 @@ interface CodeViewerProps {
 }
 
 export default function TeamSelectCodeViewer({ code, language, team }: CodeViewerProps) {
-  return <CodeViewer code={code} language={language} team={team} minHeight="500px" data-testid="code-viewer" />;
+  return (
+    <CodeViewer
+      code={code}
+      language={language}
+      team={team}
+      minHeight="var(--code-compare-min-height)"
+      data-testid="code-viewer"
+    />
+  );
 }

--- a/frontend/src/pages/teamSelectPage/components/TeamCard.tsx
+++ b/frontend/src/pages/teamSelectPage/components/TeamCard.tsx
@@ -40,29 +40,29 @@ export default function TeamCard({ team, label, description, isSelected, onClick
     <button
       onClick={onClick}
       className={`
-        w-[300px] h-[350px]
+        team-card-width team-card-height
         bg-[#1E1E2F]
-        rounded-lg
+        rounded-md xl:rounded-lg
         border-2
         ${getBorderClass()}
         transition-all
         duration-300
         hover:scale-105
         flex flex-col items-center justify-center
-        gap-6
-        p-6
+        team-card-gap
+        team-card-padding
       `}
     >
       {/* 아이콘 */}
-      <div className={`w-24 h-24 rounded-full ${styles.icon} flex items-center justify-center`}>
-        <Icon className="w-12 h-12 text-white" />
+      <div className={`team-card-icon-size rounded-full ${styles.icon} flex items-center justify-center`}>
+        <Icon className="team-card-icon-inner-size text-white" />
       </div>
 
       {/* 라벨 */}
-      <h3 className={`text-2xl font-bold ${styles.title}`}>{label}</h3>
+      <h3 className={`team-card-title-size font-bold ${styles.title}`}>{label}</h3>
 
       {/* 설명 */}
-      <p className="text-[#99A1AF] text-center text-sm">{description}</p>
+      <p className="text-[#99A1AF] text-center team-card-desc-size leading-tight text-[0.7rem]">{description}</p>
     </button>
   );
 }

--- a/frontend/src/pages/teamSelectPage/components/steps/Step1BattleInfo.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/Step1BattleInfo.tsx
@@ -68,23 +68,23 @@ export default function Step1BattleInfo({
   const phaseConfig = currentPhase ? PHASE_CONFIG[currentPhase] : null;
   const PhaseIcon = phaseConfig?.icon;
   return (
-    <div className="flex flex-col items-center gap-8 w-full max-w-6xl mx-auto">
+    <div className="flex flex-col items-center gap-4 w-full max-w-6xl mx-auto px-4">
       {/* 상단 섹션 */}
-      <div className="text-center mb-8">
-        <TrendingUp className="w-16 h-16 text-orange-500 mx-auto mb-4" />
-        <h2 className="text-2xl font-bold text-white mb-2">상황 요약</h2>
-        <p className="text-gray-400">현재 배틀 진행 현황을 확인하세요</p>
+      <div className="text-center mb-4">
+        <TrendingUp className="battle-info-icon-size text-orange-500 mx-auto mb-2" />
+        <h2 className="battle-info-title-size font-bold text-white mb-1">상황 요약</h2>
+        <p className="battle-info-desc-size text-gray-400">현재 배틀 진행 현황을 확인하세요</p>
       </div>
 
       {/* 중앙 컨테이너 - 모든 카드를 감싸는 영역 */}
-      <div className="w-full bg-[#0d0d1a]/50 rounded-2xl p-8 border border-[#1a1a2e]">
+      <div className="w-full bg-[#0d0d1a]/50 rounded-lg border border-[#1a1a2e] battle-info-card-padding">
         {/* 배틀 정보 카드 */}
-        <div className="bg-[#16162a] rounded-xl p-8 border border-[#2d2d3f] mb-6 shadow-lg w-full">
-          <div className="flex items-center gap-3 mb-4">
-            <Swords className="w-6 h-6 text-orange-500" />
-            <h3 className="text-white text-2xl font-bold">{title}</h3>
+        <div className="bg-[#16162a] rounded-lg battle-info-card-padding border border-[#2d2d3f] mb-4 shadow-lg w-full">
+          <div className="flex items-center gap-2 mb-3">
+            <Swords className="battle-info-swords-size text-orange-500" />
+            <h3 className="text-white battle-info-title-size font-bold">{title}</h3>
           </div>
-          <p className="text-gray-400 mb-6 text-left">{description}</p>
+          <p className="text-gray-400 battle-info-desc-size mb-4 text-left">{description}</p>
           <div className="flex flex-wrap gap-3">
             <div className="flex flex-col gap-1">
               <span className="text-xs text-gray-500">카테고리</span>
@@ -102,16 +102,16 @@ export default function Step1BattleInfo({
         </div>
 
         {/* 2열 그리드 카드 */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
           {/* 참여자 카드 */}
-          <div className="bg-gradient-to-br from-orange-900/30 to-orange-800/10 rounded-xl p-8 border border-orange-500/30 shadow-lg hover:shadow-orange-500/20 transition-all duration-300">
-            <div className="flex items-center gap-6 mb-6">
-              <div className="w-16 h-16 bg-orange-500/20 rounded-xl flex items-center justify-center border border-orange-500/40">
-                <Users className="w-8 h-8 text-orange-400" />
+          <div className="bg-gradient-to-br from-orange-900/30 to-orange-800/10 rounded-lg battle-info-card-padding border border-orange-500/30 shadow-lg hover:shadow-orange-500/20 transition-all duration-300">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="battle-info-stat-icon-size bg-orange-500/20 rounded-lg flex items-center justify-center border border-orange-500/40">
+                <Users className="battle-info-users-size text-orange-400" />
               </div>
               <div>
-                <div className="text-orange-300/70 font-medium mb-1">총 참여자</div>
-                <div className="text-4xl font-bold text-white">{totalParticipants}명</div>
+                <div className="text-orange-300/70 font-medium text-xs mb-1">총 참여자</div>
+                <div className="battle-info-stat-value-size font-bold text-white">{totalParticipants}명</div>
               </div>
             </div>
             <div className="flex items-center gap-2 text-orange-400 text-sm">
@@ -121,14 +121,14 @@ export default function Step1BattleInfo({
           </div>
 
           {/* 라운드 카드 */}
-          <div className="bg-gradient-to-br from-blue-900/30 to-blue-800/10 rounded-xl p-8 border border-blue-500/30 shadow-lg hover:shadow-blue-500/20 transition-all duration-300">
-            <div className="flex items-center gap-4 mb-4">
-              <div className="w-14 h-14 rounded-full bg-blue-600 flex items-center justify-center shadow-lg">
-                <Target className="w-7 h-7 text-white" />
+          <div className="bg-gradient-to-br from-blue-900/30 to-blue-800/10 rounded-lg battle-info-card-padding border border-blue-500/30 shadow-lg hover:shadow-blue-500/20 transition-all duration-300">
+            <div className="flex items-center gap-3 mb-3">
+              <div className="w-11 h-11 rounded-full bg-blue-600 flex items-center justify-center shadow-lg">
+                <Target className="battle-info-target-size text-white" />
               </div>
               <div className="flex-1">
-                <p className="text-gray-400 text-sm mb-1 text-left">진행 단계</p>
-                <p className="text-white text-3xl font-bold mb-2 text-left">
+                <p className="text-gray-400 text-xs mb-1 text-left">진행 단계</p>
+                <p className="text-white battle-info-stat-value-size font-bold mb-1.5 text-left">
                   라운드 {currentPhase === 'PENDING' ? 0 : currentRound} / {totalRounds}
                 </p>
                 <div className="flex items-center gap-3 flex-wrap">

--- a/frontend/src/pages/teamSelectPage/components/steps/Step2CodeCompare.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/Step2CodeCompare.tsx
@@ -9,17 +9,15 @@ interface Step2CodeCompareProps {
 
 export default function Step2CodeCompare({ aCode, bCode, language }: Step2CodeCompareProps) {
   return (
-    <div className="flex flex-col items-center gap-8 w-full max-w-6xl mx-auto">
-      {/* 상단 섹션 */}
-      <div className="text-center mb-8">
-        <Code2 className="w-16 h-16 text-orange-500 mx-auto mb-4" />
-        <h2 className="text-2xl font-bold text-white mb-2">쟁점</h2>
-        <p className="text-gray-400">두 구현의 코드를 비교하고 분석하세요</p>
+    <div className="flex flex-col items-center gap-4 w-full max-w-6xl mx-auto px-4">
+      <div className="text-center mb-4">
+        <Code2 className="code-compare-icon-size text-orange-500 mx-auto mb-2" />
+        <h2 className="code-compare-title-size font-bold text-white mb-1">쟁점</h2>
+        <p className="code-compare-desc-size text-gray-400">두 구현의 코드를 비교하고 분석하세요</p>
       </div>
 
-      {/* 중앙 컨테이너 */}
-      <div className="w-full bg-[#0d0d1a]/50 rounded-2xl p-8 border border-[#1a1a2e]">
-        <CodeCarousel aCode={aCode} bCode={bCode} language={language} />
+      <div className="w-full bg-[#0d0d1a]/50 rounded-lg border border-[#1a1a2e] code-compare-container-padding">
+        <CodeCarousel aCode={aCode} bCode={bCode} min-Height="var(--code-compare-min-height)" language={language} />
       </div>
     </div>
   );

--- a/frontend/src/pages/teamSelectPage/components/steps/Step4TeamSelect.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/Step4TeamSelect.tsx
@@ -9,17 +9,17 @@ interface Step4TeamSelectProps {
 
 export default function Step4TeamSelect({ onSelect, selectedTeam }: Step4TeamSelectProps) {
   return (
-    <div className="flex flex-col items-center gap-8 w-full max-w-6xl mx-auto">
+    <div className="flex flex-col items-center gap-4 xl:gap-6 2xl:gap-8 w-full max-w-6xl mx-auto px-4">
       {/* 상단 섹션 */}
-      <div className="text-center mb-8">
-        <Flag className="w-16 h-16 text-orange-500 mx-auto mb-4" />
-        <h2 className="text-2xl font-bold text-white mb-2">진영 선택</h2>
-        <p className="text-gray-400">A팀, B팀 또는 중립 진영을 선택하세요</p>
+      <div className="text-center mb-4 xl:mb-6 2xl:mb-8">
+        <Flag className="w-10 h-10 xl:w-12 xl:h-12 2xl:w-16 2xl:h-16 text-orange-500 mx-auto mb-2 xl:mb-3 2xl:mb-4" />
+        <h2 className="text-xl xl:text-2xl 2xl:text-3xl font-bold text-white mb-1 xl:mb-2">진영 선택</h2>
+        <p className="text-sm xl:text-base text-gray-400">A팀, B팀 또는 중립 진영을 선택하세요</p>
       </div>
 
       {/* 중앙 컨테이너 */}
-      <div className="w-full bg-[#0d0d1a]/50 rounded-2xl p-8 border border-[#1a1a2e]">
-        <div className="flex items-center justify-center gap-6 flex-wrap">
+      <div className="w-full bg-[#0d0d1a]/50 rounded-lg xl:rounded-xl 2xl:rounded-2xl p-4 xl:p-6 2xl:p-8 border border-[#1a1a2e]">
+        <div className="flex items-center justify-center gap-3 xl:gap-4 2xl:gap-6 flex-wrap">
           <TeamCard
             team="A"
             label="A팀"


### PR DESCRIPTION
## 🔗 관련 이슈
closes #186

## ✅ 작업 내용

### 💡개선 사항
**배틀 페이지 반응형 레이아웃 적용**

1. **코드 뷰어 / 채팅 라운지 반응형 적용**
   - 3단계 브레이크포인트 적용 (기본 < 1600px < 1920px)
   - 사이드바 열림/닫힘 상태에 따른 동적 크기 조정

2. **DiscussionInput 및 BattleTimer 반응형 적용**
   - 토론 입력창 너비 반응형 처리
   - 타이머 컴포넌트 크기 자동 조정

3. **ProgressBoard 레이아웃 시프트 수정**
   - 기존에 jsx style에 있던 애니메이션 로직을 index.css로 이동 시켰습니다. 

4. **사이드바 토글 레이아웃 시프트 방지**
   - 사이드바 열림/닫힘 시 레이아웃 깜빡임 현상 제거

5. **이의제기 Input LayoutShift 수정**
   - 입력창 렌더링 시 레이아웃 안정성 개선

<br/>

**진영 선택 페이지 반응형 디자인 적용**

1. **팀 선택 카드**
   - 3단계 브레이크포인트 적용 (기본 255×215px → 1600px: 290×290px → 1920px: 330×350px)
   - 아이콘, 텍스트, 패딩 등 모든 요소 반응형 처리

2. **배틀 정보 카드**
   - 상단 아이콘, 제목, 설명 텍스트 반응형 적용
   - 참여자 카드 및 라운드 카드 크기 자동 조정
   - 내부 아이콘(Swords, Users, Target) 크기 세분화

3. **코드 비교 페이지 (Step2CodeCompare, CodeViewer)**
   - 3단계 브레이크포인트 적용 (300px → 400px → 500px)
   - 컨테이너 패딩 및 아이콘 크기 반응형 처리

<br />


## 구현 사진 
### 진영 선택 페이지(1280px)
<img width="1278" height="779" alt="image" src="https://github.com/user-attachments/assets/f997e499-b036-4c5b-99d0-83ae35e92b2c" />
<img width="1266" height="775" alt="image" src="https://github.com/user-attachments/assets/5e7839a9-f9cd-4bfc-9370-2844af309ffb" />
<img width="1279" height="765" alt="image" src="https://github.com/user-attachments/assets/b62a854a-e005-4bb0-8921-e6d2619dc95a" />

<br/>

### 배틀 페이지(1280px)
<img width="1287" height="774" alt="image" src="https://github.com/user-attachments/assets/7ee8083b-545f-41e6-a4a6-8bb89278c9e5" />
 
<img width="1280" height="771" alt="image" src="https://github.com/user-attachments/assets/35dfcc2f-0783-4f0e-bc36-29fa371550b8" />

<img width="1275" height="766" alt="image" src="https://github.com/user-attachments/assets/2b4d2f4a-10d3-43f9-9326-c9ceaefd00bd" />

<br/>

## 📸 참고 사항
- 작은 뷰포트 화면의 기준 디자인을 피그마로 미리 설계 한 게 아니였던지라, 임의 크기로 배정을 한지라 조금 이상한 부분이 있을 것 같네요 
- 타임라인 사이드바를 열었을 때, 이의제기 input을 사이드바에 가려야할지 올려야할지 애매하네요.

### 구현 방식
- 총 3단계의 브레이크 포인트에 맞춰서 반응형 디자인을 구현했습니다. (1280px / 1600px / 1920px).
- 상당수 많은 부분이 px 단위를 사용하여 크기가 고정 되어 있었는데, rem 단위 사용함으로써 브레이크 포인트에 따른 화면 크기마다 유연하게 텍스트 / 마진 / 컨테이너 크기들이 조정 될 수 있도록 수정했습니다.
 


 