### PR TITLE
[Feature] 자신의 친 채팅 메세지는 채팅방에서 오른쪽에 정렬되어 표기된다.

### DIFF
--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -6,7 +6,7 @@ export interface BattleChat {
   sender: { userId: string; nickname: string };
   team: Team;
   text: string;
-  createdAt: Date;
+  createdAt: Date | string;
   type?: 'chat' | 'attack' | 'defense';
   votes?: number;
 }

--- a/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
@@ -1,4 +1,5 @@
 import { getTimeAgo } from '@/commons/utils/getTimeAgo';
+import { useAuthStore, selectUser } from '../../stores/authStore';
 
 interface ChatMessageProps {
   user: string;
@@ -7,7 +8,6 @@ interface ChatMessageProps {
   timestamp: string;
   showTeamBadge?: boolean;
   type?: 'normal' | 'objection' | 'rebuttal';
-  currentUserId?: string;
 }
 
 const TEAM_NICKNAME_COLORS = {
@@ -28,25 +28,23 @@ const TEAM_LABELS = {
   NONE: '중립'
 };
 
-export default function ChatMessage({
-  user,
-  team,
-  content,
-  timestamp,
-  showTeamBadge = false,
-  currentUserId
-}: ChatMessageProps) {
+export default function ChatMessage({ user, team, content, timestamp, showTeamBadge = false }: ChatMessageProps) {
+  const currentUser = useAuthStore(selectUser);
   const nickNameColor = TEAM_NICKNAME_COLORS[team];
-  const isYou = user === currentUserId;
+  const isYou = currentUser?.nickname === user;
 
   return (
     <div className={`flex ${isYou ? 'flex-col items-end' : 'flex-col items-start'} mb-3`}>
       <div className="flex items-center gap-2 mb-1">
-        <span className={`text-[13px] font-medium ${nickNameColor}`}>{user}</span>
-        {showTeamBadge && (
-          <span className={`px-1.5 py-0.5 ${TEAM_BADGE_COLORS[team]} rounded text-[10px] font-medium text-white`}>
-            {TEAM_LABELS[team]}
-          </span>
+        {!isYou && (
+          <>
+            <span className={`text-[13px] font-medium ${nickNameColor}`}>{user}</span>
+            {showTeamBadge && (
+              <span className={`px-1.5 py-0.5 ${TEAM_BADGE_COLORS[team]} rounded text-[10px] font-medium text-white`}>
+                {TEAM_LABELS[team]}
+              </span>
+            )}
+          </>
         )}
         <span className="text-[11px] text-[#666]">{getTimeAgo(timestamp)}</span>
       </div>

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -12,20 +12,22 @@ import { useAutoScrollDown } from '@/commons/hooks/useAutoScroll';
 import { useUnreadMessages } from '../../hooks/useUnreadMessages';
 
 export default function ChatSection() {
+  // Store 상태
   const team = useBattleStore(selectSelectedTeam);
   const { teamACount, teamBCount } = useBattleStore(selectTeamCounts);
   const chatInitialized = useBattleStore(selectChatInitialized);
 
+  // 로컬 상태
   const [activeTab, setActiveTab] = useState<'team' | 'all'>('team');
-
-  const { teamMessages, allMessages, opponentNotice, sendMessage } = useBattleChat();
-
   const currentTab = team === 'NONE' ? 'all' : activeTab;
 
+  // 채팅 데이터
+  const { teamMessages, allMessages, opponentNotice, sendMessage } = useBattleChat();
   const currentMessages = useMemo(() => {
     return currentTab === 'team' ? teamMessages : allMessages;
   }, [currentTab, teamMessages, allMessages]);
 
+  // 읽지 않은 메시지
   const { unreadTeamCount, unreadAllCount } = useUnreadMessages({
     teamMessages,
     allMessages,
@@ -33,15 +35,11 @@ export default function ChatSection() {
     chatInitialized
   });
 
+  // UI 상태
   const chatContainerRef = useAutoScrollDown([currentMessages]);
+  const currentMemberCount = currentTab === 'all' ? teamACount + teamBCount : team === 'A' ? teamACount : teamBCount;
 
-  const currentMemberCount = useMemo(() => {
-    if (currentTab === 'all') {
-      return teamACount + teamBCount;
-    }
-    return team === 'A' ? teamACount : teamBCount;
-  }, [currentTab, team, teamACount, teamBCount]);
-
+  // 이벤트 핸들러
   const handleSendMessage = (content: string) => {
     const scope = currentTab === 'team' ? 'TEAM' : 'ALL';
     sendMessage(content, scope);

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -5,10 +5,11 @@ import ChatTabs from './ChatTabs';
 import PeoplesIcons from '@/assets/icon/peoples.svg?react';
 import MessageIcon from '@/assets/icon/message.svg?react';
 
-import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import { useState, useMemo } from 'react';
 import { useBattleStore, selectSelectedTeam, selectTeamCounts, selectChatInitialized } from '../../stores/battleStore';
 import { useBattleChat } from '../../hooks/useBattleChat';
 import { useAutoScrollDown } from '@/commons/hooks/useAutoScroll';
+import { useUnreadMessages } from '../../hooks/useUnreadMessages';
 
 export default function ChatSection() {
   const team = useBattleStore(selectSelectedTeam);
@@ -25,40 +26,12 @@ export default function ChatSection() {
     return currentTab === 'team' ? teamMessages : allMessages;
   }, [currentTab, teamMessages, allMessages]);
 
-  const initializedRef = useRef(false);
-  const [lastReadIds, setLastReadIds] = useState({ team: '', all: '' });
-
-  useEffect(() => {
-    if (initializedRef.current || !chatInitialized) return;
-    setLastReadIds({
-      team: teamMessages[teamMessages.length - 1]?.id ?? '',
-      all: allMessages[allMessages.length - 1]?.id ?? ''
-    });
-    initializedRef.current = true;
-  }, [teamMessages, allMessages, chatInitialized]);
-
-  useEffect(() => {
-    const lastId = currentMessages[currentMessages.length - 1]?.id ?? '';
-    if (!lastId) return;
-    setLastReadIds((prev) => (prev[currentTab] === lastId ? prev : { ...prev, [currentTab]: lastId }));
-  }, [currentMessages, currentTab]);
-
-  const getUnreadCount = useCallback((messages: typeof teamMessages, lastReadId: string) => {
-    if (messages.length === 0) return 0;
-    const lastReadIndex = lastReadId ? messages.findIndex((message) => message.id === lastReadId) : -1;
-    return messages.slice(lastReadIndex + 1).length;
-  }, []);
-
-  const unreadTeamCount = useMemo(
-    () => getUnreadCount(teamMessages, lastReadIds.team),
-    [teamMessages, lastReadIds.team, getUnreadCount]
-  );
-  const unreadAllCount = useMemo(
-    () => getUnreadCount(allMessages, lastReadIds.all),
-    [allMessages, lastReadIds.all, getUnreadCount]
-  );
-  const unreadTeamDisplay = currentTab === 'team' ? 0 : unreadTeamCount;
-  const unreadAllDisplay = currentTab === 'all' ? 0 : unreadAllCount;
+  const { unreadTeamCount, unreadAllCount } = useUnreadMessages({
+    teamMessages,
+    allMessages,
+    currentTab,
+    chatInitialized
+  });
 
   const chatContainerRef = useAutoScrollDown([currentMessages]);
 
@@ -92,8 +65,8 @@ export default function ChatSection() {
           activeTab={currentTab}
           onTabChange={setActiveTab}
           team={team}
-          unreadTeamCount={unreadTeamDisplay}
-          unreadAllCount={unreadAllDisplay}
+          unreadTeamCount={unreadTeamCount}
+          unreadAllCount={unreadAllCount}
         />
       </div>
 

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -5,14 +5,12 @@ import ChatTabs from './ChatTabs';
 import PeoplesIcons from '@/assets/icon/peoples.svg?react';
 import MessageIcon from '@/assets/icon/message.svg?react';
 
-import { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { useBattleStore, selectSelectedTeam, selectTeamCounts, selectChatInitialized } from '../../stores/battleStore';
 import { useBattleChat } from '../../hooks/useBattleChat';
 import { useAutoScrollDown } from '@/commons/hooks/useAutoScroll';
-import { selectUser, useAuthStore } from '../../stores/authStore';
 
 export default function ChatSection() {
-  const user = useAuthStore(selectUser);
   const team = useBattleStore(selectSelectedTeam);
   const { teamACount, teamBCount } = useBattleStore(selectTeamCounts);
   const chatInitialized = useBattleStore(selectChatInitialized);
@@ -45,17 +43,20 @@ export default function ChatSection() {
     setLastReadIds((prev) => (prev[currentTab] === lastId ? prev : { ...prev, [currentTab]: lastId }));
   }, [currentMessages, currentTab]);
 
-  const getUnreadCount = (messages: typeof teamMessages, lastReadId: string) => {
+  const getUnreadCount = useCallback((messages: typeof teamMessages, lastReadId: string) => {
     if (messages.length === 0) return 0;
     const lastReadIndex = lastReadId ? messages.findIndex((message) => message.id === lastReadId) : -1;
     return messages.slice(lastReadIndex + 1).length;
-  };
+  }, []);
 
   const unreadTeamCount = useMemo(
     () => getUnreadCount(teamMessages, lastReadIds.team),
-    [teamMessages, lastReadIds.team]
+    [teamMessages, lastReadIds.team, getUnreadCount]
   );
-  const unreadAllCount = useMemo(() => getUnreadCount(allMessages, lastReadIds.all), [allMessages, lastReadIds.all]);
+  const unreadAllCount = useMemo(
+    () => getUnreadCount(allMessages, lastReadIds.all),
+    [allMessages, lastReadIds.all, getUnreadCount]
+  );
   const unreadTeamDisplay = currentTab === 'team' ? 0 : unreadTeamCount;
   const unreadAllDisplay = currentTab === 'all' ? 0 : unreadAllCount;
 
@@ -127,7 +128,6 @@ export default function ChatSection() {
               content={message.content}
               timestamp={message.timestamp}
               showTeamBadge={currentTab === 'all'}
-              currentUserId={user?.id}
             />
           )
         )}

--- a/frontend/src/pages/battlePage/hooks/useBattleChat.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleChat.ts
@@ -26,7 +26,7 @@ export function useBattleChat() {
     if (!user) return [];
     const myTeamChats = teamChats
       .filter((chat) => chat.team === team && chat.scope === 'TEAM' && (!chat.type || chat.type === 'chat'))
-      .map((chat) => convertBattleChatToMessage(chat, user.id));
+      .map((chat) => convertBattleChatToMessage(chat));
 
     return myTeamChats.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
   }, [teamChats, team, user]);
@@ -37,14 +37,14 @@ export function useBattleChat() {
     const filtered = allChats.filter(
       (chat) => !(team !== 'NONE' && chat.team !== team && (chat.type === 'attack' || chat.type === 'defense'))
     );
-    return filtered.map((chat) => convertBattleChatToMessage(chat, user.id));
+    return filtered.map((chat) => convertBattleChatToMessage(chat));
   }, [allChats, team, user]);
 
   const opponentNotice = useMemo(() => {
     if (!user) return null;
 
     if (team === 'NONE' || !opponentNoticeChat) return null;
-    return convertBattleChatToMessage(opponentNoticeChat, user.id);
+    return convertBattleChatToMessage(opponentNoticeChat);
   }, [opponentNoticeChat, team, user]);
   // 실시간 채팅 업데이트 이벤트 구독
 
@@ -78,7 +78,7 @@ export function useBattleChat() {
         team,
         scope,
         text: content.trim(),
-        createdAt: new Date().toISOString() as any
+        createdAt: new Date().toISOString()
       };
       addChat(optimisticMessage);
       socket.emit('battle:chat', chatMessage);

--- a/frontend/src/pages/battlePage/hooks/useUnreadMessages.ts
+++ b/frontend/src/pages/battlePage/hooks/useUnreadMessages.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import type { Message } from '../utils/convertChatMessage';
+
+interface UseUnreadMessagesProps {
+  teamMessages: Message[];
+  allMessages: Message[];
+  currentTab: 'team' | 'all';
+  chatInitialized: boolean;
+}
+
+export function useUnreadMessages({ teamMessages, allMessages, currentTab, chatInitialized }: UseUnreadMessagesProps) {
+  const initializedRef = useRef(false);
+  const [lastReadIds, setLastReadIds] = useState({ team: '', all: '' });
+
+  const currentMessages = currentTab === 'team' ? teamMessages : allMessages;
+
+  // 채팅 초기화 시 마지막 메시지를 읽음으로 표시
+  useEffect(() => {
+    if (initializedRef.current || !chatInitialized) return;
+    setLastReadIds({
+      team: teamMessages[teamMessages.length - 1]?.id ?? '',
+      all: allMessages[allMessages.length - 1]?.id ?? ''
+    });
+    initializedRef.current = true;
+  }, [teamMessages, allMessages, chatInitialized]);
+
+  // 현재 탭의 메시지를 읽음으로 표시
+  useEffect(() => {
+    const lastId = currentMessages[currentMessages.length - 1]?.id ?? '';
+    if (!lastId) return;
+    setLastReadIds((prev) => (prev[currentTab] === lastId ? prev : { ...prev, [currentTab]: lastId }));
+  }, [currentMessages, currentTab]);
+
+  const getUnreadCount = useCallback((messages: Message[], lastReadId: string) => {
+    if (messages.length === 0) return 0;
+    const lastReadIndex = lastReadId ? messages.findIndex((message) => message.id === lastReadId) : -1;
+    return messages.slice(lastReadIndex + 1).length;
+  }, []);
+
+  const unreadTeamCount = useMemo(
+    () => getUnreadCount(teamMessages, lastReadIds.team),
+    [teamMessages, lastReadIds.team, getUnreadCount]
+  );
+
+  const unreadAllCount = useMemo(
+    () => getUnreadCount(allMessages, lastReadIds.all),
+    [allMessages, lastReadIds.all, getUnreadCount]
+  );
+
+  // 현재 탭의 읽지 않은 메시지는 0으로 표시
+  const unreadTeamDisplay = currentTab === 'team' ? 0 : unreadTeamCount;
+  const unreadAllDisplay = currentTab === 'all' ? 0 : unreadAllCount;
+
+  return {
+    unreadTeamCount: unreadTeamDisplay,
+    unreadAllCount: unreadAllDisplay
+  };
+}

--- a/frontend/src/pages/battlePage/utils/convertChatMessage.ts
+++ b/frontend/src/pages/battlePage/utils/convertChatMessage.ts
@@ -10,9 +10,9 @@ export interface Message {
   votes?: number;
 }
 
-export const convertBattleChatToMessage = (chat: BattleChat, userId: string): Message => ({
+export const convertBattleChatToMessage = (chat: BattleChat): Message => ({
   id: chat.messageId,
-  user: chat.sender.userId === userId ? 'You' : chat.sender.nickname,
+  user: chat.sender.nickname,
   team: chat.team,
   content: chat.text,
   timestamp: new Date(chat.createdAt).toISOString().replace('T', ' ').substring(0, 19),

--- a/frontend/src/pages/battlePage/utils/test/convertChatMessage.test.ts
+++ b/frontend/src/pages/battlePage/utils/test/convertChatMessage.test.ts
@@ -13,13 +13,12 @@ describe('메시지 변환', () => {
     createdAt: new Date('2026-01-04T10:30:00Z')
   };
 
-  it('자신의 메시지는 "You"로 표시', () => {
-    const result = convertBattleChatToMessage(mockChat, 'user-abc');
-    expect(result.user).toBe('You');
-  });
-
-  it('다른 사용자 메시지는 ID 그대로 표시', () => {
-    const result = convertBattleChatToMessage(mockChat, 'different-user');
+  it('BattleChat을 Message로 변환이 잘되는지', () => {
+    const result = convertBattleChatToMessage(mockChat);
+    expect(result.id).toBe('msg-123');
     expect(result.user).toBe('testNick');
+    expect(result.team).toBe('A');
+    expect(result.content).toBe('Hello World');
+    expect(result.type).toBe('chat');
   });
 });


### PR DESCRIPTION
## 🔗 관련 이슈
Close #196

## ✅ 작업 내용

### 💡개선 사항

#### 1. 본인 채팅 메시지 UI 개선
- **오른쪽 정렬**: 본인이 작성한 메시지는 오른쪽에 배치
- **차별화된 배경색**: 본인 메시지는 `#6B3410` 색상 적용 하도록 했습니다.
- **불필요한 정보 제거**: 본인 메시지에서 닉네임과 팀 배지 숨겼습니다. (불필요하니깐요..)
- **판별 로직 개선**: 기존에 채팅 메세지는 낙관적 업데이트로 battleStore에 추가할 때 메세지 작성자를 'You' 라는 문자열을 넣었고 해당 단어를 통해서 자신의 메세지인지 판별했습니다. 지금 개선한 방법으로는 `you`로 변환할 필요없이 그대로 작성자의 닉네임을 그대로 battleStore에 저장 한 후 `ChatMessage` 컴포넌트에서 `authStore.nickname`과 직접 비교 하는 방식으로 판별하도록 진행했습니다. 


#### 2. 코드 구조 개선
- **관심사 분리**: 읽지 않은 메시지 카운팅 로직을 `useUnreadMessages` 커스텀 훅으로 분리 했습니다. chatSection 파일이 워낙 코드가 많다보니 UI에 집중시키기 위해 비즈니스 로직들은 다른 파일로 분리가 필요하다고 생각했습니다. 
- **불필요한 최적화 제거**: `currentMemberCount`의 불필요한 `useMemo` 제거 했습니다. 큰 연산이 아니다보니 useMemo를 사용하는 비용 오버헤드가 더 큰 것 같더라구요 

<br />

## 구현 이미지
### 내 채팅 내용

<img width="467" height="526" alt="image" src="https://github.com/user-attachments/assets/835f5f2e-6091-41b9-907a-c1264e668f29" />


## 💬 질문사항 (고민했던 부분)

1. **시간 표시 위치**
   - 현재는 본인 메시지도 상단에 시간 표시 했는데 카카오톡처럼 메시지 하단에 표시하는 게 나을까요?

