### PR TITLE
[Refactor] MVP 선정 로직 개선

### DIFF
--- a/backend/src/battles/const/battles.const.ts
+++ b/backend/src/battles/const/battles.const.ts
@@ -67,3 +67,5 @@ export const BATTLE_CHAT_SCOPE = {
   ALL: 'ALL',
   TEAM: 'TEAM',
 } as const
+
+export const MVP_DISPLAY_COUNT = 3

--- a/backend/src/battles/dto/battleResult.dto.ts
+++ b/backend/src/battles/dto/battleResult.dto.ts
@@ -21,9 +21,9 @@ export class BattleResultResponseDto {
   metrics: Metrics
   voteTimeline: VoteTimeline[]
   timeline: TimelineItem[]
-  mvp: Mvp
+  mvps: Mvp[]
 
-  static fromEntity(battle: FinishedBattleState, calculatedMvp: Mvp | null): BattleResultResponseDto {
+  static fromEntity(battle: FinishedBattleState): BattleResultResponseDto {
     const dto = new BattleResultResponseDto()
     dto.battleId = battle.battleId
     dto.authorId = battle.authorId
@@ -42,7 +42,7 @@ export class BattleResultResponseDto {
     dto.metrics = battle.metrics
     dto.voteTimeline = battle.voteTimeline
     dto.timeline = battle.timeline
-    dto.mvp = calculatedMvp || battle.mvp
+    dto.mvps = battle.mvps
     return dto
   }
 }

--- a/backend/src/battles/service/battles.service.spec.ts
+++ b/backend/src/battles/service/battles.service.spec.ts
@@ -85,7 +85,11 @@ const createFinishedBattleState = (overrides: Partial<FinishedBattleState> = {})
     userId: 'user-1',
     nickname: 'CodeMaster',
     team: 'A',
+    score: 2.5,
     totalVotes: 25,
+    opinionCount: 2,
+    selectedOpinionCount: 1,
+    joinedAt: 1000,
   },
   ...overrides,
 })
@@ -885,6 +889,370 @@ describe('BattlesService', () => {
           team: BATTLE_TEAM.A,
         }),
       ).toThrow(NotFoundException)
+    })
+  })
+
+  describe('calculateMVP (새로운 로직)', () => {
+    beforeEach(() => {
+      const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
+      service.setBattlesForTest([battle])
+      service['initBattleState']('battle-1')
+
+      const state = service['activeBattles'].get('battle-1')!
+
+      // 참가자 등록 (joinedAt 시간 순서대로)
+      service.registerGuest('battle-1', { id: 'user-1', nickname: 'User1', createdAt: 1000 })
+      service.registerGuest('battle-1', { id: 'user-2', nickname: 'User2', createdAt: 2000 })
+      service.registerGuest('battle-1', { id: 'user-3', nickname: 'User3', createdAt: 3000 })
+
+      state.participants.set('user-1', BATTLE_TEAM.A)
+      state.participants.set('user-2', BATTLE_TEAM.B)
+      state.participants.set('user-3', BATTLE_TEAM.A)
+
+      service['rebuildTeamUsers'](state)
+    })
+
+    it('모든 의견의 투표를 누적하여 MVP를 계산한다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // user-1: 2개 의견, 총 5표
+      state.teamA.attacks.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-1', nickname: 'User1' },
+        type: 'ATTACK',
+        content: 'attack 1',
+        upvotes: 3,
+        votes: ['voter-1', 'voter-2', 'voter-3'],
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        selectedAt: Date.now(),
+      })
+      state.teamA.attacks.push({
+        discussionId: 'attack-2',
+        author: { authorId: 'user-1', nickname: 'User1' },
+        type: 'ATTACK',
+        content: 'attack 2',
+        upvotes: 2,
+        votes: ['voter-4', 'voter-5'],
+        status: 'PENDING',
+        team: BATTLE_TEAM.A,
+      })
+
+      // user-2: 1개 의견, 총 4표
+      state.teamB.attacks.push({
+        discussionId: 'attack-3',
+        author: { authorId: 'user-2', nickname: 'User2' },
+        type: 'ATTACK',
+        content: 'attack 3',
+        upvotes: 4,
+        votes: ['voter-1', 'voter-2', 'voter-3', 'voter-4'],
+        status: 'SELECTED',
+        team: BATTLE_TEAM.B,
+        selectedAt: Date.now(),
+      })
+
+      // 팀별 투표 참가자 수 설정 (A팀: 5명, B팀: 4명)
+      const mvp = service['calculateMVP'](state, 'A')
+
+      // user-1: score = 3/5 + 2/5 = 1.0, totalVotes = 5
+      // user-2: score = 4/4 = 1.0, totalVotes = 4
+      // 점수 동점 → 좋아요 수 비교 → user-1이 5표로 MVP
+      expect(mvp).not.toBeNull()
+      expect(mvp!.userId).toBe('user-1')
+      expect(mvp!.totalVotes).toBe(5)
+    })
+
+    it('중립 팀 사용자는 MVP 후보에서 제외된다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // 중립 팀 사용자 추가
+      service.registerGuest('battle-1', { id: 'user-none', nickname: 'NeutralUser', createdAt: 500 })
+      state.participants.set('user-none', BATTLE_TEAM.NONE)
+
+      // 중립 팀 사용자가 가장 많은 표를 받았다고 가정 (실제로는 의견 제출 불가하지만 테스트용)
+      state.teamA.attacks.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-none', nickname: 'NeutralUser' },
+        type: 'ATTACK',
+        content: 'neutral attack',
+        upvotes: 100,
+        votes: [],
+        status: 'SELECTED',
+        team: BATTLE_TEAM.NONE,
+        selectedAt: Date.now(),
+      })
+
+      state.teamA.attacks.push({
+        discussionId: 'attack-2',
+        author: { authorId: 'user-1', nickname: 'User1' },
+        type: 'ATTACK',
+        content: 'attack',
+        upvotes: 1,
+        votes: ['voter-1'],
+        status: 'PENDING',
+        team: BATTLE_TEAM.A,
+      })
+
+      const mvp = service['calculateMVP'](state, 'A')
+
+      // 중립 팀 제외, user-1이 MVP
+      expect(mvp).not.toBeNull()
+      expect(mvp!.userId).toBe('user-1')
+    })
+
+    it('동점일 때 승리 팀 소속이 우선이다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // 동일한 점수, 좋아요, 의견 수
+      state.teamA.attacks.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-1', nickname: 'User1' },
+        type: 'ATTACK',
+        content: 'attack',
+        upvotes: 2,
+        votes: ['v1', 'v2'],
+        status: 'PENDING',
+        team: BATTLE_TEAM.A,
+      })
+
+      state.teamB.attacks.push({
+        discussionId: 'attack-2',
+        author: { authorId: 'user-2', nickname: 'User2' },
+        type: 'ATTACK',
+        content: 'attack',
+        upvotes: 2,
+        votes: ['v3', 'v4'],
+        status: 'PENDING',
+        team: BATTLE_TEAM.B,
+      })
+
+      // A팀이 승리한 경우
+      const mvp = service['calculateMVP'](state, 'A')
+      expect(mvp!.userId).toBe('user-1')
+      expect(mvp!.team).toBe('A')
+
+      // B팀이 승리한 경우
+      const mvpB = service['calculateMVP'](state, 'B')
+      expect(mvpB!.userId).toBe('user-2')
+      expect(mvpB!.team).toBe('B')
+    })
+
+    it('선정된 의견 수가 많은 후보가 우선이다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // user-1: 2개 의견, 2개 선정됨
+      state.teamA.attacks.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-1', nickname: 'User1' },
+        type: 'ATTACK',
+        content: 'attack 1',
+        upvotes: 1,
+        votes: ['v1'],
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        selectedAt: Date.now(),
+      })
+      state.teamA.attacks.push({
+        discussionId: 'attack-2',
+        author: { authorId: 'user-1', nickname: 'User1' },
+        type: 'ATTACK',
+        content: 'attack 2',
+        upvotes: 1,
+        votes: ['v2'],
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        selectedAt: Date.now(),
+      })
+
+      // user-3: 2개 의견, 0개 선정됨
+      state.teamA.attacks.push({
+        discussionId: 'attack-3',
+        author: { authorId: 'user-3', nickname: 'User3' },
+        type: 'ATTACK',
+        content: 'attack 3',
+        upvotes: 1,
+        votes: ['v3'],
+        status: 'PENDING',
+        team: BATTLE_TEAM.A,
+      })
+      state.teamA.attacks.push({
+        discussionId: 'attack-4',
+        author: { authorId: 'user-3', nickname: 'User3' },
+        type: 'ATTACK',
+        content: 'attack 4',
+        upvotes: 1,
+        votes: ['v4'],
+        status: 'PENDING',
+        team: BATTLE_TEAM.A,
+      })
+
+      const mvp = service['calculateMVP'](state, 'A')
+
+      // 동일 점수, 좋아요, 의견수, 팀 → 선정된 의견 수로 비교
+      expect(mvp!.userId).toBe('user-1')
+      expect(mvp!.selectedOpinionCount).toBe(2)
+    })
+
+    it('먼저 참여한 사용자가 우선이다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // user-1 (참가순서: 0)과 user-3 (참가순서: 2) 동일 조건
+      state.teamA.attacks.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-1', nickname: 'User1' },
+        type: 'ATTACK',
+        content: 'attack',
+        upvotes: 1,
+        votes: ['v1'],
+        status: 'PENDING',
+        team: BATTLE_TEAM.A,
+      })
+
+      state.teamA.attacks.push({
+        discussionId: 'attack-2',
+        author: { authorId: 'user-3', nickname: 'User3' },
+        type: 'ATTACK',
+        content: 'attack',
+        upvotes: 1,
+        votes: ['v2'],
+        status: 'PENDING',
+        team: BATTLE_TEAM.A,
+      })
+
+      const mvp = service['calculateMVP'](state, 'A')
+
+      // 모든 조건 동일 → 먼저 참여한 user-1이 MVP (참가순서 0)
+      expect(mvp!.userId).toBe('user-1')
+      expect(mvp!.joinedAt).toBe(0) // participants Map 삽입 순서 기반
+    })
+
+    it('의견이 없으면 null을 반환한다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      const mvp = service['calculateMVP'](state, 'A')
+      expect(mvp).toBeNull()
+    })
+
+    it('투표 참가자가 0명이면 점수는 0이다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // 투표자가 없는 의견
+      state.teamA.attacks.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-1', nickname: 'User1' },
+        type: 'ATTACK',
+        content: 'attack',
+        upvotes: 0,
+        votes: [],
+        status: 'PENDING',
+        team: BATTLE_TEAM.A,
+      })
+
+      const mvp = service['calculateMVP'](state, 'A')
+      expect(mvp).not.toBeNull()
+      expect(mvp!.score).toBe(0)
+    })
+
+    it('페이즈별로 기록된 투표 참가자 수를 사용하여 점수를 계산한다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // user-1: 2개 의견, 페이즈별 투표 참가자 수가 다름
+      // 1차 페이즈: 2표/4명 = 0.5점
+      state.teamA.attacks.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-1', nickname: 'User1' },
+        type: 'ATTACK',
+        content: 'attack 1',
+        upvotes: 2,
+        votes: ['v1', 'v2'],
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 4, // 1차 페이즈에서 4명 참여
+      })
+      // 2차 페이즈: 3표/10명 = 0.3점
+      state.teamA.attacks.push({
+        discussionId: 'attack-2',
+        author: { authorId: 'user-1', nickname: 'User1' },
+        type: 'ATTACK',
+        content: 'attack 2',
+        upvotes: 3,
+        votes: ['v3', 'v4', 'v5'],
+        status: 'PENDING',
+        team: BATTLE_TEAM.A,
+        voterCountAtPhase: 10, // 2차 페이즈에서 10명 참여
+      })
+
+      // user-2: 1개 의견
+      // 1차 페이즈: 4표/4명 = 1.0점
+      state.teamB.attacks.push({
+        discussionId: 'attack-3',
+        author: { authorId: 'user-2', nickname: 'User2' },
+        type: 'ATTACK',
+        content: 'attack 3',
+        upvotes: 4,
+        votes: ['v1', 'v2', 'v3', 'v4'],
+        status: 'SELECTED',
+        team: BATTLE_TEAM.B,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 4, // B팀 1차 페이즈에서 4명 참여
+      })
+
+      const mvp = service['calculateMVP'](state, 'A')
+
+      // user-1: score = 0.5 + 0.3 = 0.8, totalVotes = 5
+      // user-2: score = 1.0, totalVotes = 4
+      // user-2가 점수가 높으므로 MVP
+      expect(mvp).not.toBeNull()
+      expect(mvp!.userId).toBe('user-2')
+      expect(mvp!.score).toBeCloseTo(1.0)
+      expect(mvp!.totalVotes).toBe(4)
+    })
+
+    it('voterCountAtPhase가 없으면 점수 0으로 처리한다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // voterCountAtPhase가 없는 의견
+      state.teamA.attacks.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-1', nickname: 'User1' },
+        type: 'ATTACK',
+        content: 'attack',
+        upvotes: 10,
+        votes: ['v1', 'v2', 'v3', 'v4', 'v5', 'v6', 'v7', 'v8', 'v9', 'v10'],
+        status: 'PENDING',
+        team: BATTLE_TEAM.A,
+        // voterCountAtPhase 없음
+      })
+
+      // voterCountAtPhase가 있는 의견
+      state.teamA.attacks.push({
+        discussionId: 'attack-2',
+        author: { authorId: 'user-3', nickname: 'User3' },
+        type: 'ATTACK',
+        content: 'attack 2',
+        upvotes: 1,
+        votes: ['v1'],
+        status: 'PENDING',
+        team: BATTLE_TEAM.A,
+        voterCountAtPhase: 2,
+      })
+
+      const mvp = service['calculateMVP'](state, 'A')
+
+      // user-1: voterCountAtPhase 없음 → 점수 0, totalVotes = 10
+      // user-3: score = 1/2 = 0.5, totalVotes = 1
+      // user-3이 점수가 높으므로 MVP
+      expect(mvp).not.toBeNull()
+      expect(mvp!.userId).toBe('user-3')
+      expect(mvp!.score).toBeCloseTo(0.5)
     })
   })
 })

--- a/backend/src/battles/service/battles.service.spec.ts
+++ b/backend/src/battles/service/battles.service.spec.ts
@@ -1,5 +1,5 @@
 import { NotFoundException, BadRequestException, ForbiddenException, UnauthorizedException } from '@nestjs/common'
-import { Battle, FinishedBattleState } from '../types/battles.types'
+import { Battle, FinishedBattleState, BattleDefense } from '../types/battles.types'
 import { BattlesService } from './battles.service'
 import { BATTLE_TYPE, BATTLE_CATEGORY, BATTLE_PLAYTIME, BATTLE_LANGUAGE, BATTLE_STATUS, BATTLE_PHASE, BATTLE_TEAM } from '../const/battles.const'
 
@@ -1206,13 +1206,13 @@ describe('BattlesService', () => {
 
       const mvp = service['calculateMVP'](state, 'A')
 
-      // user-1: score = 0.5 + 0.3 = 0.8, totalVotes = 5
-      // user-2: score = 1.0, totalVotes = 4
-      // user-2가 점수가 높으므로 MVP
+      // user-1 (A팀): score = (0.5 + 0.3) * 1.5 = 1.2, totalVotes = 5
+      // user-2 (B팀): score = 1.0 (보너스 없음), totalVotes = 4
+      // A팀 승리 시 user-1이 보너스를 받아 MVP
       expect(mvp).not.toBeNull()
-      expect(mvp!.userId).toBe('user-2')
-      expect(mvp!.score).toBeCloseTo(1.0)
-      expect(mvp!.totalVotes).toBe(4)
+      expect(mvp!.userId).toBe('user-1')
+      expect(mvp!.score).toBeCloseTo(1.2)
+      expect(mvp!.totalVotes).toBe(5)
     })
 
     it('voterCountAtPhase가 없으면 점수 0으로 처리한다', () => {
@@ -1247,12 +1247,283 @@ describe('BattlesService', () => {
 
       const mvp = service['calculateMVP'](state, 'A')
 
-      // user-1: voterCountAtPhase 없음 → 점수 0, totalVotes = 10
-      // user-3: score = 1/2 = 0.5, totalVotes = 1
+      // user-1 (A팀): voterCountAtPhase 없음 → 점수 0 * 1.5 = 0, totalVotes = 10
+      // user-3 (A팀): score = 1/2 * 1.5 = 0.75, totalVotes = 1
       // user-3이 점수가 높으므로 MVP
       expect(mvp).not.toBeNull()
       expect(mvp!.userId).toBe('user-3')
-      expect(mvp!.score).toBeCloseTo(0.5)
+      expect(mvp!.score).toBeCloseTo(0.75)
+    })
+  })
+
+  describe('calculateMVP (승리 팀 1.5배 보너스)', () => {
+    beforeEach(() => {
+      const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
+      service.setBattlesForTest([battle])
+      service['initBattleState']('battle-1')
+
+      const state = service['activeBattles'].get('battle-1')!
+
+      service.registerGuest('battle-1', { id: 'user-a', nickname: 'UserA', createdAt: 1000 })
+      service.registerGuest('battle-1', { id: 'user-b', nickname: 'UserB', createdAt: 2000 })
+
+      state.participants.set('user-a', BATTLE_TEAM.A)
+      state.participants.set('user-b', BATTLE_TEAM.B)
+
+      service['rebuildTeamUsers'](state)
+    })
+
+    it('A팀 70표/100명 vs B팀 5표/5명: 보너스 없이는 B팀이 유리하지만, A팀 승리 시 A팀이 MVP가 된다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // user-a (A팀): 70표 / 100명 = 0.7점 → 1.5배 보너스 → 1.05점
+      state.teamA.attacks.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-a', nickname: 'UserA' },
+        type: 'ATTACK',
+        content: 'attack from A',
+        upvotes: 70,
+        votes: Array(70).fill('voter'),
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 100,
+      })
+
+      // user-b (B팀): 5표 / 5명 = 1.0점 → 보너스 없음 → 1.0점
+      state.teamB.attacks.push({
+        discussionId: 'attack-2',
+        author: { authorId: 'user-b', nickname: 'UserB' },
+        type: 'ATTACK',
+        content: 'attack from B',
+        upvotes: 5,
+        votes: Array(5).fill('voter'),
+        status: 'SELECTED',
+        team: BATTLE_TEAM.B,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 5,
+      })
+
+      // A팀 승리 시: user-a = 0.7 * 1.5 = 1.05, user-b = 1.0
+      const mvpWhenAWins = service['calculateMVP'](state, 'A')
+      expect(mvpWhenAWins).not.toBeNull()
+      expect(mvpWhenAWins!.userId).toBe('user-a')
+      expect(mvpWhenAWins!.score).toBeCloseTo(1.05)
+    })
+
+    it('A팀 70표/100명 vs B팀 5표/5명: B팀 승리 시 B팀이 MVP가 된다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // user-a (A팀): 70표 / 100명 = 0.7점 → 보너스 없음 → 0.7점
+      state.teamA.attacks.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-a', nickname: 'UserA' },
+        type: 'ATTACK',
+        content: 'attack from A',
+        upvotes: 70,
+        votes: Array(70).fill('voter'),
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 100,
+      })
+
+      // user-b (B팀): 5표 / 5명 = 1.0점 → 1.5배 보너스 → 1.5점
+      state.teamB.attacks.push({
+        discussionId: 'attack-2',
+        author: { authorId: 'user-b', nickname: 'UserB' },
+        type: 'ATTACK',
+        content: 'attack from B',
+        upvotes: 5,
+        votes: Array(5).fill('voter'),
+        status: 'SELECTED',
+        team: BATTLE_TEAM.B,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 5,
+      })
+
+      // B팀 승리 시: user-a = 0.7, user-b = 1.0 * 1.5 = 1.5
+      const mvpWhenBWins = service['calculateMVP'](state, 'B')
+      expect(mvpWhenBWins).not.toBeNull()
+      expect(mvpWhenBWins!.userId).toBe('user-b')
+      expect(mvpWhenBWins!.score).toBeCloseTo(1.5)
+    })
+
+    it('무승부 시 보너스 없이 순수 점수로 비교한다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // user-a (A팀): 70표 / 100명 = 0.7점
+      state.teamA.attacks.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-a', nickname: 'UserA' },
+        type: 'ATTACK',
+        content: 'attack from A',
+        upvotes: 70,
+        votes: Array(70).fill('voter'),
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 100,
+      })
+
+      // user-b (B팀): 5표 / 5명 = 1.0점
+      state.teamB.attacks.push({
+        discussionId: 'attack-2',
+        author: { authorId: 'user-b', nickname: 'UserB' },
+        type: 'ATTACK',
+        content: 'attack from B',
+        upvotes: 5,
+        votes: Array(5).fill('voter'),
+        status: 'SELECTED',
+        team: BATTLE_TEAM.B,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 5,
+      })
+
+      // 무승부: user-a = 0.7, user-b = 1.0 → user-b가 MVP
+      const mvpWhenDraw = service['calculateMVP'](state, 'DRAW')
+      expect(mvpWhenDraw).not.toBeNull()
+      expect(mvpWhenDraw!.userId).toBe('user-b')
+      expect(mvpWhenDraw!.score).toBeCloseTo(1.0)
+    })
+
+    it('동일 점수 + 동일 보너스 시 totalVotes로 비교한다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // 같은 팀, 같은 점수 비율
+      service.registerGuest('battle-1', { id: 'user-a2', nickname: 'UserA2', createdAt: 3000 })
+      state.participants.set('user-a2', BATTLE_TEAM.A)
+      service['rebuildTeamUsers'](state)
+
+      // user-a: 50표 / 100명 = 0.5점 → 1.5배 → 0.75점, totalVotes = 50
+      state.teamA.attacks.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-a', nickname: 'UserA' },
+        type: 'ATTACK',
+        content: 'attack from A',
+        upvotes: 50,
+        votes: Array(50).fill('voter'),
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 100,
+      })
+
+      // user-a2: 10표 / 20명 = 0.5점 → 1.5배 → 0.75점, totalVotes = 10
+      state.teamA.attacks.push({
+        discussionId: 'attack-2',
+        author: { authorId: 'user-a2', nickname: 'UserA2' },
+        type: 'ATTACK',
+        content: 'attack from A2',
+        upvotes: 10,
+        votes: Array(10).fill('voter'),
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 20,
+      })
+
+      const mvp = service['calculateMVP'](state, 'A')
+      expect(mvp).not.toBeNull()
+      // 점수 동점 → totalVotes로 비교 → user-a가 50표로 MVP
+      expect(mvp!.userId).toBe('user-a')
+      expect(mvp!.totalVotes).toBe(50)
+    })
+
+    it('여러 의견이 있을 때 누적 점수에 보너스가 적용된다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // user-a: 2개 의견, 각각 30표/100명 = 0.3 + 0.3 = 0.6점 → 1.5배 → 0.9점
+      state.teamA.attacks.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-a', nickname: 'UserA' },
+        type: 'ATTACK',
+        content: 'attack 1 from A',
+        upvotes: 30,
+        votes: Array(30).fill('voter'),
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 100,
+      })
+      state.teamA.defenses.push({
+        discussionId: 'defense-1',
+        author: { authorId: 'user-a', nickname: 'UserA' },
+        type: 'DEFENSE',
+        content: 'defense 1 from A',
+        upvotes: 30,
+        votes: Array(30).fill('voter'),
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 100,
+        attackId: 'attack-x',
+      } as BattleDefense)
+
+      // user-b: 1개 의견, 5표/10명 = 0.5점 → 보너스 없음 → 0.5점
+      state.teamB.attacks.push({
+        discussionId: 'attack-2',
+        author: { authorId: 'user-b', nickname: 'UserB' },
+        type: 'ATTACK',
+        content: 'attack from B',
+        upvotes: 5,
+        votes: Array(5).fill('voter'),
+        status: 'SELECTED',
+        team: BATTLE_TEAM.B,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 10,
+      })
+
+      // A팀 승리: user-a = 0.6 * 1.5 = 0.9, user-b = 0.5
+      const mvp = service['calculateMVP'](state, 'A')
+      expect(mvp).not.toBeNull()
+      expect(mvp!.userId).toBe('user-a')
+      expect(mvp!.score).toBeCloseTo(0.9)
+      expect(mvp!.opinionCount).toBe(2)
+    })
+
+    it('소수 인원으로 참여한 팀이 불리하지 않도록 보너스가 적용된다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // user-a (A팀, 다수): 80표 / 100명 = 0.8점 → 1.5배 → 1.2점
+      state.teamA.attacks.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-a', nickname: 'UserA' },
+        type: 'ATTACK',
+        content: 'attack from A',
+        upvotes: 80,
+        votes: Array(80).fill('voter'),
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 100,
+      })
+
+      // user-b (B팀, 소수): 3표 / 3명 = 1.0점 → 보너스 없음 → 1.0점
+      state.teamB.attacks.push({
+        discussionId: 'attack-2',
+        author: { authorId: 'user-b', nickname: 'UserB' },
+        type: 'ATTACK',
+        content: 'attack from B',
+        upvotes: 3,
+        votes: Array(3).fill('voter'),
+        status: 'SELECTED',
+        team: BATTLE_TEAM.B,
+        selectedAt: Date.now(),
+        voterCountAtPhase: 3,
+      })
+
+      // A팀 승리: user-a = 0.8 * 1.5 = 1.2 > user-b = 1.0
+      const mvp = service['calculateMVP'](state, 'A')
+      expect(mvp).not.toBeNull()
+      expect(mvp!.userId).toBe('user-a')
+      expect(mvp!.score).toBeCloseTo(1.2)
     })
   })
 })

--- a/backend/src/battles/service/battles.service.spec.ts
+++ b/backend/src/battles/service/battles.service.spec.ts
@@ -81,16 +81,18 @@ const createFinishedBattleState = (overrides: Partial<FinishedBattleState> = {})
       createdAt: '2025-12-15T10:06:00Z',
     },
   ],
-  mvp: {
-    userId: 'user-1',
-    nickname: 'CodeMaster',
-    team: 'A',
-    score: 2.5,
-    totalVotes: 25,
-    opinionCount: 2,
-    selectedOpinionCount: 1,
-    joinedAt: 1000,
-  },
+  mvps: [
+    {
+      userId: 'user-1',
+      nickname: 'CodeMaster',
+      team: 'A',
+      score: 2.5,
+      totalVotes: 25,
+      opinionCount: 2,
+      selectedOpinionCount: 1,
+      joinedAt: 1000,
+    },
+  ],
   ...overrides,
 })
 
@@ -686,7 +688,7 @@ describe('BattlesService', () => {
       expect(result).toHaveProperty('metrics')
       expect(result).toHaveProperty('voteTimeline')
       expect(result).toHaveProperty('timeline')
-      expect(result).toHaveProperty('mvp')
+      expect(result).toHaveProperty('mvps')
     })
 
     it('존재하지 않는 배틀 조회 시 NotFoundException을 던져야 함', () => {
@@ -714,9 +716,9 @@ describe('BattlesService', () => {
 
     it('MVP가 올바르게 계산되어야 함 (최다 upvotes)', () => {
       const result = service.getBattleResult('battle-1')
-      expect(result.mvp.nickname).toBe('CodeMaster')
-      expect(result.mvp.totalVotes).toBe(25)
-      expect(result.mvp.team).toBe('A')
+      expect(result.mvps[0].nickname).toBe('CodeMaster')
+      expect(result.mvps[0].totalVotes).toBe(25)
+      expect(result.mvps[0].team).toBe('A')
     })
 
     it('투표 추세가 누적값으로 반환되어야 함', () => {
@@ -892,7 +894,7 @@ describe('BattlesService', () => {
     })
   })
 
-  describe('calculateMVP (새로운 로직)', () => {
+  describe('calculateMVPs (새로운 로직)', () => {
     beforeEach(() => {
       const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
       service.setBattlesForTest([battle])
@@ -953,14 +955,14 @@ describe('BattlesService', () => {
       })
 
       // 팀별 투표 참가자 수 설정 (A팀: 5명, B팀: 4명)
-      const mvp = service['calculateMVP'](state, 'A')
+      const mvps = service['calculateMVPs'](state, 'A')
 
       // user-1: score = 3/5 + 2/5 = 1.0, totalVotes = 5
       // user-2: score = 4/4 = 1.0, totalVotes = 4
       // 점수 동점 → 좋아요 수 비교 → user-1이 5표로 MVP
-      expect(mvp).not.toBeNull()
-      expect(mvp!.userId).toBe('user-1')
-      expect(mvp!.totalVotes).toBe(5)
+      expect(mvps.length).toBeGreaterThan(0)
+      expect(mvps[0].userId).toBe('user-1')
+      expect(mvps[0].totalVotes).toBe(5)
     })
 
     it('중립 팀 사용자는 MVP 후보에서 제외된다', () => {
@@ -995,11 +997,11 @@ describe('BattlesService', () => {
         team: BATTLE_TEAM.A,
       })
 
-      const mvp = service['calculateMVP'](state, 'A')
+      const mvps = service['calculateMVPs'](state, 'A')
 
       // 중립 팀 제외, user-1이 MVP
-      expect(mvp).not.toBeNull()
-      expect(mvp!.userId).toBe('user-1')
+      expect(mvps.length).toBeGreaterThan(0)
+      expect(mvps[0].userId).toBe('user-1')
     })
 
     it('동점일 때 승리 팀 소속이 우선이다', () => {
@@ -1030,14 +1032,14 @@ describe('BattlesService', () => {
       })
 
       // A팀이 승리한 경우
-      const mvp = service['calculateMVP'](state, 'A')
-      expect(mvp!.userId).toBe('user-1')
-      expect(mvp!.team).toBe('A')
+      const mvpsA = service['calculateMVPs'](state, 'A')
+      expect(mvpsA[0].userId).toBe('user-1')
+      expect(mvpsA[0].team).toBe('A')
 
       // B팀이 승리한 경우
-      const mvpB = service['calculateMVP'](state, 'B')
-      expect(mvpB!.userId).toBe('user-2')
-      expect(mvpB!.team).toBe('B')
+      const mvpsB = service['calculateMVPs'](state, 'B')
+      expect(mvpsB[0].userId).toBe('user-2')
+      expect(mvpsB[0].team).toBe('B')
     })
 
     it('선정된 의견 수가 많은 후보가 우선이다', () => {
@@ -1090,11 +1092,11 @@ describe('BattlesService', () => {
         team: BATTLE_TEAM.A,
       })
 
-      const mvp = service['calculateMVP'](state, 'A')
+      const mvps = service['calculateMVPs'](state, 'A')
 
       // 동일 점수, 좋아요, 의견수, 팀 → 선정된 의견 수로 비교
-      expect(mvp!.userId).toBe('user-1')
-      expect(mvp!.selectedOpinionCount).toBe(2)
+      expect(mvps[0].userId).toBe('user-1')
+      expect(mvps[0].selectedOpinionCount).toBe(2)
     })
 
     it('먼저 참여한 사용자가 우선이다', () => {
@@ -1124,17 +1126,17 @@ describe('BattlesService', () => {
         team: BATTLE_TEAM.A,
       })
 
-      const mvp = service['calculateMVP'](state, 'A')
+      const mvps = service['calculateMVPs'](state, 'A')
 
       // 모든 조건 동일 → 먼저 참여한 user-1이 MVP (참가순서 0)
-      expect(mvp!.userId).toBe('user-1')
-      expect(mvp!.joinedAt).toBe(0) // participants Map 삽입 순서 기반
+      expect(mvps[0].userId).toBe('user-1')
+      expect(mvps[0].joinedAt).toBe(0) // participants Map 삽입 순서 기반
     })
 
-    it('의견이 없으면 null을 반환한다', () => {
+    it('의견이 없으면 빈 배열을 반환한다', () => {
       const state = service['activeBattles'].get('battle-1')!
-      const mvp = service['calculateMVP'](state, 'A')
-      expect(mvp).toBeNull()
+      const mvps = service['calculateMVPs'](state, 'A')
+      expect(mvps).toEqual([])
     })
 
     it('투표 참가자가 0명이면 점수는 0이다', () => {
@@ -1153,9 +1155,9 @@ describe('BattlesService', () => {
         team: BATTLE_TEAM.A,
       })
 
-      const mvp = service['calculateMVP'](state, 'A')
-      expect(mvp).not.toBeNull()
-      expect(mvp!.score).toBe(0)
+      const mvps = service['calculateMVPs'](state, 'A')
+      expect(mvps.length).toBeGreaterThan(0)
+      expect(mvps[0].score).toBe(0)
     })
 
     it('페이즈별로 기록된 투표 참가자 수를 사용하여 점수를 계산한다', () => {
@@ -1204,15 +1206,15 @@ describe('BattlesService', () => {
         voterCountAtPhase: 4, // B팀 1차 페이즈에서 4명 참여
       })
 
-      const mvp = service['calculateMVP'](state, 'A')
+      const mvps = service['calculateMVPs'](state, 'A')
 
       // user-1 (A팀): score = (0.5 + 0.3) * 1.5 = 1.2, totalVotes = 5
       // user-2 (B팀): score = 1.0 (보너스 없음), totalVotes = 4
       // A팀 승리 시 user-1이 보너스를 받아 MVP
-      expect(mvp).not.toBeNull()
-      expect(mvp!.userId).toBe('user-1')
-      expect(mvp!.score).toBeCloseTo(1.2)
-      expect(mvp!.totalVotes).toBe(5)
+      expect(mvps.length).toBeGreaterThan(0)
+      expect(mvps[0].userId).toBe('user-1')
+      expect(mvps[0].score).toBeCloseTo(1.2)
+      expect(mvps[0].totalVotes).toBe(5)
     })
 
     it('voterCountAtPhase가 없으면 점수 0으로 처리한다', () => {
@@ -1245,18 +1247,18 @@ describe('BattlesService', () => {
         voterCountAtPhase: 2,
       })
 
-      const mvp = service['calculateMVP'](state, 'A')
+      const mvps = service['calculateMVPs'](state, 'A')
 
       // user-1 (A팀): voterCountAtPhase 없음 → 점수 0 * 1.5 = 0, totalVotes = 10
       // user-3 (A팀): score = 1/2 * 1.5 = 0.75, totalVotes = 1
       // user-3이 점수가 높으므로 MVP
-      expect(mvp).not.toBeNull()
-      expect(mvp!.userId).toBe('user-3')
-      expect(mvp!.score).toBeCloseTo(0.75)
+      expect(mvps.length).toBeGreaterThan(0)
+      expect(mvps[0].userId).toBe('user-3')
+      expect(mvps[0].score).toBeCloseTo(0.75)
     })
   })
 
-  describe('calculateMVP (승리 팀 1.5배 보너스)', () => {
+  describe('calculateMVPs (승리 팀 1.5배 보너스)', () => {
     beforeEach(() => {
       const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
       service.setBattlesForTest([battle])
@@ -1306,10 +1308,10 @@ describe('BattlesService', () => {
       })
 
       // A팀 승리 시: user-a = 0.7 * 1.5 = 1.05, user-b = 1.0
-      const mvpWhenAWins = service['calculateMVP'](state, 'A')
-      expect(mvpWhenAWins).not.toBeNull()
-      expect(mvpWhenAWins!.userId).toBe('user-a')
-      expect(mvpWhenAWins!.score).toBeCloseTo(1.05)
+      const mvpsWhenAWins = service['calculateMVPs'](state, 'A')
+      expect(mvpsWhenAWins.length).toBeGreaterThan(0)
+      expect(mvpsWhenAWins[0].userId).toBe('user-a')
+      expect(mvpsWhenAWins[0].score).toBeCloseTo(1.05)
     })
 
     it('A팀 70표/100명 vs B팀 5표/5명: B팀 승리 시 B팀이 MVP가 된다', () => {
@@ -1345,10 +1347,10 @@ describe('BattlesService', () => {
       })
 
       // B팀 승리 시: user-a = 0.7, user-b = 1.0 * 1.5 = 1.5
-      const mvpWhenBWins = service['calculateMVP'](state, 'B')
-      expect(mvpWhenBWins).not.toBeNull()
-      expect(mvpWhenBWins!.userId).toBe('user-b')
-      expect(mvpWhenBWins!.score).toBeCloseTo(1.5)
+      const mvpsWhenBWins = service['calculateMVPs'](state, 'B')
+      expect(mvpsWhenBWins.length).toBeGreaterThan(0)
+      expect(mvpsWhenBWins[0].userId).toBe('user-b')
+      expect(mvpsWhenBWins[0].score).toBeCloseTo(1.5)
     })
 
     it('무승부 시 보너스 없이 순수 점수로 비교한다', () => {
@@ -1384,10 +1386,10 @@ describe('BattlesService', () => {
       })
 
       // 무승부: user-a = 0.7, user-b = 1.0 → user-b가 MVP
-      const mvpWhenDraw = service['calculateMVP'](state, 'DRAW')
-      expect(mvpWhenDraw).not.toBeNull()
-      expect(mvpWhenDraw!.userId).toBe('user-b')
-      expect(mvpWhenDraw!.score).toBeCloseTo(1.0)
+      const mvpsWhenDraw = service['calculateMVPs'](state, 'DRAW')
+      expect(mvpsWhenDraw.length).toBeGreaterThan(0)
+      expect(mvpsWhenDraw[0].userId).toBe('user-b')
+      expect(mvpsWhenDraw[0].score).toBeCloseTo(1.0)
     })
 
     it('동일 점수 + 동일 보너스 시 totalVotes로 비교한다', () => {
@@ -1427,11 +1429,11 @@ describe('BattlesService', () => {
         voterCountAtPhase: 20,
       })
 
-      const mvp = service['calculateMVP'](state, 'A')
-      expect(mvp).not.toBeNull()
+      const mvps = service['calculateMVPs'](state, 'A')
+      expect(mvps.length).toBeGreaterThan(0)
       // 점수 동점 → totalVotes로 비교 → user-a가 50표로 MVP
-      expect(mvp!.userId).toBe('user-a')
-      expect(mvp!.totalVotes).toBe(50)
+      expect(mvps[0].userId).toBe('user-a')
+      expect(mvps[0].totalVotes).toBe(50)
     })
 
     it('여러 의견이 있을 때 누적 점수에 보너스가 적용된다', () => {
@@ -1480,11 +1482,11 @@ describe('BattlesService', () => {
       })
 
       // A팀 승리: user-a = 0.6 * 1.5 = 0.9, user-b = 0.5
-      const mvp = service['calculateMVP'](state, 'A')
-      expect(mvp).not.toBeNull()
-      expect(mvp!.userId).toBe('user-a')
-      expect(mvp!.score).toBeCloseTo(0.9)
-      expect(mvp!.opinionCount).toBe(2)
+      const mvps = service['calculateMVPs'](state, 'A')
+      expect(mvps.length).toBeGreaterThan(0)
+      expect(mvps[0].userId).toBe('user-a')
+      expect(mvps[0].score).toBeCloseTo(0.9)
+      expect(mvps[0].opinionCount).toBe(2)
     })
 
     it('소수 인원으로 참여한 팀이 불리하지 않도록 보너스가 적용된다', () => {
@@ -1520,10 +1522,10 @@ describe('BattlesService', () => {
       })
 
       // A팀 승리: user-a = 0.8 * 1.5 = 1.2 > user-b = 1.0
-      const mvp = service['calculateMVP'](state, 'A')
-      expect(mvp).not.toBeNull()
-      expect(mvp!.userId).toBe('user-a')
-      expect(mvp!.score).toBeCloseTo(1.2)
+      const mvps = service['calculateMVPs'](state, 'A')
+      expect(mvps.length).toBeGreaterThan(0)
+      expect(mvps[0].userId).toBe('user-a')
+      expect(mvps[0].score).toBeCloseTo(1.2)
     })
   })
 })

--- a/backend/src/battles/service/battles.service.spec.ts
+++ b/backend/src/battles/service/battles.service.spec.ts
@@ -919,7 +919,7 @@ describe('BattlesService', () => {
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-1: 2개 의견, 총 5표
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-1',
         author: { authorId: 'user-1', nickname: 'User1' },
         type: 'ATTACK',
@@ -930,7 +930,7 @@ describe('BattlesService', () => {
         team: BATTLE_TEAM.A,
         selectedAt: Date.now(),
       })
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-2',
         author: { authorId: 'user-1', nickname: 'User1' },
         type: 'ATTACK',
@@ -942,7 +942,7 @@ describe('BattlesService', () => {
       })
 
       // user-2: 1개 의견, 총 4표
-      state.teamB.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-3',
         author: { authorId: 'user-2', nickname: 'User2' },
         type: 'ATTACK',
@@ -974,7 +974,7 @@ describe('BattlesService', () => {
       state.participants.set('user-none', BATTLE_TEAM.NONE)
 
       // 중립 팀 사용자가 가장 많은 표를 받았다고 가정 (실제로는 의견 제출 불가하지만 테스트용)
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-1',
         author: { authorId: 'user-none', nickname: 'NeutralUser' },
         type: 'ATTACK',
@@ -986,7 +986,7 @@ describe('BattlesService', () => {
         selectedAt: Date.now(),
       })
 
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-2',
         author: { authorId: 'user-1', nickname: 'User1' },
         type: 'ATTACK',
@@ -1009,7 +1009,7 @@ describe('BattlesService', () => {
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // 동일한 점수, 좋아요, 의견 수
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-1',
         author: { authorId: 'user-1', nickname: 'User1' },
         type: 'ATTACK',
@@ -1020,7 +1020,7 @@ describe('BattlesService', () => {
         team: BATTLE_TEAM.A,
       })
 
-      state.teamB.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-2',
         author: { authorId: 'user-2', nickname: 'User2' },
         type: 'ATTACK',
@@ -1047,7 +1047,7 @@ describe('BattlesService', () => {
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-1: 2개 의견, 2개 선정됨
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-1',
         author: { authorId: 'user-1', nickname: 'User1' },
         type: 'ATTACK',
@@ -1058,7 +1058,7 @@ describe('BattlesService', () => {
         team: BATTLE_TEAM.A,
         selectedAt: Date.now(),
       })
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-2',
         author: { authorId: 'user-1', nickname: 'User1' },
         type: 'ATTACK',
@@ -1071,7 +1071,7 @@ describe('BattlesService', () => {
       })
 
       // user-3: 2개 의견, 0개 선정됨
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-3',
         author: { authorId: 'user-3', nickname: 'User3' },
         type: 'ATTACK',
@@ -1081,7 +1081,7 @@ describe('BattlesService', () => {
         status: 'PENDING',
         team: BATTLE_TEAM.A,
       })
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-4',
         author: { authorId: 'user-3', nickname: 'User3' },
         type: 'ATTACK',
@@ -1104,7 +1104,7 @@ describe('BattlesService', () => {
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-1 (참가순서: 0)과 user-3 (참가순서: 2) 동일 조건
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-1',
         author: { authorId: 'user-1', nickname: 'User1' },
         type: 'ATTACK',
@@ -1115,7 +1115,7 @@ describe('BattlesService', () => {
         team: BATTLE_TEAM.A,
       })
 
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-2',
         author: { authorId: 'user-3', nickname: 'User3' },
         type: 'ATTACK',
@@ -1144,7 +1144,7 @@ describe('BattlesService', () => {
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // 투표자가 없는 의견
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-1',
         author: { authorId: 'user-1', nickname: 'User1' },
         type: 'ATTACK',
@@ -1166,7 +1166,7 @@ describe('BattlesService', () => {
 
       // user-1: 2개 의견, 페이즈별 투표 참가자 수가 다름
       // 1차 페이즈: 2표/4명 = 0.5점
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-1',
         author: { authorId: 'user-1', nickname: 'User1' },
         type: 'ATTACK',
@@ -1179,7 +1179,7 @@ describe('BattlesService', () => {
         voterCountAtPhase: 4, // 1차 페이즈에서 4명 참여
       })
       // 2차 페이즈: 3표/10명 = 0.3점
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-2',
         author: { authorId: 'user-1', nickname: 'User1' },
         type: 'ATTACK',
@@ -1193,7 +1193,7 @@ describe('BattlesService', () => {
 
       // user-2: 1개 의견
       // 1차 페이즈: 4표/4명 = 1.0점
-      state.teamB.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-3',
         author: { authorId: 'user-2', nickname: 'User2' },
         type: 'ATTACK',
@@ -1222,7 +1222,7 @@ describe('BattlesService', () => {
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // voterCountAtPhase가 없는 의견
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-1',
         author: { authorId: 'user-1', nickname: 'User1' },
         type: 'ATTACK',
@@ -1235,7 +1235,7 @@ describe('BattlesService', () => {
       })
 
       // voterCountAtPhase가 있는 의견
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-2',
         author: { authorId: 'user-3', nickname: 'User3' },
         type: 'ATTACK',
@@ -1280,7 +1280,7 @@ describe('BattlesService', () => {
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-a (A팀): 70표 / 100명 = 0.7점 → 1.5배 보너스 → 1.05점
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-1',
         author: { authorId: 'user-a', nickname: 'UserA' },
         type: 'ATTACK',
@@ -1294,7 +1294,7 @@ describe('BattlesService', () => {
       })
 
       // user-b (B팀): 5표 / 5명 = 1.0점 → 보너스 없음 → 1.0점
-      state.teamB.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-2',
         author: { authorId: 'user-b', nickname: 'UserB' },
         type: 'ATTACK',
@@ -1319,7 +1319,7 @@ describe('BattlesService', () => {
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-a (A팀): 70표 / 100명 = 0.7점 → 보너스 없음 → 0.7점
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-1',
         author: { authorId: 'user-a', nickname: 'UserA' },
         type: 'ATTACK',
@@ -1333,7 +1333,7 @@ describe('BattlesService', () => {
       })
 
       // user-b (B팀): 5표 / 5명 = 1.0점 → 1.5배 보너스 → 1.5점
-      state.teamB.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-2',
         author: { authorId: 'user-b', nickname: 'UserB' },
         type: 'ATTACK',
@@ -1358,7 +1358,7 @@ describe('BattlesService', () => {
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-a (A팀): 70표 / 100명 = 0.7점
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-1',
         author: { authorId: 'user-a', nickname: 'UserA' },
         type: 'ATTACK',
@@ -1372,7 +1372,7 @@ describe('BattlesService', () => {
       })
 
       // user-b (B팀): 5표 / 5명 = 1.0점
-      state.teamB.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-2',
         author: { authorId: 'user-b', nickname: 'UserB' },
         type: 'ATTACK',
@@ -1402,7 +1402,7 @@ describe('BattlesService', () => {
       service['rebuildTeamUsers'](state)
 
       // user-a: 50표 / 100명 = 0.5점 → 1.5배 → 0.75점, totalVotes = 50
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-1',
         author: { authorId: 'user-a', nickname: 'UserA' },
         type: 'ATTACK',
@@ -1416,7 +1416,7 @@ describe('BattlesService', () => {
       })
 
       // user-a2: 10표 / 20명 = 0.5점 → 1.5배 → 0.75점, totalVotes = 10
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-2',
         author: { authorId: 'user-a2', nickname: 'UserA2' },
         type: 'ATTACK',
@@ -1441,7 +1441,7 @@ describe('BattlesService', () => {
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-a: 2개 의견, 각각 30표/100명 = 0.3 + 0.3 = 0.6점 → 1.5배 → 0.9점
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-1',
         author: { authorId: 'user-a', nickname: 'UserA' },
         type: 'ATTACK',
@@ -1453,7 +1453,7 @@ describe('BattlesService', () => {
         selectedAt: Date.now(),
         voterCountAtPhase: 100,
       })
-      state.teamA.defenses.push({
+      state.opinionHistory.push({
         discussionId: 'defense-1',
         author: { authorId: 'user-a', nickname: 'UserA' },
         type: 'DEFENSE',
@@ -1468,7 +1468,7 @@ describe('BattlesService', () => {
       } as BattleDefense)
 
       // user-b: 1개 의견, 5표/10명 = 0.5점 → 보너스 없음 → 0.5점
-      state.teamB.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-2',
         author: { authorId: 'user-b', nickname: 'UserB' },
         type: 'ATTACK',
@@ -1494,7 +1494,7 @@ describe('BattlesService', () => {
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-a (A팀, 다수): 80표 / 100명 = 0.8점 → 1.5배 → 1.2점
-      state.teamA.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-1',
         author: { authorId: 'user-a', nickname: 'UserA' },
         type: 'ATTACK',
@@ -1508,7 +1508,7 @@ describe('BattlesService', () => {
       })
 
       // user-b (B팀, 소수): 3표 / 3명 = 1.0점 → 보너스 없음 → 1.0점
-      state.teamB.attacks.push({
+      state.opinionHistory.push({
         discussionId: 'attack-2',
         author: { authorId: 'user-b', nickname: 'UserB' },
         type: 'ATTACK',
@@ -1526,6 +1526,130 @@ describe('BattlesService', () => {
       expect(mvps.length).toBeGreaterThan(0)
       expect(mvps[0].userId).toBe('user-a')
       expect(mvps[0].score).toBeCloseTo(1.2)
+    })
+  })
+
+  describe('resetDiscussions 후 MVP 계산', () => {
+    beforeEach(() => {
+      const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
+      service.setBattlesForTest([battle])
+      service['initBattleState']('battle-1')
+
+      const state = service['activeBattles'].get('battle-1')!
+
+      service.registerGuest('battle-1', { id: 'user-1', nickname: 'User1', createdAt: 1000 })
+      service.registerGuest('battle-1', { id: 'user-2', nickname: 'User2', createdAt: 2000 })
+
+      state.participants.set('user-1', BATTLE_TEAM.A)
+      state.participants.set('user-2', BATTLE_TEAM.B)
+
+      service['rebuildTeamUsers'](state)
+    })
+
+    it('resetDiscussions 호출 후에도 opinionHistory에서 MVP를 정상 계산한다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // 의견 등록
+      state.opinionHistory.push({
+        discussionId: 'attack-1',
+        author: { authorId: 'user-1', nickname: 'User1' },
+        type: 'ATTACK',
+        content: 'attack 1',
+        upvotes: 5,
+        votes: ['v1', 'v2', 'v3', 'v4', 'v5'],
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        voterCountAtPhase: 10,
+      })
+      state.teamA.attacks.push(state.opinionHistory[0])
+
+      state.opinionHistory.push({
+        discussionId: 'attack-2',
+        author: { authorId: 'user-2', nickname: 'User2' },
+        type: 'ATTACK',
+        content: 'attack 2',
+        upvotes: 3,
+        votes: ['v1', 'v2', 'v3'],
+        status: 'PENDING',
+        team: BATTLE_TEAM.B,
+        voterCountAtPhase: 10,
+      })
+      state.teamB.attacks.push(state.opinionHistory[1])
+
+      // resetDiscussions 호출 전 상태 확인
+      expect(state.opinionHistory.length).toBe(2)
+      expect(state.teamA.attacks.length).toBe(1)
+      expect(state.teamB.attacks.length).toBe(1)
+
+      // resetDiscussions 호출 (teamA/teamB만 초기화)
+      service['resetDiscussions']('battle-1')
+
+      // resetDiscussions 후 상태 확인
+      expect(state.opinionHistory.length).toBe(2) // opinionHistory는 유지
+      expect(state.teamA.attacks.length).toBe(0) // teamA는 초기화
+      expect(state.teamB.attacks.length).toBe(0) // teamB는 초기화
+
+      // MVP 계산 - opinionHistory에서 읽으므로 정상 동작
+      const mvps = service['calculateMVPs'](state, 'A')
+
+      expect(mvps.length).toBeGreaterThan(0)
+      expect(mvps[0].userId).toBe('user-1')
+      expect(mvps[0].totalVotes).toBe(5)
+    })
+
+    it('여러 번 resetDiscussions 호출 후에도 누적된 모든 의견으로 MVP를 계산한다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      // 1라운드 의견
+      state.opinionHistory.push({
+        discussionId: 'attack-r1',
+        author: { authorId: 'user-1', nickname: 'User1' },
+        type: 'ATTACK',
+        content: 'round 1 attack',
+        upvotes: 3,
+        votes: ['v1', 'v2', 'v3'],
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        voterCountAtPhase: 5,
+      })
+      state.teamA.attacks.push(state.opinionHistory[0])
+
+      // 1라운드 후 reset
+      service['resetDiscussions']('battle-1')
+      expect(state.teamA.attacks.length).toBe(0)
+
+      // 2라운드 의견
+      state.opinionHistory.push({
+        discussionId: 'attack-r2',
+        author: { authorId: 'user-1', nickname: 'User1' },
+        type: 'ATTACK',
+        content: 'round 2 attack',
+        upvotes: 4,
+        votes: ['v1', 'v2', 'v3', 'v4'],
+        status: 'SELECTED',
+        team: BATTLE_TEAM.A,
+        voterCountAtPhase: 5,
+      })
+      state.teamA.attacks.push(state.opinionHistory[1])
+
+      // 2라운드 후 reset
+      service['resetDiscussions']('battle-1')
+      expect(state.teamA.attacks.length).toBe(0)
+
+      // opinionHistory에는 2개 의견이 누적되어 있어야 함
+      expect(state.opinionHistory.length).toBe(2)
+
+      // MVP 계산 - 누적 점수로 계산
+      const mvps = service['calculateMVPs'](state, 'A')
+
+      expect(mvps.length).toBeGreaterThan(0)
+      expect(mvps[0].userId).toBe('user-1')
+      // user-1: score = 3/5 + 4/5 = 1.4, 승리팀 보너스 1.5배 = 2.1
+      expect(mvps[0].score).toBeCloseTo(2.1)
+      expect(mvps[0].totalVotes).toBe(7) // 3 + 4
+      expect(mvps[0].opinionCount).toBe(2)
     })
   })
 })

--- a/backend/src/battles/service/battles.service.spec.ts
+++ b/backend/src/battles/service/battles.service.spec.ts
@@ -1652,4 +1652,88 @@ describe('BattlesService', () => {
       expect(mvps[0].opinionCount).toBe(2)
     })
   })
+
+  describe('handleAttack / handleDefense의 opinionHistory 저장', () => {
+    beforeEach(() => {
+      const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
+      service.setBattlesForTest([battle])
+      service['initBattleState']('battle-1')
+
+      const state = service['activeBattles'].get('battle-1')!
+
+      service.registerGuest('battle-1', { id: 'user-1', nickname: 'User1', createdAt: 1000 })
+      service.registerGuest('battle-1', { id: 'user-2', nickname: 'User2', createdAt: 2000 })
+
+      state.participants.set('user-1', BATTLE_TEAM.A)
+      state.participants.set('user-2', BATTLE_TEAM.B)
+
+      service['rebuildTeamUsers'](state)
+    })
+
+    it('handleAttack 호출 시 opinionHistory에 의견이 저장된다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      expect(state.opinionHistory.length).toBe(0)
+
+      service['handleAttack']('battle-1', { authorId: 'user-1', content: '공격 의견입니다', team: BATTLE_TEAM.A })
+
+      expect(state.opinionHistory.length).toBe(1)
+      expect(state.opinionHistory[0].content).toBe('공격 의견입니다')
+      expect(state.opinionHistory[0].author.authorId).toBe('user-1')
+      expect(state.opinionHistory[0].status).toBe('PENDING')
+      expect(state.opinionHistory[0].type).toBe('ATTACK')
+    })
+
+    it('handleDefense 호출 시 opinionHistory에 의견이 저장된다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.DEFENSE.name
+
+      expect(state.opinionHistory.length).toBe(0)
+
+      service['handleDefense']('battle-1', { authorId: 'user-2', content: '수비 의견입니다', team: BATTLE_TEAM.B })
+
+      expect(state.opinionHistory.length).toBe(1)
+      expect(state.opinionHistory[0].content).toBe('수비 의견입니다')
+      expect(state.opinionHistory[0].author.authorId).toBe('user-2')
+      expect(state.opinionHistory[0].status).toBe('PENDING')
+      expect(state.opinionHistory[0].type).toBe('DEFENSE')
+    })
+
+    it('여러 의견 등록 시 모두 opinionHistory에 누적된다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      service['handleAttack']('battle-1', { authorId: 'user-1', content: '첫 번째 공격', team: BATTLE_TEAM.A })
+      service['handleAttack']('battle-1', { authorId: 'user-2', content: '두 번째 공격', team: BATTLE_TEAM.B })
+
+      state.phase = BATTLE_PHASE.DEFENSE.name
+
+      service['handleDefense']('battle-1', { authorId: 'user-1', content: '첫 번째 수비', team: BATTLE_TEAM.A })
+
+      expect(state.opinionHistory.length).toBe(3)
+      expect(state.opinionHistory[0].type).toBe('ATTACK')
+      expect(state.opinionHistory[1].type).toBe('ATTACK')
+      expect(state.opinionHistory[2].type).toBe('DEFENSE')
+    })
+
+    it('opinionHistory와 teamA/teamB 모두에 저장된다', () => {
+      const state = service['activeBattles'].get('battle-1')!
+      state.phase = BATTLE_PHASE.ATTACK.name
+
+      service['handleAttack']('battle-1', { authorId: 'user-1', content: 'A팀 공격', team: BATTLE_TEAM.A })
+      service['handleAttack']('battle-1', { authorId: 'user-2', content: 'B팀 공격', team: BATTLE_TEAM.B })
+
+      // opinionHistory에 모두 저장
+      expect(state.opinionHistory.length).toBe(2)
+
+      // teamA/teamB에도 각각 저장
+      expect(state.teamA.attacks.length).toBe(1)
+      expect(state.teamB.attacks.length).toBe(1)
+
+      // 같은 객체를 참조
+      expect(state.opinionHistory[0]).toBe(state.teamA.attacks[0])
+      expect(state.opinionHistory[1]).toBe(state.teamB.attacks[0])
+    })
+  })
 })

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -34,6 +34,7 @@ import {
   BATTLE_TYPE,
   BATTLE_DISCUSSION_TYPE,
   BATTLE_MAX_PHASE_COUNT,
+  MVP_DISPLAY_COUNT,
 } from '../const/battles.const'
 import { BattlePhaseResponseDto, BattleRoundResponseDto } from '../dto/battleTurnResponse.dto'
 import { DiscussionVoteResponseDto } from '../dto/discussionVoteResponse.dto'
@@ -155,7 +156,7 @@ export class BattlesService extends EventEmitter {
     }
 
     // 3. 저장된 MVP 반환 (배틀 종료 시 계산됨)
-    return BattleResultResponseDto.fromEntity(battle, battle.mvp)
+    return BattleResultResponseDto.fromEntity(battle)
   }
 
   joinBattleInfo(battleId: string): BattleJoinInfoResponseDto {
@@ -207,7 +208,7 @@ export class BattlesService extends EventEmitter {
     this.battles = battles
   }
 
-  private calculateMVP(state: ActiveBattleState, winner: 'A' | 'B' | 'DRAW'): Mvp | null {
+  private calculateMVPs(state: ActiveBattleState, winner: 'A' | 'B' | 'DRAW'): Mvp[] {
     // 모든 의견 수집 (teamA + teamB의 attacks + defenses)
     const allOpinions: BattleDiscussion[] = [
       ...state.teamA.attacks.filter((d): d is BattleDiscussion => d !== null),
@@ -216,7 +217,7 @@ export class BattlesService extends EventEmitter {
       ...state.teamB.defenses.filter((d): d is BattleDiscussion => d !== null),
     ]
 
-    if (allOpinions.length === 0) return null
+    if (allOpinions.length === 0) return []
 
     // 사용자별 MVP 후보 데이터 집계
     const candidateMap = new Map<string, Mvp>()
@@ -258,18 +259,18 @@ export class BattlesService extends EventEmitter {
       }
     })
 
-    if (candidateMap.size === 0) return null
+    if (candidateMap.size === 0) return []
 
     // 승리 팀 보너스 적용 (1.5배)
     candidateMap.forEach(candidate => {
       candidate.score = applyWinnerBonus(candidate.score, candidate.team, winner)
     })
 
-    // 후보자 정렬 및 MVP 선정
+    // 후보자 정렬 및 상위 MVP_DISPLAY_COUNT명 반환
     const candidates = [...candidateMap.values()]
     candidates.sort((a, b) => compareMvpCandidates(a, b, winner))
 
-    return candidates[0]
+    return candidates.slice(0, MVP_DISPLAY_COUNT)
   }
 
   private getParticipantJoinedAt(battleId: string, oderId: string): number {
@@ -644,7 +645,7 @@ export class BattlesService extends EventEmitter {
     ]
 
     const timeline = this.buildTimeline(state)
-    const calculatedMvp = this.calculateMVP(state, result.winner)
+    const calculatedMvps = this.calculateMVPs(state, result.winner)
 
     const metrics: Metrics = {
       totalParticipants,
@@ -671,7 +672,7 @@ export class BattlesService extends EventEmitter {
       metrics,
       voteTimeline,
       timeline,
-      mvp: calculatedMvp || createMvpCandidate(),
+      mvps: calculatedMvps,
     }
   }
 

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -4,7 +4,7 @@ import { Injectable, NotFoundException, BadRequestException, UnauthorizedExcepti
 
 import { MOCK_BATTLES } from '../mock/battles.mock'
 import { TimelineItem, Mvp, BattleResult, VoteTimeline, Metrics } from '../types/battleResult.types'
-import { calculateOpinionScore, compareMvpCandidates, createEmptyMvp } from './utils/mvp.util'
+import { calculateOpinionScore, compareMvpCandidates, createEmptyMvp, applyWinnerBonus } from './utils/mvp.util'
 import {
   ActiveBattleState,
   Battle,
@@ -256,6 +256,11 @@ export class BattlesService extends EventEmitter {
     })
 
     if (candidateMap.size === 0) return null
+
+    // 승리 팀 보너스 적용 (1.5배)
+    candidateMap.forEach(candidate => {
+      candidate.score = applyWinnerBonus(candidate.score, candidate.team, winner)
+    })
 
     // 후보자 정렬 및 MVP 선정
     const candidates = [...candidateMap.values()]

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -4,7 +4,7 @@ import { Injectable, NotFoundException, BadRequestException, UnauthorizedExcepti
 
 import { MOCK_BATTLES } from '../mock/battles.mock'
 import { TimelineItem, Mvp, BattleResult, VoteTimeline, Metrics } from '../types/battleResult.types'
-import { calculateOpinionScore, compareMvpCandidates, createEmptyMvp, applyWinnerBonus } from './utils/mvp.util'
+import { calculateOpinionScore, compareMvpCandidates, createMvpCandidate, applyWinnerBonus } from './utils/mvp.util'
 import {
   ActiveBattleState,
   Battle,
@@ -242,16 +242,19 @@ export class BattlesService extends EventEmitter {
         }
       } else {
         const joinedAt = this.getParticipantJoinedAt(state.battleId, authorId)
-        candidateMap.set(authorId, {
-          userId: authorId,
-          nickname,
-          team: team === BATTLE_TEAM.A ? 'A' : 'B',
-          score: opinionScore,
-          totalVotes: opinion.upvotes,
-          opinionCount: 1,
-          selectedOpinionCount: opinion.status === 'SELECTED' ? 1 : 0,
-          joinedAt,
-        })
+        candidateMap.set(
+          authorId,
+          createMvpCandidate({
+            userId: authorId,
+            nickname,
+            team: team === BATTLE_TEAM.A ? 'A' : 'B',
+            score: opinionScore,
+            totalVotes: opinion.upvotes,
+            opinionCount: 1,
+            selectedOpinionCount: opinion.status === 'SELECTED' ? 1 : 0,
+            joinedAt,
+          }),
+        )
       }
     })
 
@@ -668,7 +671,7 @@ export class BattlesService extends EventEmitter {
       metrics,
       voteTimeline,
       timeline,
-      mvp: calculatedMvp || createEmptyMvp(),
+      mvp: calculatedMvp || createMvpCandidate(),
     }
   }
 

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -4,6 +4,7 @@ import { Injectable, NotFoundException, BadRequestException, UnauthorizedExcepti
 
 import { MOCK_BATTLES } from '../mock/battles.mock'
 import { TimelineItem, Mvp, BattleResult, VoteTimeline, Metrics } from '../types/battleResult.types'
+import { calculateOpinionScore, compareMvpCandidates, createEmptyMvp } from './utils/mvp.util'
 import {
   ActiveBattleState,
   Battle,
@@ -153,10 +154,8 @@ export class BattlesService extends EventEmitter {
       throw new BadRequestException('배틀이 아직 진행 중입니다.')
     }
 
-    // 3. MVP 재계산 (검증용)
-    const mvp = this.calculateMVP(battle.timeline)
-
-    return BattleResultResponseDto.fromEntity(battle, mvp)
+    // 3. 저장된 MVP 반환 (배틀 종료 시 계산됨)
+    return BattleResultResponseDto.fromEntity(battle, battle.mvp)
   }
 
   joinBattleInfo(battleId: string): BattleJoinInfoResponseDto {
@@ -208,34 +207,69 @@ export class BattlesService extends EventEmitter {
     this.battles = battles
   }
 
-  private calculateMVP(timeline: TimelineItem[]): Mvp | null {
-    if (timeline.length === 0) return null
+  private calculateMVP(state: ActiveBattleState, winner: 'A' | 'B' | 'DRAW'): Mvp | null {
+    // 모든 의견 수집 (teamA + teamB의 attacks + defenses)
+    const allOpinions: BattleDiscussion[] = [
+      ...state.teamA.attacks.filter((d): d is BattleDiscussion => d !== null),
+      ...state.teamA.defenses.filter((d): d is BattleDiscussion => d !== null),
+      ...state.teamB.attacks.filter((d): d is BattleDiscussion => d !== null),
+      ...state.teamB.defenses.filter((d): d is BattleDiscussion => d !== null),
+    ]
 
-    // 사용자별 누적 upvotes 집계
-    const userVotes = new Map<string, { nickname: string; team: 'A' | 'B'; votes: number }>()
+    if (allOpinions.length === 0) return null
 
-    timeline.forEach(item => {
-      const current = userVotes.get(item.author.id) || {
-        nickname: item.author.nickname,
-        team: item.team,
-        votes: 0,
+    // 사용자별 MVP 후보 데이터 집계
+    const candidateMap = new Map<string, Mvp>()
+
+    allOpinions.forEach(opinion => {
+      const { authorId, nickname } = opinion.author
+      const team = opinion.team
+
+      // 중립 팀 및 빈 userId(placeholder) 제외
+      if (team === BATTLE_TEAM.NONE || !authorId) return
+
+      // 페이즈별로 기록된 투표 참가자 수 사용 (없으면 0으로 처리)
+      const voterCount = opinion.voterCountAtPhase ?? 0
+      const opinionScore = calculateOpinionScore(opinion.upvotes, voterCount)
+
+      const existing = candidateMap.get(authorId)
+      if (existing) {
+        existing.score += opinionScore
+        existing.totalVotes += opinion.upvotes
+        existing.opinionCount += 1
+        if (opinion.status === 'SELECTED') {
+          existing.selectedOpinionCount += 1
+        }
+      } else {
+        const joinedAt = this.getParticipantJoinedAt(state.battleId, authorId)
+        candidateMap.set(authorId, {
+          userId: authorId,
+          nickname,
+          team: team === BATTLE_TEAM.A ? 'A' : 'B',
+          score: opinionScore,
+          totalVotes: opinion.upvotes,
+          opinionCount: 1,
+          selectedOpinionCount: opinion.status === 'SELECTED' ? 1 : 0,
+          joinedAt,
+        })
       }
-      current.votes += item.upvotes
-      userVotes.set(item.author.id, current)
     })
 
-    // 최다 득표자 (동점 시 첫 번째)
-    const entries = [...userVotes.entries()].sort((a, b) => b[1].votes - a[1].votes)
-    if (entries.length === 0) return null
+    if (candidateMap.size === 0) return null
 
-    const [userId, data] = entries[0]
+    // 후보자 정렬 및 MVP 선정
+    const candidates = [...candidateMap.values()]
+    candidates.sort((a, b) => compareMvpCandidates(a, b, winner))
 
-    return {
-      userId,
-      nickname: data.nickname,
-      team: data.team,
-      totalVotes: data.votes,
-    }
+    return candidates[0]
+  }
+
+  private getParticipantJoinedAt(battleId: string, oderId: string): number {
+    const state = this.activeBattles.get(battleId)
+    if (!state) return 0
+    // participants Map의 삽입 순서를 기반으로 참가 순서 반환
+    const participantOrder = [...state.participants.keys()].indexOf(oderId)
+    return participantOrder >= 0 ? participantOrder : 0
   }
 
   private initBattleState(battleId: string): void {
@@ -602,7 +636,7 @@ export class BattlesService extends EventEmitter {
     ]
 
     const timeline = this.buildTimeline(state)
-    const calculatedMvp = this.calculateMVP(timeline)
+    const calculatedMvp = this.calculateMVP(state, result.winner)
 
     const metrics: Metrics = {
       totalParticipants,
@@ -629,14 +663,7 @@ export class BattlesService extends EventEmitter {
       metrics,
       voteTimeline,
       timeline,
-      mvp:
-        calculatedMvp ||
-        ({
-          userId: '',
-          nickname: 'unknown',
-          team: 'A',
-          totalVotes: 0,
-        } as Mvp),
+      mvp: calculatedMvp || createEmptyMvp(),
     }
   }
 
@@ -959,31 +986,59 @@ export class BattlesService extends EventEmitter {
   }
 
   private emitAttackedResult(battleId: string) {
-    const top = this.pickTopVotedAttack(battleId)
-
     const battleState = this.activeBattles.get(battleId)
+    if (!battleState) return
+
+    // 페이즈 종료 시 각 팀의 투표 참가자 수 계산 및 의견에 기록
+    this.recordVoterCountAtPhase(battleState.teamA.attacks, BATTLE_TEAM.A)
+    this.recordVoterCountAtPhase(battleState.teamB.attacks, BATTLE_TEAM.B)
+
+    const top = this.pickTopVotedAttack(battleId)
 
     const { aTeam, bTeam } = top
     const aEntry = aTeam ? aTeam : this.createNullPlaceholder('A', 'ATTACK')
     const bEntry = bTeam ? bTeam : this.createNullPlaceholder('B', 'ATTACK')
-    battleState?.all.attacks.push(aEntry)
-    battleState?.all.attacks.push(bEntry)
+    battleState.all.attacks.push(aEntry)
+    battleState.all.attacks.push(bEntry)
 
     this.emit('battle:attacked', DiscussionVoteResultDto.attacked(battleId, top))
   }
 
   private emitDefensedResult(battleId: string) {
-    const top = this.pickTopVotedDefense(battleId)
-
     const battleState = this.activeBattles.get(battleId)
+    if (!battleState) return
+
+    // 페이즈 종료 시 각 팀의 투표 참가자 수 계산 및 의견에 기록
+    this.recordVoterCountAtPhase(battleState.teamA.defenses, BATTLE_TEAM.A)
+    this.recordVoterCountAtPhase(battleState.teamB.defenses, BATTLE_TEAM.B)
+
+    const top = this.pickTopVotedDefense(battleId)
 
     const { aTeam, bTeam } = top
     const aEntry = aTeam ? aTeam : this.createNullPlaceholder('A', 'DEFENSE')
     const bEntry = bTeam ? bTeam : this.createNullPlaceholder('B', 'DEFENSE')
-    battleState?.all.defenses.push(aEntry)
-    battleState?.all.defenses.push(bEntry)
+    battleState.all.defenses.push(aEntry)
+    battleState.all.defenses.push(bEntry)
 
     this.emit('battle:defensed', DiscussionVoteResultDto.defensed(battleId, top))
+  }
+
+  private recordVoterCountAtPhase(opinions: (BattleDiscussion | null)[], team: BattleTeam): void {
+    // 해당 팀의 이번 페이즈 투표 참가자 수 계산
+    const allVoters = new Set<string>()
+    opinions.forEach(o => {
+      if (o && o.team === team) {
+        o.votes.forEach(v => allVoters.add(v))
+      }
+    })
+    const voterCount = allVoters.size
+
+    // 각 의견에 투표 참가자 수 기록
+    opinions.forEach(o => {
+      if (o && o.team === team) {
+        o.voterCountAtPhase = voterCount
+      }
+    })
   }
 
   private hasAlreadyVoted(votes: readonly string[], userId: string): boolean {

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -209,13 +209,9 @@ export class BattlesService extends EventEmitter {
   }
 
   private calculateMVPs(state: ActiveBattleState, winner: 'A' | 'B' | 'DRAW'): Mvp[] {
-    // 모든 의견 수집 (teamA + teamB의 attacks + defenses)
-    const allOpinions: BattleDiscussion[] = [
-      ...state.teamA.attacks.filter((d): d is BattleDiscussion => d !== null),
-      ...state.teamA.defenses.filter((d): d is BattleDiscussion => d !== null),
-      ...state.teamB.attacks.filter((d): d is BattleDiscussion => d !== null),
-      ...state.teamB.defenses.filter((d): d is BattleDiscussion => d !== null),
-    ]
+    // 모든 의견 수집 (opinionHistory에 저장된 전체 의견)
+    // teamA/teamB는 resetDiscussions에서 초기화되므로 opinionHistory 사용
+    const allOpinions: BattleDiscussion[] = state.opinionHistory
 
     if (allOpinions.length === 0) return []
 
@@ -314,6 +310,8 @@ export class BattlesService extends EventEmitter {
       teamVotes: new Map(),
 
       guestInfoMap: new Map(),
+
+      opinionHistory: [],
 
       phase: BATTLE_PHASE.PENDING.name,
       round: 1,
@@ -765,7 +763,7 @@ export class BattlesService extends EventEmitter {
       team,
     }
 
-    // battleState.all.attacks.push(attack)
+    battleState.opinionHistory.push(attack)
     if (team === BATTLE_TEAM.A) {
       battleState.teamA.attacks.push(attack)
     } else {
@@ -800,7 +798,7 @@ export class BattlesService extends EventEmitter {
       team,
     }
 
-    // battleState.all.defenses.push(defense)
+    battleState.opinionHistory.push(defense)
     if (team === BATTLE_TEAM.A) {
       battleState.teamA.defenses.push(defense)
     } else {

--- a/backend/src/battles/service/utils/mvp.util.spec.ts
+++ b/backend/src/battles/service/utils/mvp.util.spec.ts
@@ -1,5 +1,5 @@
 import { Mvp } from '../../types/battleResult.types'
-import { calculateOpinionScore, compareMvpCandidates, createEmptyMvp } from './mvp.util'
+import { calculateOpinionScore, compareMvpCandidates, createEmptyMvp, applyWinnerBonus, WINNER_TEAM_BONUS_MULTIPLIER } from './mvp.util'
 
 describe('MVP Utils', () => {
   describe('calculateOpinionScore', () => {
@@ -114,6 +114,43 @@ describe('MVP Utils', () => {
         selectedOpinionCount: 0,
         joinedAt: 0,
       })
+    })
+  })
+
+  describe('applyWinnerBonus', () => {
+    it('승리 팀에 1.5배 보너스를 적용한다', () => {
+      const score = applyWinnerBonus(1.0, 'A', 'A')
+      expect(score).toBe(1.0 * WINNER_TEAM_BONUS_MULTIPLIER)
+      expect(score).toBe(1.5)
+    })
+
+    it('패배 팀에는 보너스를 적용하지 않는다', () => {
+      const score = applyWinnerBonus(1.0, 'B', 'A')
+      expect(score).toBe(1.0)
+    })
+
+    it('무승부인 경우 보너스를 적용하지 않는다', () => {
+      const scoreA = applyWinnerBonus(1.0, 'A', 'DRAW')
+      const scoreB = applyWinnerBonus(1.0, 'B', 'DRAW')
+      expect(scoreA).toBe(1.0)
+      expect(scoreB).toBe(1.0)
+    })
+
+    it('B팀이 승리한 경우 B팀에 보너스를 적용한다', () => {
+      const scoreA = applyWinnerBonus(1.0, 'A', 'B')
+      const scoreB = applyWinnerBonus(1.0, 'B', 'B')
+      expect(scoreA).toBe(1.0)
+      expect(scoreB).toBe(1.5)
+    })
+
+    it('점수가 0이면 보너스 적용해도 0이다', () => {
+      const score = applyWinnerBonus(0, 'A', 'A')
+      expect(score).toBe(0)
+    })
+
+    it('소수점 점수에도 정확히 1.5배를 적용한다', () => {
+      const score = applyWinnerBonus(0.7, 'A', 'A')
+      expect(score).toBeCloseTo(1.05)
     })
   })
 })

--- a/backend/src/battles/service/utils/mvp.util.spec.ts
+++ b/backend/src/battles/service/utils/mvp.util.spec.ts
@@ -1,5 +1,12 @@
 import { Mvp } from '../../types/battleResult.types'
-import { calculateOpinionScore, compareMvpCandidates, createEmptyMvp, applyWinnerBonus, WINNER_TEAM_BONUS_MULTIPLIER } from './mvp.util'
+import {
+  calculateOpinionScore,
+  compareMvpCandidates,
+  createEmptyMvp,
+  createMvpCandidate,
+  applyWinnerBonus,
+  WINNER_TEAM_BONUS_MULTIPLIER,
+} from './mvp.util'
 
 describe('MVP Utils', () => {
   describe('calculateOpinionScore', () => {
@@ -100,7 +107,50 @@ describe('MVP Utils', () => {
     })
   })
 
-  describe('createEmptyMvp', () => {
+  describe('createMvpCandidate', () => {
+    it('매개변수 없이 호출하면 기본값으로 채워진 객체를 반환한다', () => {
+      const mvp = createMvpCandidate()
+
+      expect(mvp).toEqual({
+        userId: '',
+        nickname: 'unknown',
+        team: 'A',
+        score: 0,
+        totalVotes: 0,
+        opinionCount: 0,
+        selectedOpinionCount: 0,
+        joinedAt: 0,
+      })
+    })
+
+    it('일부 값만 전달하면 나머지는 기본값으로 채워진다', () => {
+      const mvp = createMvpCandidate({ userId: 'user-1', nickname: 'TestUser' })
+
+      expect(mvp.userId).toBe('user-1')
+      expect(mvp.nickname).toBe('TestUser')
+      expect(mvp.team).toBe('A')
+      expect(mvp.score).toBe(0)
+    })
+
+    it('모든 값을 전달하면 해당 값으로 객체가 생성된다', () => {
+      const data: Mvp = {
+        userId: 'user-1',
+        nickname: 'MVP',
+        team: 'B',
+        score: 2.5,
+        totalVotes: 25,
+        opinionCount: 3,
+        selectedOpinionCount: 2,
+        joinedAt: 1000,
+      }
+
+      const mvp = createMvpCandidate(data)
+
+      expect(mvp).toEqual(data)
+    })
+  })
+
+  describe('createEmptyMvp (deprecated)', () => {
     it('빈 MVP 객체를 생성한다', () => {
       const emptyMvp = createEmptyMvp()
 

--- a/backend/src/battles/service/utils/mvp.util.spec.ts
+++ b/backend/src/battles/service/utils/mvp.util.spec.ts
@@ -1,0 +1,119 @@
+import { Mvp } from '../../types/battleResult.types'
+import { calculateOpinionScore, compareMvpCandidates, createEmptyMvp } from './mvp.util'
+
+describe('MVP Utils', () => {
+  describe('calculateOpinionScore', () => {
+    it('좋아요 수를 투표 참가자 수로 나눈 점수를 반환한다', () => {
+      const score = calculateOpinionScore(5, 10)
+      expect(score).toBe(0.5)
+    })
+
+    it('투표 참가자가 0명이면 0점을 반환한다', () => {
+      const score = calculateOpinionScore(5, 0)
+      expect(score).toBe(0)
+    })
+
+    it('좋아요가 0이면 0점을 반환한다', () => {
+      const score = calculateOpinionScore(0, 10)
+      expect(score).toBe(0)
+    })
+
+    it('모든 투표자가 좋아요를 누르면 1점을 반환한다', () => {
+      const score = calculateOpinionScore(10, 10)
+      expect(score).toBe(1)
+    })
+  })
+
+  describe('compareMvpCandidates', () => {
+    const baseCandidate: Mvp = {
+      userId: 'user-1',
+      nickname: 'User1',
+      team: 'A',
+      score: 1.0,
+      totalVotes: 10,
+      opinionCount: 5,
+      selectedOpinionCount: 2,
+      joinedAt: 1000,
+    }
+
+    it('점수가 높은 후보가 우선이다', () => {
+      const higher: Mvp = { ...baseCandidate, score: 2.0 }
+      const lower: Mvp = { ...baseCandidate, score: 1.0 }
+
+      expect(compareMvpCandidates(higher, lower, 'A')).toBeLessThan(0)
+      expect(compareMvpCandidates(lower, higher, 'A')).toBeGreaterThan(0)
+    })
+
+    it('점수가 같으면 총 좋아요 수가 많은 후보가 우선이다', () => {
+      const moreVotes: Mvp = { ...baseCandidate, totalVotes: 20 }
+      const lessVotes: Mvp = { ...baseCandidate, totalVotes: 10 }
+
+      expect(compareMvpCandidates(moreVotes, lessVotes, 'A')).toBeLessThan(0)
+      expect(compareMvpCandidates(lessVotes, moreVotes, 'A')).toBeGreaterThan(0)
+    })
+
+    it('좋아요 수도 같으면 의견 제출 수가 많은 후보가 우선이다', () => {
+      const moreOpinions: Mvp = { ...baseCandidate, opinionCount: 10 }
+      const lessOpinions: Mvp = { ...baseCandidate, opinionCount: 5 }
+
+      expect(compareMvpCandidates(moreOpinions, lessOpinions, 'A')).toBeLessThan(0)
+      expect(compareMvpCandidates(lessOpinions, moreOpinions, 'A')).toBeGreaterThan(0)
+    })
+
+    it('의견 수도 같으면 승리 팀 소속이 우선이다', () => {
+      const winnerTeam: Mvp = { ...baseCandidate, team: 'A' }
+      const loserTeam: Mvp = { ...baseCandidate, team: 'B' }
+
+      expect(compareMvpCandidates(winnerTeam, loserTeam, 'A')).toBeLessThan(0)
+      expect(compareMvpCandidates(loserTeam, winnerTeam, 'A')).toBeGreaterThan(0)
+    })
+
+    it('승리 팀도 같으면 선정된 의견 수가 많은 후보가 우선이다', () => {
+      const moreSelected: Mvp = { ...baseCandidate, selectedOpinionCount: 5 }
+      const lessSelected: Mvp = { ...baseCandidate, selectedOpinionCount: 2 }
+
+      expect(compareMvpCandidates(moreSelected, lessSelected, 'A')).toBeLessThan(0)
+      expect(compareMvpCandidates(lessSelected, moreSelected, 'A')).toBeGreaterThan(0)
+    })
+
+    it('선정된 의견 수도 같으면 먼저 참여한 후보가 우선이다', () => {
+      const earlier: Mvp = { ...baseCandidate, joinedAt: 500 }
+      const later: Mvp = { ...baseCandidate, joinedAt: 1000 }
+
+      expect(compareMvpCandidates(earlier, later, 'A')).toBeLessThan(0)
+      expect(compareMvpCandidates(later, earlier, 'A')).toBeGreaterThan(0)
+    })
+
+    it('모든 조건이 같으면 0을 반환한다', () => {
+      const candidate1: Mvp = { ...baseCandidate }
+      const candidate2: Mvp = { ...baseCandidate }
+
+      expect(compareMvpCandidates(candidate1, candidate2, 'A')).toBe(0)
+    })
+
+    it('무승부일 경우 승리 팀 비교를 건너뛴다', () => {
+      const teamA: Mvp = { ...baseCandidate, team: 'A' }
+      const teamB: Mvp = { ...baseCandidate, team: 'B' }
+
+      // DRAW일 때는 팀 비교가 의미 없으므로 다음 조건으로 넘어감
+      expect(compareMvpCandidates(teamA, teamB, 'DRAW')).toBe(0)
+    })
+  })
+
+  describe('createEmptyMvp', () => {
+    it('빈 MVP 객체를 생성한다', () => {
+      const emptyMvp = createEmptyMvp()
+
+      expect(emptyMvp).toEqual({
+        userId: '',
+        nickname: 'unknown',
+        team: 'A',
+        score: 0,
+        totalVotes: 0,
+        opinionCount: 0,
+        selectedOpinionCount: 0,
+        joinedAt: 0,
+      })
+    })
+  })
+})

--- a/backend/src/battles/service/utils/mvp.util.ts
+++ b/backend/src/battles/service/utils/mvp.util.ts
@@ -1,5 +1,8 @@
 import { Mvp } from '../../types/battleResult.types'
 
+/** 승리 팀 보너스 배율 */
+export const WINNER_TEAM_BONUS_MULTIPLIER = 1.5
+
 /**
  * 의견별 점수를 계산한다
  * 점수 = 좋아요 수 / 해당 팀 투표 참가자 수
@@ -8,6 +11,19 @@ import { Mvp } from '../../types/battleResult.types'
 export function calculateOpinionScore(upvotes: number, voterCount: number): number {
   if (voterCount === 0) return 0
   return upvotes / voterCount
+}
+
+/**
+ * 승리 팀 보너스를 적용한 최종 점수를 계산한다
+ * 승리 팀에 속한 후보자는 누적 점수에 1.5배 보너스를 받는다
+ * 무승부인 경우 보너스 없음
+ */
+export function applyWinnerBonus(score: number, team: 'A' | 'B', winner: 'A' | 'B' | 'DRAW'): number {
+  if (winner === 'DRAW') return score
+  if (team === winner) {
+    return score * WINNER_TEAM_BONUS_MULTIPLIER
+  }
+  return score
 }
 
 /**

--- a/backend/src/battles/service/utils/mvp.util.ts
+++ b/backend/src/battles/service/utils/mvp.util.ts
@@ -1,0 +1,77 @@
+import { Mvp } from '../../types/battleResult.types'
+
+/**
+ * 의견별 점수를 계산한다
+ * 점수 = 좋아요 수 / 해당 팀 투표 참가자 수
+ * 투표 참가자가 0명이면 0점
+ */
+export function calculateOpinionScore(upvotes: number, voterCount: number): number {
+  if (voterCount === 0) return 0
+  return upvotes / voterCount
+}
+
+/**
+ * MVP 후보자 비교 함수 (정렬용)
+ * 우선순위:
+ * 1. 누적 점수 (높을수록 우선)
+ * 2. 총 좋아요 수 (높을수록 우선)
+ * 3. 의견 제출 수 (높을수록 우선)
+ * 4. 승리 팀 소속 (승리팀 우선)
+ * 5. 선정된 의견 수 (높을수록 우선)
+ * 6. 먼저 참여한 순서 (빠를수록 우선)
+ *
+ * @returns 음수: a 우선, 양수: b 우선, 0: 동일
+ */
+export function compareMvpCandidates(a: Mvp, b: Mvp, winner: 'A' | 'B' | 'DRAW'): number {
+  // 1. 누적 점수
+  if (a.score !== b.score) {
+    return b.score - a.score
+  }
+
+  // 2. 총 좋아요 수
+  if (a.totalVotes !== b.totalVotes) {
+    return b.totalVotes - a.totalVotes
+  }
+
+  // 3. 의견 제출 수
+  if (a.opinionCount !== b.opinionCount) {
+    return b.opinionCount - a.opinionCount
+  }
+
+  // 4. 승리 팀 소속 (무승부면 건너뜀)
+  if (winner !== 'DRAW') {
+    const aIsWinner = a.team === winner
+    const bIsWinner = b.team === winner
+    if (aIsWinner !== bIsWinner) {
+      return aIsWinner ? -1 : 1
+    }
+  }
+
+  // 5. 선정된 의견 수
+  if (a.selectedOpinionCount !== b.selectedOpinionCount) {
+    return b.selectedOpinionCount - a.selectedOpinionCount
+  }
+
+  // 6. 먼저 참여한 순서
+  if (a.joinedAt !== b.joinedAt) {
+    return a.joinedAt - b.joinedAt
+  }
+
+  return 0
+}
+
+/**
+ * 빈 MVP 객체 생성
+ */
+export function createEmptyMvp(): Mvp {
+  return {
+    userId: '',
+    nickname: 'unknown',
+    team: 'A',
+    score: 0,
+    totalVotes: 0,
+    opinionCount: 0,
+    selectedOpinionCount: 0,
+    joinedAt: 0,
+  }
+}

--- a/backend/src/battles/service/utils/mvp.util.ts
+++ b/backend/src/battles/service/utils/mvp.util.ts
@@ -26,6 +26,25 @@ export function applyWinnerBonus(score: number, team: 'A' | 'B', winner: 'A' | '
   return score
 }
 
+/** MVP 비교 함수 타입 */
+type MvpComparator = (a: Mvp, b: Mvp) => number
+
+const compareByScore: MvpComparator = (a, b) => b.score - a.score
+const compareByTotalVotes: MvpComparator = (a, b) => b.totalVotes - a.totalVotes
+const compareByOpinionCount: MvpComparator = (a, b) => b.opinionCount - a.opinionCount
+const compareBySelectedOpinionCount: MvpComparator = (a, b) => b.selectedOpinionCount - a.selectedOpinionCount
+const compareByJoinedAt: MvpComparator = (a, b) => a.joinedAt - b.joinedAt
+
+const compareByWinnerTeam = (winner: 'A' | 'B' | 'DRAW'): MvpComparator => {
+  return (a, b) => {
+    if (winner === 'DRAW') return 0
+    const aIsWinner = a.team === winner
+    const bIsWinner = b.team === winner
+    if (aIsWinner === bIsWinner) return 0
+    return aIsWinner ? -1 : 1
+  }
+}
+
 /**
  * MVP 후보자 비교 함수 (정렬용)
  * 우선순위:
@@ -39,48 +58,29 @@ export function applyWinnerBonus(score: number, team: 'A' | 'B', winner: 'A' | '
  * @returns 음수: a 우선, 양수: b 우선, 0: 동일
  */
 export function compareMvpCandidates(a: Mvp, b: Mvp, winner: 'A' | 'B' | 'DRAW'): number {
-  // 1. 누적 점수
-  if (a.score !== b.score) {
-    return b.score - a.score
-  }
+  const comparators: MvpComparator[] = [
+    compareByScore,
+    compareByTotalVotes,
+    compareByOpinionCount,
+    compareByWinnerTeam(winner),
+    compareBySelectedOpinionCount,
+    compareByJoinedAt,
+  ]
 
-  // 2. 총 좋아요 수
-  if (a.totalVotes !== b.totalVotes) {
-    return b.totalVotes - a.totalVotes
-  }
-
-  // 3. 의견 제출 수
-  if (a.opinionCount !== b.opinionCount) {
-    return b.opinionCount - a.opinionCount
-  }
-
-  // 4. 승리 팀 소속 (무승부면 건너뜀)
-  if (winner !== 'DRAW') {
-    const aIsWinner = a.team === winner
-    const bIsWinner = b.team === winner
-    if (aIsWinner !== bIsWinner) {
-      return aIsWinner ? -1 : 1
-    }
-  }
-
-  // 5. 선정된 의견 수
-  if (a.selectedOpinionCount !== b.selectedOpinionCount) {
-    return b.selectedOpinionCount - a.selectedOpinionCount
-  }
-
-  // 6. 먼저 참여한 순서
-  if (a.joinedAt !== b.joinedAt) {
-    return a.joinedAt - b.joinedAt
+  for (const compare of comparators) {
+    const result = compare(a, b)
+    if (result !== 0) return result
   }
 
   return 0
 }
 
 /**
- * 빈 MVP 객체 생성
+ * MVP 후보 객체 생성 팩토리 메서드
+ * 매개변수가 없으면 초기화된 빈 객체를, 매개변수가 있으면 해당 값으로 채워진 객체를 반환
  */
-export function createEmptyMvp(): Mvp {
-  return {
+export function createMvpCandidate(data?: Partial<Mvp>): Mvp {
+  const defaults: Mvp = {
     userId: '',
     nickname: 'unknown',
     team: 'A',
@@ -90,4 +90,16 @@ export function createEmptyMvp(): Mvp {
     selectedOpinionCount: 0,
     joinedAt: 0,
   }
+
+  if (!data) return defaults
+
+  return { ...defaults, ...data }
+}
+
+/**
+ * 빈 MVP 객체 생성
+ * @deprecated createMvpCandidate() 사용을 권장
+ */
+export function createEmptyMvp(): Mvp {
+  return createMvpCandidate()
 }

--- a/backend/src/battles/types/battleResult.types.ts
+++ b/backend/src/battles/types/battleResult.types.ts
@@ -45,5 +45,9 @@ export interface Mvp {
   userId: string
   nickname: string
   team: 'A' | 'B'
+  score: number
   totalVotes: number
+  opinionCount: number
+  selectedOpinionCount: number
+  joinedAt: number
 }

--- a/backend/src/battles/types/battles.types.ts
+++ b/backend/src/battles/types/battles.types.ts
@@ -106,6 +106,8 @@ export interface ActiveBattleState {
 
   guestInfoMap: Map<string, string>
 
+  opinionHistory: BattleDiscussion[]
+
   round: number
   topics: string[]
   phase: BattlePhaseName

--- a/backend/src/battles/types/battles.types.ts
+++ b/backend/src/battles/types/battles.types.ts
@@ -135,5 +135,5 @@ export interface FinishedBattleState {
   metrics: Metrics
   voteTimeline: VoteTimeline[]
   timeline: TimelineItem[]
-  mvp: Mvp
+  mvps: Mvp[]
 }

--- a/backend/src/battles/types/battles.types.ts
+++ b/backend/src/battles/types/battles.types.ts
@@ -73,6 +73,7 @@ export interface BattleDiscussion {
   status: BattleDiscussionStatus
   selectedAt?: number // SELECTED로 변경된 시간 (timestamp)
   team: BattleTeam // 어느 팀의 토론인지
+  voterCountAtPhase?: number // 해당 페이즈 종료 시 팀 투표 참가자 수
 }
 
 export interface BattleTopOpinions {


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #193

## ✅ 작업 내용

### 💡개선 사항

**MVP 선정 기준 개선 (6단계 우선순위)**
1. 누적 점수 (좋아요 수 / 투표 참가자 수) × 승리 팀 보너스(1.5배)
2. 총 좋아요 수
3. 의견 제출 수
4. 승리 팀 소속
5. 선정된 의견 수
6. 먼저 참여한 순서

**MVP 1,2,3등 표시 지원**
- `mvp: Mvp` → `mvps: Mvp[]` 배열로 변경
- `MVP_DISPLAY_COUNT = 3` 상수로 표시 인원 수 관리
- 배열 인덱스가 순위를 나타냄 (0=1등, 1=2등, 2=3등)
- MVP가 없는 경우 빈 배열 반환

**페이즈별 점수 계산**
- 각 페이즈 종료 시 투표 참가자 수를 의견에 기록 (`voterCountAtPhase`)
- 배틀 중 인원 변동에도 공정한 점수 계산 가능

**승리 팀 1.5배 보너스**
- 최종 승리 팀에 속한 후보자의 누적 점수에 1.5배 적용
- 예: A팀 70표/100명 = 0.7점 → A팀 승리 시 1.05점
- 무승부인 경우 보너스 미적용

**버그 수정: resetDiscussions로 인한 MVP 빈 배열 문제**
- `ActiveBattleState`에 `opinionHistory` 필드 추가
- 의견 등록 시 `opinionHistory`에 저장 (`handleAttack`, `handleDefense`)
- `calculateMVPs`가 `teamA/teamB` 대신 `opinionHistory`에서 읽도록 수정
- 기존 문제: 각 페이즈 종료 시 `resetDiscussions`가 `teamA/teamB`의 attacks/defenses 배열을 초기화하여 배틀 종료 시점에 MVP 계산 불가
- 해결: 모든 의견을 `opinionHistory`에 누적 저장하여 `resetDiscussions` 영향 없이 MVP 계산 가능

**코드 구조 개선**
- MVP 헬퍼 함수 분리 (`service/utils/mvp.util.ts`)
- `compareMvpCandidates`: 조건별 함수 분리 및 배열 기반 비교로 유연성 향상
- `createMvpCandidate`: Partial<Mvp> 지원 팩토리 메서드 추가

<br />

## 📸 참고 사항

**변경 파일**
- `const/battles.const.ts`: MVP_DISPLAY_COUNT 상수 추가
- `types/battleResult.types.ts`: Mvp 인터페이스 확장
- `types/battles.types.ts`: BattleDiscussion에 voterCountAtPhase 필드 추가, FinishedBattleState mvp → mvps 변경, ActiveBattleState에 opinionHistory 필드 추가
- `dto/battleResult.dto.ts`: BattleResultResponseDto mvp → mvps 변경
- `service/utils/mvp.util.ts`: MVP 헬퍼 함수 (비교 함수 분리, 팩토리 메서드)
- `service/battles.service.ts`: calculateMVP → calculateMVPs 리팩토링, 상위 3명 반환, opinionHistory 기반 MVP 계산

**테스트 결과**: 전체 132개 테스트 통과 (resetDiscussions 관련 테스트 2개 추가)

<br />

## 💬 질문사항 (고민했던 부분)

- 기존 회의 내용은 (투표수 / 팀원수) 였는데 이 경우에 팀원은 많지만 투표를 많이 하지 않는 경우 점수가 낮아져서 (투표수/투표참여자수)로 진행함
- 그리고 선정 기준에서 동일한 경우 채팅수가 많은 사람으로 하자는 의견이 있었는데 단순 채팅보다는 의견을 많이 낸 사람으로 변경함
- 레이팅과 헷갈리는 부분이 있는데 단순히 mvp를 선정하는 것은 (투표수/투표참여자수)로만 판단하면 되는가?
- 비회원인 경우, 닉네임만 저장했다가 결과 조회할 때 사용되는 정도로만 저장하면 되는가?
- mvp선정 시 페이즈 별로 점수를 환산할 것인가, 전체 배틀에 대해 점수 환산할 것인가
  - 페이즈 별로 계산
    - 인원이 한 쪽으로 몰린 경우
      1. A팀 3명 참여해서 3표 받음 → 100% → A팀 승리 시 1.5점
      2. B팀 100명 참여해서 50표 받음 → 50% → 0.5점
    - 인원이 비슷하게 나눠져 있으면 공정한 것 같음
  - 전체 배틀에 대해 계산
    - 장점을 모르겠어서 이 방법으로 안함

**현재 Mvp 선정 시 배틀 종료 시점에 제출된 모든 의견에 대해서 좋아요수/해당 페이즈 투표 참가자 수로 점수 환산 후 승리 팀인 경우 배수함**
- 배틀 종료 시점에서 각 페이즈 별로 승리한 진영들에 배수를 해주어야 하나, 승리한 사람들에게 배수를 해주어야 하나
- 중간에 팀을 변경하면서 의견을 낸 경우 배수가 어떻게 적용되어야 하는가
- user1과 user2는 같은 팀 user1은 의견을 한 번 내서 선정도 되고 0.6점을 받음 / user2는 의견을 두 번 내서 선정된 적은 없더라도 0.4점 0.3점을 받아서 총 0.7점임 -> 이 경우에 누가 mvp?
- 라운드가 별로 없고 진영 변경 페이즈가 별로 없다 보니 변동 사항으로 판단하기 어려움
- 현재 1.5배수로 적용했는데 user1이 100표 중 70표 받으면 0.7점 / user2가 10표 중 10표 받으면 1점 => user1이 이기면 1.05로 겨우 이겨지긴 함 배수가 더 필요한가? (과반수만 받아도 이길 수 있을만해야 할지도)

- 그냥 단순히 선정된 의견에 대해서만 처리하는 것이 나은가? 추후에 굉장히 많은 의견들에 대해 처리한다고 할 때 문제가 생길 수 있나?