### PR TITLE
[Devops] monitoring 환경 구성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: deploy
 
 on:
-  pull_request:
+  push:
     branches:
       - dev
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: deploy
 
 on:
- push:
+  pull_request:
     branches:
       - dev
 
@@ -60,6 +60,17 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync monitoring configs to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          username: ${{ secrets.NCP_USER }}
+          password: ${{ secrets.NCP_PASSWORD }}
+          source: "monitoring/**"
+          target: ${{ secrets.NCP_DEPLOY_PATH }}
+
       - name: Deploy on NCP via SSH
         uses: appleboy/ssh-action@v1.0.3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: deploy
 
 on:
-  push:
+  pull_request:
     branches:
       - dev
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -41,6 +41,7 @@
     "passport-jwt": "^4.0.1",
     "passport-kakao": "^1.0.1",
     "pg": "^8.17.1",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,13 +1,19 @@
-import { Module } from '@nestjs/common'
+import { Module, MiddlewareConsumer, NestModule } from '@nestjs/common'
 import { AppController } from './app.controller'
 import { AppService } from './app.service'
 import { BattlesModule } from './battles/battles.module'
 import { ConfigModule } from '@nestjs/config'
 import { OauthModule } from './oauth/oauth.module'
+import { MetricsModule } from './metrics/metrics.module'
+import { HttpMetricsMiddleware } from './metrics/http-metrics.middleware'
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), BattlesModule, OauthModule],
+  imports: [ConfigModule.forRoot({ isGlobal: true }), BattlesModule, OauthModule, MetricsModule],
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(HttpMetricsMiddleware).forRoutes('*')
+  }
+}

--- a/backend/src/battles/battles.module.ts
+++ b/backend/src/battles/battles.module.ts
@@ -6,9 +6,10 @@ import { BattlesService } from './service/battles.service'
 import { AuthService } from './service/auth.service'
 import { PrismaService } from 'src/prisma/prisma.service'
 import { OauthModule } from '../oauth/oauth.module'
+import { MetricsModule } from '../metrics/metrics.module'
 
 @Module({
-  imports: [OauthModule],
+  imports: [OauthModule, MetricsModule],
   controllers: [BattlesController, AuthController],
   providers: [BattlesGateway, BattlesService, PrismaService, AuthService],
   exports: [BattlesService],

--- a/backend/src/battles/gateway/battles.gateway.spec.ts
+++ b/backend/src/battles/gateway/battles.gateway.spec.ts
@@ -13,6 +13,7 @@ import { BattleDiscussion, BattleDefense } from '../types/battles.types'
 import { DiscussionVoteResponseDto } from '../dto/discussionVoteResponse.dto'
 import { BattleUserUpdateResponseDto } from '../dto/battleUserUpdateResponse.dto'
 import { BattleTeamUpdateAllResponseDto } from '../dto/battleTeamUpdateAllResponse.dto'
+import { MetricsService } from '../../metrics/metrics.service'
 
 describe('BattlesGateway - Discussion Events', () => {
   let gateway: BattlesGateway
@@ -34,6 +35,13 @@ describe('BattlesGateway - Discussion Events', () => {
             getBattleRoomId: jest.fn(),
             on: jest.fn(),
             emit: jest.fn(),
+          },
+        },
+        {
+          provide: MetricsService,
+          useValue: {
+            startSocketTimer: jest.fn(() => jest.fn()),
+            setActiveSocketConnections: jest.fn(),
           },
         },
       ],

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -23,6 +23,7 @@ import { BattleClosedResponseDto } from '../dto/battleClosedResponse.dto'
 import { BattleTeamUpdateAllResponseDto } from '../dto/battleTeamUpdateAllResponse.dto'
 import { BattleUserUpdateResponseDto } from '../dto/battleUserUpdateResponse.dto'
 import { BattleStartDto } from '../dto/battleStart.dto'
+import { MetricsService } from '../../metrics/metrics.service'
 
 @WebSocketGateway({
   cors: {
@@ -37,7 +38,10 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
   private readonly logger = new Logger(BattlesGateway.name)
   private readonly userIdToSocketMap = new Map<string, SocketWithUserId>()
 
-  constructor(private readonly battlesService: BattlesService) {}
+  constructor(
+    private readonly battlesService: BattlesService,
+    private readonly metricsService: MetricsService,
+  ) {}
 
   onModuleInit() {
     this.bindBattleEvents()
@@ -64,6 +68,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
       // 인증 성공 시 socket.data.userId에 사용자 정보를 저장
       client.data.userId = userId
       this.userIdToSocketMap.set(userId, client)
+      this.metricsService.setActiveSocketConnections(this.userIdToSocketMap.size)
       this.logger.log(`[소켓 연결] userId: ${userId}`)
     } catch {
       this.logger.error(`[소켓 연결 실패] - ${client.id}`)
@@ -75,6 +80,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     const userId = client.data.userId
     if (userId) {
       this.userIdToSocketMap.delete(userId)
+      this.metricsService.setActiveSocketConnections(this.userIdToSocketMap.size)
       this.logger.log(`[소켓 연결 해제] userId: ${userId}`)
     } else {
       this.logger.log(`[소켓 연결 해제] - ${client.id}`)
@@ -85,6 +91,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
   @SubscribeMessage('battle:join')
   async joinBattle(@MessageBody() battleJoinRequestDto: BattleJoinRequestDto, @ConnectedSocket() client: SocketWithUserId) {
+    const stopTimer = this.metricsService.startSocketTimer('battle:join')
     try {
       const userId = this.getUserIdFromSocket(client)
 
@@ -99,7 +106,9 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
       await client.join(battleTeamRoom)
 
       client.emit('battle:joined', { ...res })
+      stopTimer('success')
     } catch (error) {
+      stopTimer('error')
       if (error instanceof Error) {
         client.emit('battle:join:error', {
           message: error.message,
@@ -121,16 +130,24 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
   @SubscribeMessage('battle:start')
   handleStart(@MessageBody() dto: BattleStartDto) {
-    const { battleId } = dto
-    this.battlesService.startBattle(battleId)
+    const stopTimer = this.metricsService.startSocketTimer('battle:start')
+    try {
+      const { battleId } = dto
+      this.battlesService.startBattle(battleId)
 
-    const battleRoomId = this.battlesService.getBattleRoomId(battleId)
+      const battleRoomId = this.battlesService.getBattleRoomId(battleId)
 
-    this.server.to(battleRoomId).emit('battle:started')
+      this.server.to(battleRoomId).emit('battle:started')
+      stopTimer('success')
+    } catch (error) {
+      stopTimer('error')
+      throw error
+    }
   }
 
   @SubscribeMessage('battle:attack')
   handleAttack(@MessageBody() dto: AttackRequestDto, @ConnectedSocket() client: SocketWithUserId) {
+    const stopTimer = this.metricsService.startSocketTimer('battle:attack')
     try {
       const userId = this.getUserIdFromSocket(client)
       const { battleId, content, team } = dto
@@ -138,7 +155,9 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
       const teamRoom = this.battlesService.getBattleRoomId(battleId, team)
 
       this.server.to(teamRoom).emit('battle:attack:created', attack)
+      stopTimer('success')
     } catch (error) {
+      stopTimer('error')
       if (error instanceof Error) {
         client.emit('battle:attack:error', {
           message: error.message,
@@ -149,6 +168,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
   @SubscribeMessage('battle:defense')
   handleDefense(@MessageBody() dto: DefenseRequestDto, @ConnectedSocket() client: SocketWithUserId) {
+    const stopTimer = this.metricsService.startSocketTimer('battle:defense')
     try {
       const userId = this.getUserIdFromSocket(client)
       const { battleId, content, team } = dto
@@ -156,7 +176,9 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
       const teamRoom = this.battlesService.getBattleRoomId(battleId, team)
 
       this.server.to(teamRoom).emit('battle:defense:created', defense)
+      stopTimer('success')
     } catch (error) {
+      stopTimer('error')
       if (error instanceof Error) {
         client.emit('battle:defense:error', {
           message: error.message,
@@ -167,6 +189,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
   @SubscribeMessage('battle:attack:vote')
   handleAttackVote(@MessageBody() dto: AttackVoteRequestDto, @ConnectedSocket() client: SocketWithUserId) {
+    const stopTimer = this.metricsService.startSocketTimer('battle:attack:vote')
     try {
       const userId = this.getUserIdFromSocket(client)
       const { battleId, discussionId, team } = dto
@@ -177,7 +200,9 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
       updates.forEach(update => {
         this.server.to(teamRoom).emit('battle:attack:voted', update)
       })
+      stopTimer('success')
     } catch (error) {
+      stopTimer('error')
       if (error instanceof Error) {
         client.emit('battle:attack:vote:error', {
           message: error.message,
@@ -188,6 +213,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
   @SubscribeMessage('battle:defense:vote')
   handleDefenseVote(@MessageBody() dto: DefenseVoteRequestDto, @ConnectedSocket() client: SocketWithUserId) {
+    const stopTimer = this.metricsService.startSocketTimer('battle:defense:vote')
     try {
       const userId = this.getUserIdFromSocket(client)
       const { battleId, discussionId, team } = dto
@@ -198,7 +224,9 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
       updates.forEach(update => {
         this.server.to(teamRoom).emit('battle:defense:voted', update)
       })
+      stopTimer('success')
     } catch (error) {
+      stopTimer('error')
       if (error instanceof Error) {
         client.emit('battle:defense:vote:error', {
           message: error.message,
@@ -276,6 +304,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
   @SubscribeMessage('battle:chat')
   handleChat(@MessageBody() battleChatDto: BattleChatDto, @ConnectedSocket() client: SocketWithUserId) {
+    const stopTimer = this.metricsService.startSocketTimer('battle:chat')
     try {
       const userId = this.getUserIdFromSocket(client)
 
@@ -287,7 +316,9 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
       // this.server.to(roomId).emit('battle:chatted', saved)
       this.server.to(roomId).except(client.id).emit('battle:chatted', saved)
+      stopTimer('success')
     } catch (error) {
+      stopTimer('error')
       if (error instanceof Error) {
         client.emit('battle:chat:error', { message: error.message })
       }
@@ -296,11 +327,14 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
 
   @SubscribeMessage('battle:team:vote')
   handleTeamVote(@MessageBody() dto: BattleTeamVoteDto, @ConnectedSocket() client: SocketWithUserId) {
+    const stopTimer = this.metricsService.startSocketTimer('battle:team:vote')
     try {
       const userId = this.getUserIdFromSocket(client)
 
       this.battlesService.voteTeam(dto, userId)
+      stopTimer('success')
     } catch (error) {
+      stopTimer('error')
       if (error instanceof Error) {
         client.emit('battle:team:vote:error', { message: error.message })
       }

--- a/backend/src/metrics/http-metrics.middleware.ts
+++ b/backend/src/metrics/http-metrics.middleware.ts
@@ -1,0 +1,29 @@
+import { Injectable, NestMiddleware } from '@nestjs/common'
+import type { Request, Response, NextFunction } from 'express'
+import { MetricsService } from './metrics.service'
+
+@Injectable()
+export class HttpMetricsMiddleware implements NestMiddleware {
+  constructor(private readonly metricsService: MetricsService) {}
+
+  use(req: Request, res: Response, next: NextFunction) {
+    const start = process.hrtime()
+
+    res.on('finish', () => {
+      const route = (req as { route?: { path?: unknown } }).route
+      const routePath = typeof route?.path === 'string' ? route.path : undefined
+      const baseUrl = req.baseUrl ?? ''
+      const route = routePath ? `${baseUrl}${routePath}` : 'unmatched'
+      const durationSeconds = this.getDurationSeconds(start)
+
+      this.metricsService.observeHttpRequest(req.method, route, res.statusCode, durationSeconds)
+    })
+
+    next()
+  }
+
+  private getDurationSeconds(start: [number, number]) {
+    const diff = process.hrtime(start)
+    return diff[0] + diff[1] / 1e9
+  }
+}

--- a/backend/src/metrics/http-metrics.middleware.ts
+++ b/backend/src/metrics/http-metrics.middleware.ts
@@ -10,13 +10,13 @@ export class HttpMetricsMiddleware implements NestMiddleware {
     const start = process.hrtime()
 
     res.on('finish', () => {
-      const route = (req as { route?: { path?: unknown } }).route
-      const routePath = typeof route?.path === 'string' ? route.path : undefined
+      const routeInfo = (req as { route?: { path?: unknown } }).route
+      const routePath = typeof routeInfo?.path === 'string' ? routeInfo.path : undefined
       const baseUrl = req.baseUrl ?? ''
-      const route = routePath ? `${baseUrl}${routePath}` : 'unmatched'
+      const routeLabel = routePath ? `${baseUrl}${routePath}` : 'unmatched'
       const durationSeconds = this.getDurationSeconds(start)
 
-      this.metricsService.observeHttpRequest(req.method, route, res.statusCode, durationSeconds)
+      this.metricsService.observeHttpRequest(req.method, routeLabel, res.statusCode, durationSeconds)
     })
 
     next()

--- a/backend/src/metrics/metrics.controller.ts
+++ b/backend/src/metrics/metrics.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Res } from '@nestjs/common'
+import type { Response } from 'express'
+import { MetricsService } from './metrics.service'
+
+@Controller('metrics')
+export class MetricsController {
+  constructor(private readonly metricsService: MetricsService) {}
+
+  @Get()
+  async getMetrics(@Res() res: Response) {
+    res.setHeader('Content-Type', this.metricsService.contentType)
+    res.send(await this.metricsService.getMetrics())
+  }
+}

--- a/backend/src/metrics/metrics.module.ts
+++ b/backend/src/metrics/metrics.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { MetricsController } from './metrics.controller'
+import { MetricsService } from './metrics.service'
+
+@Module({
+  controllers: [MetricsController],
+  providers: [MetricsService],
+  exports: [MetricsService],
+})
+export class MetricsModule {}

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -1,0 +1,102 @@
+import { Injectable } from '@nestjs/common'
+import { Registry, collectDefaultMetrics, Counter, Histogram, Gauge } from 'prom-client'
+
+type SocketStatus = 'success' | 'error'
+
+@Injectable()
+export class MetricsService {
+  private readonly registry = new Registry()
+  private readonly httpRequestDuration: Histogram<'method' | 'route' | 'status_code'>
+  private readonly httpRequestCount: Counter<'method' | 'route' | 'status_code'>
+  private readonly socketEventDuration: Histogram<'event' | 'status'>
+  private readonly socketEventCount: Counter<'event' | 'status'>
+  private readonly socketEventErrors: Counter<'event'>
+  private readonly socketActiveConnections: Gauge<'scope'>
+
+  constructor() {
+    collectDefaultMetrics({ register: this.registry })
+
+    this.httpRequestDuration = new Histogram({
+      name: 'http_request_duration_seconds',
+      help: 'HTTP request duration in seconds',
+      labelNames: ['method', 'route', 'status_code'],
+      buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+      registers: [this.registry],
+    })
+
+    this.httpRequestCount = new Counter({
+      name: 'http_requests_total',
+      help: 'Total number of HTTP requests',
+      labelNames: ['method', 'route', 'status_code'],
+      registers: [this.registry],
+    })
+
+    this.socketEventDuration = new Histogram({
+      name: 'socket_event_duration_seconds',
+      help: 'Socket event handling duration in seconds',
+      labelNames: ['event', 'status'],
+      buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2],
+      registers: [this.registry],
+    })
+
+    this.socketEventCount = new Counter({
+      name: 'socket_events_total',
+      help: 'Total number of socket events',
+      labelNames: ['event', 'status'],
+      registers: [this.registry],
+    })
+
+    this.socketEventErrors = new Counter({
+      name: 'socket_event_errors_total',
+      help: 'Total number of socket event errors',
+      labelNames: ['event'],
+      registers: [this.registry],
+    })
+
+    this.socketActiveConnections = new Gauge({
+      name: 'socket_active_connections',
+      help: 'Active socket connections',
+      labelNames: ['scope'],
+      registers: [this.registry],
+    })
+  }
+
+  get contentType() {
+    return this.registry.contentType
+  }
+
+  async getMetrics(): Promise<string> {
+    return this.registry.metrics()
+  }
+
+  observeHttpRequest(method: string, route: string, statusCode: number, durationSeconds: number) {
+    const labels = {
+      method,
+      route,
+      status_code: String(statusCode),
+    }
+    this.httpRequestDuration.observe(labels, durationSeconds)
+    this.httpRequestCount.inc(labels)
+  }
+
+  startSocketTimer(event: string) {
+    const start = process.hrtime()
+    return (status: SocketStatus) => {
+      const durationSeconds = this.getDurationSeconds(start)
+      this.socketEventDuration.observe({ event, status }, durationSeconds)
+      this.socketEventCount.inc({ event, status })
+      if (status === 'error') {
+        this.socketEventErrors.inc({ event })
+      }
+    }
+  }
+
+  setActiveSocketConnections(count: number) {
+    this.socketActiveConnections.set({ scope: 'user' }, count)
+  }
+
+  private getDurationSeconds(start: [number, number]) {
+    const diff = process.hrtime(start)
+    return diff[0] + diff[1] / 1e9
+  }
+}

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -9,6 +9,42 @@ services:
       - '3000:3000'
     restart: unless-stopped
 
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - '9090:9090'
+    depends_on:
+      - backend
+      - cadvisor
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - '3001:3000'
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    ports:
+      - '8080:8080'
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    privileged: true
+    restart: unless-stopped
+
   frontend:
     image: ghcr.io/boostcampwm2025/web02-cmc-frontend:latest
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,13 +13,49 @@ services:
       - "3000:3000"
     restart: unless-stopped
 
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - '9090:9090'
+    depends_on:
+      - backend
+      - cadvisor
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - '3001:3000'
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    ports:
+      - '8080:8080'
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    privileged: true
+    restart: unless-stopped
+
   frontend:
     build:
       context: .
       dockerfile: frontend/Dockerfile
       args:
         # 배포 시 백엔드 도메인/포트로 교체
-        VITE_API_URL: http://49.50.137.2:3000
+        VITE_API_URL: /
     ports:
       - "80:80"
     depends_on:

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'cmc-dashboards'
+    orgId: 1
+    folder: 'CMC'
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/monitoring/grafana/provisioning/dashboards/http-rest.json
+++ b/monitoring/grafana/provisioning/dashboards/http-rest.json
@@ -1,0 +1,94 @@
+{
+  "title": "HTTP REST",
+  "uid": "cmc-http",
+  "tags": ["cmc", "http", "rest"],
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "10s",
+  "templating": {
+    "list": [
+      {
+        "name": "route",
+        "type": "query",
+        "datasource": "Prometheus",
+        "query": "label_values(http_requests_total, route)",
+        "refresh": 2,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Request Rate (RPS) by route/method",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{route=~\"$route\"}[1m])) by (route, method)",
+          "legendFormat": "{{method}} {{route}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "5xx Error Rate by route",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "percent" } },
+      "targets": [
+        {
+          "expr": "100 * sum(rate(http_requests_total{route=~\"$route\", status_code=~\"5..\"}[5m])) by (route) / sum(rate(http_requests_total{route=~\"$route\"}[5m])) by (route)",
+          "legendFormat": "{{route}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "p95 Latency by route/method",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{route=~\"$route\"}[5m])) by (le, route, method))",
+          "legendFormat": "{{method}} {{route}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Average Latency by route/method",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "expr": "sum(rate(http_request_duration_seconds_sum{route=~\"$route\"}[5m])) by (route, method) / sum(rate(http_request_duration_seconds_count{route=~\"$route\"}[5m])) by (route, method)",
+          "legendFormat": "{{method}} {{route}}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "table",
+      "title": "Status Code Breakdown",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 16, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{route=~\"$route\"}[5m])) by (route, method, status_code)",
+          "legendFormat": "{{method}} {{route}} {{status_code}}"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/socket-events.json
+++ b/monitoring/grafana/provisioning/dashboards/socket-events.json
@@ -1,0 +1,95 @@
+{
+  "title": "Socket Events",
+  "uid": "cmc-socket",
+  "tags": ["cmc", "socket"],
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "10s",
+  "templating": {
+    "list": [
+      {
+        "name": "event",
+        "type": "query",
+        "datasource": "Prometheus",
+        "query": "label_values(socket_events_total, event)",
+        "refresh": 2,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Event Rate by status",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "ops" } },
+      "targets": [
+        {
+          "expr": "sum(rate(socket_events_total{event=~\"$event\"}[1m])) by (event, status)",
+          "legendFormat": "{{event}} {{status}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "p95 Handling Time by event",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(socket_event_duration_seconds_bucket{event=~\"$event\"}[5m])) by (le, event))",
+          "legendFormat": "{{event}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Average Handling Time by event/status",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "expr": "sum(rate(socket_event_duration_seconds_sum{event=~\"$event\"}[5m])) by (event, status) / sum(rate(socket_event_duration_seconds_count{event=~\"$event\"}[5m])) by (event, status)",
+          "legendFormat": "{{event}} {{status}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Socket Errors by event",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "ops" } },
+      "targets": [
+        {
+          "expr": "sum(rate(socket_event_errors_total{event=~\"$event\"}[5m])) by (event)",
+          "legendFormat": "{{event}}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Active Socket Connections",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 16, "w": 24, "h": 4 },
+      "fieldConfig": { "defaults": { "unit": "none", "decimals": 0 } },
+      "targets": [
+        {
+          "expr": "socket_active_connections",
+          "legendFormat": "connections"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/system-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/system-overview.json
@@ -1,0 +1,85 @@
+{
+  "title": "System & Containers",
+  "uid": "cmc-system",
+  "tags": ["cmc", "system", "cadvisor"],
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "10s",
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": "Prometheus",
+        "query": "label_values(container_cpu_usage_seconds_total{job=\"cadvisor\"}, container_label_com_docker_compose_service)",
+        "refresh": 2,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "CPU Usage (cores) by service",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "cores" } },
+      "targets": [
+        {
+          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"cadvisor\", container_label_com_docker_compose_service=~\"$service\", image!=\"\"}[1m])) by (container_label_com_docker_compose_service)",
+          "legendFormat": "{{container_label_com_docker_compose_service}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Memory Working Set by service",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "targets": [
+        {
+          "expr": "sum(container_memory_working_set_bytes{job=\"cadvisor\", container_label_com_docker_compose_service=~\"$service\", image!=\"\"}) by (container_label_com_docker_compose_service)",
+          "legendFormat": "{{container_label_com_docker_compose_service}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Network RX/TX by service",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "Bps" } },
+      "targets": [
+        {
+          "expr": "sum(rate(container_network_receive_bytes_total{job=\"cadvisor\", container_label_com_docker_compose_service=~\"$service\"}[1m])) by (container_label_com_docker_compose_service)",
+          "legendFormat": "RX {{container_label_com_docker_compose_service}}"
+        },
+        {
+          "expr": "sum(rate(container_network_transmit_bytes_total{job=\"cadvisor\", container_label_com_docker_compose_service=~\"$service\"}[1m])) by (container_label_com_docker_compose_service)",
+          "legendFormat": "TX {{container_label_com_docker_compose_service}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Filesystem Usage by service",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "targets": [
+        {
+          "expr": "sum(container_fs_usage_bytes{job=\"cadvisor\", container_label_com_docker_compose_service=~\"$service\", image!=\"\"}) by (container_label_com_docker_compose_service)",
+          "legendFormat": "{{container_label_com_docker_compose_service}}"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/system-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/system-overview.json
@@ -9,10 +9,10 @@
   "templating": {
     "list": [
       {
-        "name": "service",
+        "name": "container_id",
         "type": "query",
         "datasource": "Prometheus",
-        "query": "label_values(container_cpu_usage_seconds_total{job=\"cadvisor\"}, container_label_com_docker_compose_service)",
+        "query": "label_values(container_cpu_usage_seconds_total{job=\"cadvisor\"}, id)",
         "refresh": 2,
         "includeAll": true,
         "allValue": ".*",
@@ -24,60 +24,60 @@
     {
       "id": 1,
       "type": "timeseries",
-      "title": "CPU Usage (cores) by service",
+      "title": "CPU Usage (cores) by container",
       "datasource": "Prometheus",
       "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
       "fieldConfig": { "defaults": { "unit": "cores" } },
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"cadvisor\", container_label_com_docker_compose_service=~\"$service\", image!=\"\"}[1m])) by (container_label_com_docker_compose_service)",
-          "legendFormat": "{{container_label_com_docker_compose_service}}"
+          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"cadvisor\", id=~\"$container_id\"}[1m])) by (id)",
+          "legendFormat": "{{id}}"
         }
       ]
     },
     {
       "id": 2,
       "type": "timeseries",
-      "title": "Memory Working Set by service",
+      "title": "Memory Working Set by container",
       "datasource": "Prometheus",
       "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
       "fieldConfig": { "defaults": { "unit": "bytes" } },
       "targets": [
         {
-          "expr": "sum(container_memory_working_set_bytes{job=\"cadvisor\", container_label_com_docker_compose_service=~\"$service\", image!=\"\"}) by (container_label_com_docker_compose_service)",
-          "legendFormat": "{{container_label_com_docker_compose_service}}"
+          "expr": "sum(container_memory_working_set_bytes{job=\"cadvisor\", id=~\"$container_id\"}) by (id)",
+          "legendFormat": "{{id}}"
         }
       ]
     },
     {
       "id": 3,
       "type": "timeseries",
-      "title": "Network RX/TX by service",
+      "title": "Network RX/TX by container",
       "datasource": "Prometheus",
       "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
       "fieldConfig": { "defaults": { "unit": "Bps" } },
       "targets": [
         {
-          "expr": "sum(rate(container_network_receive_bytes_total{job=\"cadvisor\", container_label_com_docker_compose_service=~\"$service\"}[1m])) by (container_label_com_docker_compose_service)",
-          "legendFormat": "RX {{container_label_com_docker_compose_service}}"
+          "expr": "sum(rate(container_network_receive_bytes_total{job=\"cadvisor\", id=~\"$container_id\"}[1m])) by (id)",
+          "legendFormat": "RX {{id}}"
         },
         {
-          "expr": "sum(rate(container_network_transmit_bytes_total{job=\"cadvisor\", container_label_com_docker_compose_service=~\"$service\"}[1m])) by (container_label_com_docker_compose_service)",
-          "legendFormat": "TX {{container_label_com_docker_compose_service}}"
+          "expr": "sum(rate(container_network_transmit_bytes_total{job=\"cadvisor\", id=~\"$container_id\"}[1m])) by (id)",
+          "legendFormat": "TX {{id}}"
         }
       ]
     },
     {
       "id": 4,
       "type": "timeseries",
-      "title": "Filesystem Usage by service",
+      "title": "Filesystem Usage by container",
       "datasource": "Prometheus",
       "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
       "fieldConfig": { "defaults": { "unit": "bytes" } },
       "targets": [
         {
-          "expr": "sum(container_fs_usage_bytes{job=\"cadvisor\", container_label_com_docker_compose_service=~\"$service\", image!=\"\"}) by (container_label_com_docker_compose_service)",
-          "legendFormat": "{{container_label_com_docker_compose_service}}"
+          "expr": "sum(container_fs_usage_bytes{job=\"cadvisor\", id=~\"$container_id\"}) by (id)",
+          "legendFormat": "{{id}}"
         }
       ]
     }

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,16 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['prometheus:9090']
+
+  - job_name: 'backend'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['backend:3000']
+
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['cadvisor:8080']

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       pg:
         specifier: ^8.17.1
         version: 8.17.1
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -291,7 +294,7 @@ importers:
         version: 3.5.0(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@24.10.4)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
 
 packages:
 
@@ -1215,6 +1218,10 @@ packages:
     resolution: {integrity: sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==}
     engines: {node: ^14.18.0 || >=16.10.0, npm: '>=5.10.0'}
     hasBin: true
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -2383,6 +2390,9 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -4344,8 +4354,14 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+<<<<<<< HEAD
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+=======
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+>>>>>>> 7f1600a (devops: 의존성 추가)
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
@@ -4797,6 +4813,9 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   terser-webpack-plugin@5.3.16:
     resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
@@ -6354,6 +6373,8 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -7525,6 +7546,8 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  bintrees@1.0.2: {}
 
   bl@4.1.0:
     dependencies:
@@ -9652,11 +9675,18 @@ snapshots:
 
   prismjs@1.30.0: {}
 
+<<<<<<< HEAD
   proper-lockfile@4.1.2:
     dependencies:
       graceful-fs: 4.2.11
       retry: 0.12.0
       signal-exit: 3.0.7
+=======
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      tdigest: 0.1.2
+>>>>>>> 7f1600a (devops: 의존성 추가)
 
   property-information@7.1.0: {}
 
@@ -10168,7 +10198,15 @@ snapshots:
 
   tapable@2.3.0: {}
 
+<<<<<<< HEAD
   terser-webpack-plugin@5.3.16(@swc/core@1.15.10)(webpack@5.103.0(@swc/core@1.15.10)):
+=======
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
+
+  terser-webpack-plugin@5.3.16(webpack@5.103.0):
+>>>>>>> 7f1600a (devops: 의존성 추가)
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -10479,7 +10517,7 @@ snapshots:
       terser: 5.44.1
       yaml: 2.8.2
 
-  vitest@4.0.16(@types/node@24.10.4)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2):
+  vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.16
       '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
@@ -10502,6 +10540,7 @@ snapshots:
       vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 24.10.4
       jsdom: 27.4.0
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4354,14 +4354,12 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
-<<<<<<< HEAD
-  proper-lockfile@4.1.2:
-    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
-=======
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
->>>>>>> 7f1600a (devops: 의존성 추가)
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
@@ -9675,18 +9673,16 @@ snapshots:
 
   prismjs@1.30.0: {}
 
-<<<<<<< HEAD
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      tdigest: 0.1.2
+
   proper-lockfile@4.1.2:
     dependencies:
       graceful-fs: 4.2.11
       retry: 0.12.0
       signal-exit: 3.0.7
-=======
-  prom-client@15.1.3:
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      tdigest: 0.1.2
->>>>>>> 7f1600a (devops: 의존성 추가)
 
   property-information@7.1.0: {}
 
@@ -10198,15 +10194,11 @@ snapshots:
 
   tapable@2.3.0: {}
 
-<<<<<<< HEAD
-  terser-webpack-plugin@5.3.16(@swc/core@1.15.10)(webpack@5.103.0(@swc/core@1.15.10)):
-=======
   tdigest@0.1.2:
     dependencies:
       bintrees: 1.0.2
 
-  terser-webpack-plugin@5.3.16(webpack@5.103.0):
->>>>>>> 7f1600a (devops: 의존성 추가)
+  terser-webpack-plugin@5.3.16(@swc/core@1.15.10)(webpack@5.103.0(@swc/core@1.15.10)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->
Closes  #203 
## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<img width="807" height="608" alt="image" src="https://github.com/user-attachments/assets/3294f1e1-f00a-4c3d-8eeb-30cf304ee029" />


  - Prometheus/Grafana/cAdvisor 모니터링 스택 추가
      - docker-compose.yml, docker-compose-prod.yml에 Prometheus/Grafana/cAdvisor 서비스 추가
      - Prometheus 설정(monitoring/prometheus.yml) / Grafana 데이터소스 프로비저닝(monitoring/grafana/provisioning/...) 구성
  - 백엔드 메트릭 수집 추가
      - /metrics 엔드포인트를 추가해 Prometheus 스크랩 가능
      - HTTP 요청 메트릭: 라우트/상태 코드 기준 요청 수와 지연 시간 히스토그램 기록
      - Socket 이벤트 메트릭: 이벤트별 처리 시간, 건수, 에러 카운트 기록
      - 활성 소켓 연결 수 기록
  - 서비스 연결 및 전역 적용
      - AppModule에 MetricsModule 추가
      - 전역 미들웨어로 HTTP 메트릭 수집 적용
      - BattlesGateway에서 MetricsService를 주입받아 소켓 이벤트 기록



### 대시보드 구성
<img width="1276" height="667" alt="Screenshot 2026-01-23 at 3 33 13 AM" src="https://github.com/user-attachments/assets/d04a59a0-6206-4c77-8145-4a61e6ad7d52" />
<img width="1269" height="970" alt="Screenshot 2026-01-23 at 3 33 34 AM" src="https://github.com/user-attachments/assets/d955d3a8-cb68-4eb1-a79b-468e4715e234" />
<img width="1273" height="810" alt="Screenshot 2026-01-23 at 3 35 42 AM" src="https://github.com/user-attachments/assets/ab7502b9-b9de-4d2c-9fd4-43477c354df5" />



<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->
  - /metrics는 Prometheus 포맷으로 노출
  - 소켓 기록은 backend/src/battles/gateway/battles.gateway.ts에서 battle: 이벤트 기준으로 기록
  - Grafana 기본 계정: admin/admin, 포트 3001
  - Prometheus 포트: 9090, cAdvisor 포트: 8080
<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
