### PR TITLE
[Feature] 배틀 결과 페이지에 MVP 표시 기능 추가

### DIFF
--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -1086,6 +1086,16 @@ export class BattlesService extends EventEmitter {
   private resetDiscussions(battleId: string) {
     const battleState = this.getBattleState(battleId)
 
+    // MVP 계산을 위해 모든 의견을 all에 누적 저장 (이미 all에 있는 의견 제외)
+    const existingAttackIds = new Set(battleState.all.attacks.map(a => a?.discussionId))
+    const existingDefenseIds = new Set(battleState.all.defenses.map(d => d?.discussionId))
+
+    const newAttacks = [...battleState.teamA.attacks, ...battleState.teamB.attacks].filter(a => a && !existingAttackIds.has(a.discussionId))
+    const newDefenses = [...battleState.teamA.defenses, ...battleState.teamB.defenses].filter(d => d && !existingDefenseIds.has(d.discussionId))
+
+    battleState.all.attacks.push(...newAttacks)
+    battleState.all.defenses.push(...newDefenses)
+
     battleState.teamA.attacks = []
     battleState.teamB.attacks = []
     battleState.teamA.defenses = []

--- a/frontend/public/mvp-pattern.svg
+++ b/frontend/public/mvp-pattern.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <defs>
+    <pattern id="mvp-pattern" x="0" y="0" width="100" height="100" patternUnits="userSpaceOnUse">
+      <path d="M0 50 Q 25 25, 50 50 T 100 50" fill="none" stroke="white" stroke-width="2" opacity="0.3" />
+      <path d="M0 70 Q 25 45, 50 70 T 100 70" fill="none" stroke="white" stroke-width="2" opacity="0.2" />
+      <circle cx="20" cy="30" r="3" fill="white" opacity="0.2" />
+      <circle cx="60" cy="80" r="4" fill="white" opacity="0.15" />
+      <circle cx="85" cy="45" r="2" fill="white" opacity="0.25" />
+      <circle cx="40" cy="60" r="3" fill="white" opacity="0.2" />
+    </pattern>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#mvp-pattern)" />
+</svg>

--- a/frontend/src/pages/battleResultPage/components/MvpCard.tsx
+++ b/frontend/src/pages/battleResultPage/components/MvpCard.tsx
@@ -13,28 +13,16 @@ export default function MvpCard({ mvpList, bestOpinion }: MvpCardProps) {
   if (!mvp) return null;
   return (
     <div className="rounded-xl overflow-hidden relative shadow-2xl h-full">
-      {/* Orange Gradient Background with Pattern */}
+      {/* 오렌지 그라데이션 배경 및 패턴 */}
       <div className="absolute inset-0 bg-gradient-to-br from-orange-600 via-orange-500 to-orange-400">
-        {/* Shine Animation Overlay */}
+        {/* 빛나는 애니메이션 오버레이 */}
         <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent animate-shine"></div>
 
-        {/* Pattern Overlay */}
-        <svg className="absolute inset-0 w-full h-full opacity-10" xmlns="http://www.w3.org/2000/svg">
-          <defs>
-            <pattern id="mvp-pattern" x="0" y="0" width="100" height="100" patternUnits="userSpaceOnUse">
-              <path d="M0 50 Q 25 25, 50 50 T 100 50" fill="none" stroke="white" strokeWidth="2" opacity="0.3" />
-              <path d="M0 70 Q 25 45, 50 70 T 100 70" fill="none" stroke="white" strokeWidth="2" opacity="0.2" />
-              <circle cx="20" cy="30" r="3" fill="white" opacity="0.2" />
-              <circle cx="60" cy="80" r="4" fill="white" opacity="0.15" />
-              <circle cx="85" cy="45" r="2" fill="white" opacity="0.25" />
-              <circle cx="40" cy="60" r="3" fill="white" opacity="0.2" />
-            </pattern>
-          </defs>
-          <rect width="100%" height="100%" fill="url(#mvp-pattern)" />
-        </svg>
+        {/* 패턴 오버레이 */}
+        <img src="/mvp-pattern.svg" className="absolute inset-0 w-full h-full opacity-10 object-cover" alt="" />
       </div>
 
-      {/* Content */}
+      {/* 컨텐츠 */}
       <div className="relative z-10 p-6">
         <div className="flex items-center gap-2 mb-4">
           <div className="w-2 h-2 bg-yellow-300 rounded-full"></div>
@@ -42,7 +30,7 @@ export default function MvpCard({ mvpList, bestOpinion }: MvpCardProps) {
         </div>
 
         <div className="flex flex-col items-center text-center gap-4">
-          {/* MVP Icon and Badge */}
+          {/* MVP 아이콘 및 뱃지 */}
           <div className="relative">
             <div className="bg-white/20 backdrop-blur-sm p-5 rounded-2xl border-2 border-white/30">
               <Crown className="w-12 h-12 text-yellow-300" />
@@ -52,7 +40,7 @@ export default function MvpCard({ mvpList, bestOpinion }: MvpCardProps) {
             </div>
           </div>
 
-          {/* MVP Info */}
+          {/* MVP 정보 */}
           <div className="w-full">
             <div className="inline-block px-3 py-1 bg-black/30 backdrop-blur-sm rounded-full text-white text-xs mb-2 border border-white/20">
               최고의 전략가
@@ -70,7 +58,7 @@ export default function MvpCard({ mvpList, bestOpinion }: MvpCardProps) {
               </div>
             </div>
 
-            {/* Best Opinion */}
+            {/* 최고 의견 */}
             {bestOpinion && (
               <div className="bg-black/20 backdrop-blur-sm rounded-xl p-4 border border-white/20">
                 <div className="flex items-start gap-2 mb-2">
@@ -88,7 +76,7 @@ export default function MvpCard({ mvpList, bestOpinion }: MvpCardProps) {
               </div>
             )}
 
-            {/* MVP Stats */}
+            {/* MVP 통계 */}
             <div className="mt-4 grid grid-cols-2 gap-2">
               <div className="bg-black/20 backdrop-blur-sm rounded-lg p-2 border border-white/10">
                 <div className="text-white/70 text-xs">총 좋아요</div>

--- a/frontend/src/pages/battleResultPage/components/MvpCard.tsx
+++ b/frontend/src/pages/battleResultPage/components/MvpCard.tsx
@@ -1,0 +1,103 @@
+import { Crown, Award, ThumbsUp } from 'lucide-react';
+import type { Mvp, TimelineItem } from '../types';
+
+interface MvpCardProps {
+  mvp: Mvp;
+  bestOpinion: TimelineItem | null;
+}
+
+export default function MvpCard({ mvp, bestOpinion }: MvpCardProps) {
+  return (
+    <div className="rounded-xl overflow-hidden relative shadow-2xl h-full">
+      {/* Orange Gradient Background with Pattern */}
+      <div className="absolute inset-0 bg-gradient-to-br from-orange-600 via-orange-500 to-orange-400">
+        {/* Shine Animation Overlay */}
+        <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent animate-shine"></div>
+
+        {/* Pattern Overlay */}
+        <svg className="absolute inset-0 w-full h-full opacity-10" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <pattern id="mvp-pattern" x="0" y="0" width="100" height="100" patternUnits="userSpaceOnUse">
+              <path d="M0 50 Q 25 25, 50 50 T 100 50" fill="none" stroke="white" strokeWidth="2" opacity="0.3" />
+              <path d="M0 70 Q 25 45, 50 70 T 100 70" fill="none" stroke="white" strokeWidth="2" opacity="0.2" />
+              <circle cx="20" cy="30" r="3" fill="white" opacity="0.2" />
+              <circle cx="60" cy="80" r="4" fill="white" opacity="0.15" />
+              <circle cx="85" cy="45" r="2" fill="white" opacity="0.25" />
+              <circle cx="40" cy="60" r="3" fill="white" opacity="0.2" />
+            </pattern>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#mvp-pattern)" />
+        </svg>
+      </div>
+
+      {/* Content */}
+      <div className="relative z-10 p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <div className="w-2 h-2 bg-yellow-300 rounded-full"></div>
+          <h3 className="text-white font-bold">MVP</h3>
+        </div>
+
+        <div className="flex flex-col items-center text-center gap-4">
+          {/* MVP Icon and Badge */}
+          <div className="relative">
+            <div className="bg-white/20 backdrop-blur-sm p-5 rounded-2xl border-2 border-white/30">
+              <Crown className="w-12 h-12 text-yellow-300" />
+            </div>
+            <div className="absolute -top-2 -right-2 bg-yellow-400 text-orange-900 px-2.5 py-0.5 rounded-full text-xs font-bold border-2 border-white shadow-lg">
+              MVP
+            </div>
+          </div>
+
+          {/* MVP Info */}
+          <div className="w-full">
+            <div className="inline-block px-3 py-1 bg-black/30 backdrop-blur-sm rounded-full text-white text-xs mb-2 border border-white/20">
+              최고의 전략가
+            </div>
+            <div className="flex items-center justify-center gap-2 mb-3">
+              <h4 className="text-2xl font-bold text-white">{mvp.nickname}</h4>
+              <div
+                className={`px-2 py-0.5 rounded-full text-xs font-bold ${
+                  mvp.team === 'A'
+                    ? 'bg-blue-500/30 text-blue-200 border border-blue-400/50'
+                    : 'bg-red-500/30 text-red-200 border border-red-400/50'
+                }`}
+              >
+                {mvp.team === 'A' ? '코드 A' : '코드 B'}팀
+              </div>
+            </div>
+
+            {/* Best Opinion */}
+            {bestOpinion && (
+              <div className="bg-black/20 backdrop-blur-sm rounded-xl p-4 border border-white/20">
+                <div className="flex items-start gap-2 mb-2">
+                  <Award className="w-4 h-4 text-yellow-300 flex-shrink-0 mt-1" />
+                  <div className="flex-1 text-left">
+                    <div className="text-white/90 text-xs font-medium mb-1">가장 많은 좋아요를 받은 의견</div>
+                    <p className="text-white text-sm leading-relaxed">{bestOpinion.content}</p>
+                  </div>
+                </div>
+                <div className="flex items-center justify-end gap-2 mt-3 pt-3 border-t border-white/10">
+                  <ThumbsUp className="w-4 h-4 text-yellow-300" />
+                  <span className="text-xl font-bold text-white">{bestOpinion.upvotes}</span>
+                  <span className="text-white/80 text-sm">좋아요</span>
+                </div>
+              </div>
+            )}
+
+            {/* MVP Stats */}
+            <div className="mt-4 grid grid-cols-2 gap-2">
+              <div className="bg-black/20 backdrop-blur-sm rounded-lg p-2 border border-white/10">
+                <div className="text-white/70 text-xs">총 좋아요</div>
+                <div className="text-white font-bold">{mvp.totalVotes}</div>
+              </div>
+              <div className="bg-black/20 backdrop-blur-sm rounded-lg p-2 border border-white/10">
+                <div className="text-white/70 text-xs">제출 의견</div>
+                <div className="text-white font-bold">{mvp.opinionCount}개</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/battleResultPage/components/MvpCard.tsx
+++ b/frontend/src/pages/battleResultPage/components/MvpCard.tsx
@@ -1,12 +1,16 @@
-import { Crown, Award, ThumbsUp } from 'lucide-react';
+import { Crown, Award, ThumbsUp, Medal } from 'lucide-react';
 import type { Mvp, TimelineItem } from '../types';
 
 interface MvpCardProps {
-  mvp: Mvp;
+  mvpList: Mvp[];
   bestOpinion: TimelineItem | null;
 }
 
-export default function MvpCard({ mvp, bestOpinion }: MvpCardProps) {
+export default function MvpCard({ mvpList, bestOpinion }: MvpCardProps) {
+  const mvp = mvpList[0];
+  const runners = mvpList.slice(1);
+
+  if (!mvp) return null;
   return (
     <div className="rounded-xl overflow-hidden relative shadow-2xl h-full">
       {/* Orange Gradient Background with Pattern */}
@@ -95,6 +99,30 @@ export default function MvpCard({ mvp, bestOpinion }: MvpCardProps) {
                 <div className="text-white font-bold">{mvp.opinionCount}개</div>
               </div>
             </div>
+
+            {/* 2등, 3등 표시 */}
+            {runners.length > 0 && (
+              <div className="mt-4 pt-4 border-t border-white/20">
+                <div className="flex flex-col gap-2">
+                  {runners.map((runner, index) => (
+                    <div
+                      key={runner.userId}
+                      className="flex items-center justify-between bg-black/10 rounded-lg px-3 py-2"
+                    >
+                      <div className="flex items-center gap-2">
+                        <Medal className={`w-4 h-4 ${index === 0 ? 'text-gray-300' : 'text-amber-600'}`} />
+                        <span className="text-white/80 text-sm">{index + 2}등</span>
+                        <span className="text-white font-medium">{runner.nickname}</span>
+                      </div>
+                      <div className="flex items-center gap-3 text-xs text-white/70">
+                        <span>총 좋아요 {runner.totalVotes}</span>
+                        <span>제출 의견 {runner.opinionCount}개</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/battleResultPage/index.tsx
+++ b/frontend/src/pages/battleResultPage/index.tsx
@@ -28,8 +28,9 @@ export default function BattleResultPage() {
   }, [id]);
 
   const bestOpinion = useMemo(() => {
-    if (!battleData?.mvp || !battleData.timeline.length) return null;
-    const mvpOpinions = battleData.timeline.filter((item) => item.author.id === battleData.mvp?.userId);
+    if (!battleData?.mvps?.length || !battleData.timeline.length) return null;
+    const topMvp = battleData.mvps[0];
+    const mvpOpinions = battleData.timeline.filter((item) => item.author.id === topMvp.userId);
     if (!mvpOpinions.length) return null;
     return mvpOpinions.reduce((max, current) => (current.upvotes > max.upvotes ? current : max), mvpOpinions[0]);
   }, [battleData]);
@@ -67,8 +68,8 @@ export default function BattleResultPage() {
           neutralPercentage={result.neutral.percentage}
           neutralVotes={result.neutral.votes}
         />
-        {battleData.mvp ? (
-          <MvpCard mvp={battleData.mvp} bestOpinion={bestOpinion} />
+        {battleData.mvps.length > 0 ? (
+          <MvpCard mvpList={battleData.mvps} bestOpinion={bestOpinion} />
         ) : (
           <MetricsCards
             totalParticipants={battleData.metrics.totalParticipants}

--- a/frontend/src/pages/battleResultPage/index.tsx
+++ b/frontend/src/pages/battleResultPage/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import TrophyIcon from '@/assets/icon/trophy.svg?react';
 import WinnerSection from './components/WinnerSection';
@@ -6,6 +6,7 @@ import VoteChart from './components/VoteChartSector';
 import MetricsCards from './components/MetricsCards';
 import CodeViewerSection from './components/CodeViewerSection';
 import TimelineSection from './components/TimelineSection';
+import MvpCard from './components/MvpCard';
 import { Trophy, Activity } from 'lucide-react';
 import { getBattleResult } from './apis/getBattleResult';
 import type { BattleResultApiResponse } from './types';
@@ -25,6 +26,13 @@ export default function BattleResultPage() {
 
     fetchBattleResult();
   }, [id]);
+
+  const bestOpinion = useMemo(() => {
+    if (!battleData?.mvp || !battleData.timeline.length) return null;
+    const mvpOpinions = battleData.timeline.filter((item) => item.author.id === battleData.mvp?.userId);
+    if (!mvpOpinions.length) return null;
+    return mvpOpinions.reduce((max, current) => (current.upvotes > max.upvotes ? current : max), mvpOpinions[0]);
+  }, [battleData]);
 
   if (!battleData) {
     return <div>로딩 중...</div>;
@@ -50,24 +58,24 @@ export default function BattleResultPage() {
         teamBVotes={result.teamB.votes}
       />
 
-      <div className="max-w-7xl mx-auto mb-12 flex gap-6 items-stretch">
-        <div className="flex-1">
-          <VoteChart
-            teamAPercentage={result.teamA.percentage}
-            teamAVotes={result.teamA.votes}
-            teamBPercentage={result.teamB.percentage}
-            teamBVotes={result.teamB.votes}
-            neutralPercentage={result.neutral.percentage}
-            neutralVotes={result.neutral.votes}
-          />
-        </div>
-        <div className="flex-1">
+      <div className="max-w-7xl mx-auto mb-12 grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <VoteChart
+          teamAPercentage={result.teamA.percentage}
+          teamAVotes={result.teamA.votes}
+          teamBPercentage={result.teamB.percentage}
+          teamBVotes={result.teamB.votes}
+          neutralPercentage={result.neutral.percentage}
+          neutralVotes={result.neutral.votes}
+        />
+        {battleData.mvp ? (
+          <MvpCard mvp={battleData.mvp} bestOpinion={bestOpinion} />
+        ) : (
           <MetricsCards
             totalParticipants={battleData.metrics.totalParticipants}
             totalViews={battleData.metrics.totalViews}
             strategiesCount={battleData.metrics.strategiesCount}
           />
-        </div>
+        )}
       </div>
 
       <CodeViewerSection

--- a/frontend/src/pages/battleResultPage/types/index.ts
+++ b/frontend/src/pages/battleResultPage/types/index.ts
@@ -44,6 +44,17 @@ export interface TimelineItem {
   createdAt: string;
 }
 
+export interface Mvp {
+  userId: string;
+  nickname: string;
+  team: Exclude<Team, 'NONE'>;
+  score: number;
+  totalVotes: number;
+  opinionCount: number;
+  selectedOpinionCount: number;
+  joinedAt: number;
+}
+
 export interface BattleResultApiResponse {
   battleId: string;
   author: string;
@@ -63,4 +74,5 @@ export interface BattleResultApiResponse {
   voteTimeline: VoteTimelineItem[];
   timeline: TimelineItem[];
   topics: string[];
+  mvp: Mvp | null;
 }

--- a/frontend/src/pages/battleResultPage/types/index.ts
+++ b/frontend/src/pages/battleResultPage/types/index.ts
@@ -74,5 +74,5 @@ export interface BattleResultApiResponse {
   voteTimeline: VoteTimelineItem[];
   timeline: TimelineItem[];
   topics: string[];
-  mvp: Mvp | null;
+  mvps: Mvp[];
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #199, Relates to #193

## ✅ 작업 내용

### 💡개선 사항

**프론트엔드**
- 배틀 결과 페이지 MVP 카드 컴포넌트 구현
- MVP 1등: 닉네임, 팀, 가장 많은 좋아요를 받은 의견, 총 좋아요/제출 의견 수 표시
- MVP 2등, 3등: 닉네임, 총 좋아요/제출 의견 수 표시
- 프론트엔드 타입 `mvp: Mvp | null` → `mvps: Mvp[]` 배열로 변경

<br />

## 📸 참고 사항

**주요 파일**
- `frontend/src/pages/battleResultPage/components/MvpCard.tsx` - MVP 카드 UI
- `frontend/src/pages/battleResultPage/types/index.ts` - 프론트엔드 타입 정의

**발견된 버그**
- `opinionCount`, `totalVotes`가 0으로 표시되는 문제 발견 - 별도 fix 이슈로 처리 예정

<br />

## 💬 질문사항 (고민했던 부분)