### PR TITLE
[Feature] in-memory 저장구조에서 DB로 전환한다.

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,10 +14,10 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test": "pnpm prisma:generate && jest",
+    "test:watch": "pnpm prisma:generate && jest --watch",
+    "test:cov": "pnpm prisma:generate && jest --coverage",
+    "test:debug": "pnpm prisma:generate && node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "prisma:generate": "npx prisma generate"
   },
@@ -95,6 +95,13 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1",
+      "^generated/prisma/(.*)$": "<rootDir>/../generated/prisma/$1.ts",
+      "^generated/prisma/(.*)\\.js$": "<rootDir>/../generated/prisma/$1.ts",
+      "^\\.\\/internal\\/(.*)\\.js$": "<rootDir>/../generated/prisma/internal/$1.ts",
+      "^\\.\\/enums\\.js$": "<rootDir>/../generated/prisma/enums.ts"
+    }
   }
 }

--- a/backend/prisma/migrations/20260121181910_add_active_state/migration.sql
+++ b/backend/prisma/migrations/20260121181910_add_active_state/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "battles" ADD COLUMN     "active_state" JSONB;

--- a/backend/prisma/migrations/20260122092555_battle_state_columns/migration.sql
+++ b/backend/prisma/migrations/20260122092555_battle_state_columns/migration.sql
@@ -1,0 +1,22 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `active_state` on the `battles` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "battles" DROP COLUMN "active_state",
+ADD COLUMN     "attacks_state" JSONB,
+ADD COLUMN     "chats_all_state" JSONB,
+ADD COLUMN     "chats_team_a_state" JSONB,
+ADD COLUMN     "chats_team_b_state" JSONB,
+ADD COLUMN     "current_phase" VARCHAR(20),
+ADD COLUMN     "current_round" INTEGER,
+ADD COLUMN     "defenses_state" JSONB,
+ADD COLUMN     "expired_at" TIMESTAMP(3),
+ADD COLUMN     "opinion_history_state" JSONB,
+ADD COLUMN     "participants_state" JSONB,
+ADD COLUMN     "phase_count" INTEGER,
+ADD COLUMN     "started_at" TIMESTAMP(3),
+ADD COLUMN     "team_votes_state" JSONB,
+ADD COLUMN     "user_info_state" JSONB;

--- a/backend/prisma/migrations/20260126055411_add_mvps_state/migration.sql
+++ b/backend/prisma/migrations/20260126055411_add_mvps_state/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "battles" ADD COLUMN     "mvps_state" JSONB;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -60,6 +60,7 @@ model Battle {
   totalParticipantsCount   Int?       @map("total_participants_count")
   winningTeam              String?    @db.VarChar(10) @map("winning_team")
   mvps                     String[]   @db.VarChar(10)
+  mvpsState                Json?      @map("mvps_state")
     
   /* 시간 */
   createdAt                DateTime   @default(now()) @map("created_at")

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -65,6 +65,21 @@ model Battle {
   createdAt                DateTime   @default(now()) @map("created_at")
   updatedAt                DateTime?  @updatedAt  @map("updated_at")
   finishedAt               DateTime?  @map("finished_at")
+  currentRound             Int?       @map("current_round")
+  currentPhase             String?    @db.VarChar(20) @map("current_phase")
+  phaseCount               Int?       @map("phase_count")
+  startedAt                DateTime?  @map("started_at")
+  expiredAt                DateTime?  @map("expired_at")
+
+  participantsState        Json?      @map("participants_state")
+  teamVotesState           Json?      @map("team_votes_state")
+  userInfoState            Json?      @map("user_info_state")
+  attacksState             Json?      @map("attacks_state")
+  defensesState            Json?      @map("defenses_state")
+  opinionHistoryState      Json?      @map("opinion_history_state")
+  chatsAllState            Json?      @map("chats_all_state")
+  chatsTeamAState          Json?      @map("chats_team_a_state")
+  chatsTeamBState          Json?      @map("chats_team_b_state")
 
   creator                  User?      @relation("BattleCreator", fields: [userId], references: [id])
   participants             BattleParticipant[]

--- a/backend/src/battles/controller/auth.controller.spec.ts
+++ b/backend/src/battles/controller/auth.controller.spec.ts
@@ -64,11 +64,11 @@ describe('AuthController', () => {
     }
 
     beforeEach(() => {
-      mockBattlesService.getBattleState.mockReturnValue(mockBattleState)
+      mockBattlesService.getBattleState.mockResolvedValue({ battleState: mockBattleState })
       mockOauthService.isNicknameExists.mockReturnValue(false)
     })
 
-    it('정상적으로 Guest를 생성한다', () => {
+    it('정상적으로 Guest를 생성한다', async () => {
       const mockNickname = '심심한 레오'
       const mockGuest: GuestAccount = {
         id: 'client-id-1',
@@ -76,10 +76,10 @@ describe('AuthController', () => {
         createdAt: Date.now(),
       }
 
-      mockBattlesService.generateGuestNickname.mockReturnValue(mockNickname)
+      mockBattlesService.generateGuestNickname.mockResolvedValue(mockNickname)
       mockAuthService.createGuest.mockReturnValue(mockGuest)
 
-      const result = controller.createGuest(battleId)
+      const result = await controller.createGuest(battleId)
 
       expect(result).toEqual(mockGuest)
       expect(mockBattlesService.getBattleState).toHaveBeenCalledWith(battleId)
@@ -88,16 +88,15 @@ describe('AuthController', () => {
       expect(mockBattlesService.registerGuest).toHaveBeenCalledWith(battleId, mockGuest)
     })
 
-    it('배틀이 존재하지 않으면 NotFoundException을 던진다', () => {
-      mockBattlesService.getBattleState.mockReturnValue(null)
+    it('배틀이 존재하지 않으면 NotFoundException을 던진다', async () => {
+      mockBattlesService.getBattleState.mockRejectedValue(new NotFoundException())
 
-      expect(() => controller.createGuest(battleId)).toThrow(NotFoundException)
-      expect(mockBattlesService.generateGuestNickname).not.toHaveBeenCalled()
+      await expect(controller.createGuest(battleId)).rejects.toThrow(NotFoundException)
       expect(mockAuthService.createGuest).not.toHaveBeenCalled()
       expect(mockBattlesService.registerGuest).not.toHaveBeenCalled()
     })
 
-    it('OAuth 사용자 닉네임과 중복되지 않는 닉네임을 생성한다', () => {
+    it('OAuth 사용자 닉네임과 중복되지 않는 닉네임을 생성한다', async () => {
       const mockNickname = '심심한 레오'
       const mockGuest: GuestAccount = {
         id: 'client-id-1',
@@ -107,13 +106,13 @@ describe('AuthController', () => {
 
       // OAuth 닉네임 체크 함수가 올바르게 전달되는지 확인
       let capturedIsTaken: ((nickname: string) => boolean) | undefined
-      mockBattlesService.generateGuestNickname.mockImplementation((battleId: string, isTaken: (nickname: string) => boolean) => {
+      mockBattlesService.generateGuestNickname.mockImplementation(async (battleId: string, isTaken: (nickname: string) => boolean) => {
         capturedIsTaken = isTaken
         return mockNickname
       })
       mockAuthService.createGuest.mockReturnValue(mockGuest)
 
-      controller.createGuest(battleId)
+      await controller.createGuest(battleId)
 
       expect(capturedIsTaken).toBeDefined()
       if (!capturedIsTaken) {
@@ -128,7 +127,7 @@ describe('AuthController', () => {
       expect(capturedIsTaken('new-nickname')).toBe(false)
     })
 
-    it('Guest 생성 후 배틀에 등록한다', () => {
+    it('Guest 생성 후 배틀에 등록한다', async () => {
       const mockNickname = '심심한 레오'
       const mockGuest: GuestAccount = {
         id: 'client-id-1',
@@ -136,10 +135,10 @@ describe('AuthController', () => {
         createdAt: Date.now(),
       }
 
-      mockBattlesService.generateGuestNickname.mockReturnValue(mockNickname)
+      mockBattlesService.generateGuestNickname.mockResolvedValue(mockNickname)
       mockAuthService.createGuest.mockReturnValue(mockGuest)
 
-      controller.createGuest(battleId)
+      await controller.createGuest(battleId)
 
       expect(mockBattlesService.getBattleState).toHaveBeenCalledTimes(1)
       expect(mockBattlesService.generateGuestNickname).toHaveBeenCalledTimes(1)

--- a/backend/src/battles/controller/auth.controller.spec.ts
+++ b/backend/src/battles/controller/auth.controller.spec.ts
@@ -65,7 +65,7 @@ describe('AuthController', () => {
 
     beforeEach(() => {
       mockBattlesService.getBattleState.mockResolvedValue({ battleState: mockBattleState })
-      mockOauthService.isNicknameExists.mockReturnValue(false)
+      mockOauthService.isNicknameExists.mockResolvedValue(false)
     })
 
     it('정상적으로 Guest를 생성한다', async () => {
@@ -105,8 +105,9 @@ describe('AuthController', () => {
       }
 
       // OAuth 닉네임 체크 함수가 올바르게 전달되는지 확인
-      let capturedIsTaken: ((nickname: string) => boolean) | undefined
-      mockBattlesService.generateGuestNickname.mockImplementation(async (battleId: string, isTaken: (nickname: string) => boolean) => {
+      let capturedIsTaken: ((nickname: string) => boolean | Promise<boolean>) | undefined
+      mockBattlesService.generateGuestNickname.mockImplementation(
+        async (battleId: string, isTaken: (nickname: string) => boolean | Promise<boolean>) => {
         capturedIsTaken = isTaken
         return mockNickname
       })
@@ -120,11 +121,11 @@ describe('AuthController', () => {
       }
 
       // isTaken 함수가 OAuth 서비스를 올바르게 호출하는지 확인
-      mockOauthService.isNicknameExists.mockReturnValue(true)
-      expect(capturedIsTaken('existing-nickname')).toBe(true)
+      mockOauthService.isNicknameExists.mockResolvedValue(true)
+      await expect(capturedIsTaken('existing-nickname')).resolves.toBe(true)
 
-      mockOauthService.isNicknameExists.mockReturnValue(false)
-      expect(capturedIsTaken('new-nickname')).toBe(false)
+      mockOauthService.isNicknameExists.mockResolvedValue(false)
+      await expect(capturedIsTaken('new-nickname')).resolves.toBe(false)
     })
 
     it('Guest 생성 후 배틀에 등록한다', async () => {

--- a/backend/src/battles/controller/auth.controller.ts
+++ b/backend/src/battles/controller/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, HttpCode, Param, NotFoundException } from '@nestjs/common'
+import { Controller, Post, HttpCode, Param } from '@nestjs/common'
 import { AuthService } from '../service/auth.service'
 import { BattlesService } from '../service/battles.service'
 import { OauthService } from '../../oauth/service/oauth.service'
@@ -14,19 +14,19 @@ export class AuthController {
 
   @Post('guest/:battleId')
   @HttpCode(200)
-  createGuest(@Param('battleId') battleId: string): GuestAccount {
+  async createGuest(@Param('battleId') battleId: string): Promise<GuestAccount> {
     // 배틀 존재 확인
-    const battleState = this.battlesService.getBattleState(battleId)
-    if (!battleState) {
-      throw new NotFoundException('배틀을 찾을 수 없습니다.')
-    }
+    await this.battlesService.getBattleState(battleId)
 
     // Guest 닉네임 생성 (배틀 내 + OAuth 사용자 닉네임 중복 체크)
-    const guestNickname = this.battlesService.generateGuestNickname(battleId, nickname => this.oauthService.isNicknameExists(nickname))
+    const guestNickname = await this.battlesService.generateGuestNickname(
+      battleId,
+      nickname => this.oauthService.isNicknameExists(nickname),
+    )
     const guest = this.authService.createGuest(guestNickname)
 
     // 배틀 방에 Guest 등록
-    this.battlesService.registerGuest(battleId, guest)
+    await this.battlesService.registerGuest(battleId, guest)
 
     return guest
   }

--- a/backend/src/battles/controller/battles.controller.spec.ts
+++ b/backend/src/battles/controller/battles.controller.spec.ts
@@ -33,7 +33,7 @@ describe('BattlesController', () => {
   })
 
   describe('getOpenBattles', () => {
-    it('query.limit/offset을 getOpenBattles로 전달하고 결과를  반환한다', () => {
+    it('query.limit/offset을 getOpenBattles로 전달하고 결과를  반환한다', async () => {
       const query: BattleListRequestQueryDto = {
         limit: 10,
         offset: 0,
@@ -48,9 +48,9 @@ describe('BattlesController', () => {
         },
       }
 
-      const spy = jest.spyOn(service, 'getOpenBattles').mockReturnValue(mockResult)
+      const spy = jest.spyOn(service, 'getOpenBattles').mockResolvedValue(mockResult as never)
 
-      const result = controller.getOpenBattles(query)
+      const result = await controller.getOpenBattles(query)
 
       expect(spy).toHaveBeenCalledWith(10, 0)
       expect(result).toBe(mockResult)
@@ -58,7 +58,7 @@ describe('BattlesController', () => {
   })
 
   describe('getClosedBattles', () => {
-    it('query.limit/offset을 getClosedBattles로 전달하고 결과를 반환한다', () => {
+    it('query.limit/offset을 getClosedBattles로 전달하고 결과를 반환한다', async () => {
       const query: BattleListRequestQueryDto = {
         limit: 5,
         offset: 20,
@@ -73,9 +73,9 @@ describe('BattlesController', () => {
         },
       }
 
-      const spy = jest.spyOn(service, 'getClosedBattles').mockReturnValue(mockResult)
+      const spy = jest.spyOn(service, 'getClosedBattles').mockResolvedValue(mockResult as never)
 
-      const result = controller.getClosedBattles(query)
+      const result = await controller.getClosedBattles(query)
 
       expect(spy).toHaveBeenCalledWith(5, 20)
       expect(result).toBe(mockResult)
@@ -83,33 +83,29 @@ describe('BattlesController', () => {
   })
 
   describe('GET /battles/:id/result', () => {
-    it('배틀 결과를 200 상태코드와 함께 반환해야 함', () => {
+    it('배틀 결과를 200 상태코드와 함께 반환해야 함', async () => {
       const mockResult = {
         battleId: 'battle-1',
         status: 'CLOSED' as const,
       }
 
-      jest.spyOn(service, 'getBattleResult').mockReturnValue(mockResult as BattleResultResponseDto)
+      jest.spyOn(service, 'getBattleResult').mockResolvedValue(mockResult as BattleResultResponseDto)
 
-      const result = controller.getBattleResult('battle-1')
+      const result = await controller.getBattleResult('battle-1')
       expect(result).toBeDefined()
       expect(result.battleId).toBe('battle-1')
     })
 
-    it('존재하지 않는 배틀 조회 시 404 에러를 반환해야 함', () => {
-      jest.spyOn(service, 'getBattleResult').mockImplementation(() => {
-        throw new NotFoundException()
-      })
+    it('존재하지 않는 배틀 조회 시 404 에러를 반환해야 함', async () => {
+      jest.spyOn(service, 'getBattleResult').mockRejectedValue(new NotFoundException() as never)
 
-      expect(() => controller.getBattleResult('battle-999')).toThrow(NotFoundException)
+      await expect(controller.getBattleResult('battle-999')).rejects.toThrow(NotFoundException)
     })
 
-    it('진행 중인 배틀 조회 시 400 에러를 반환해야 함', () => {
-      jest.spyOn(service, 'getBattleResult').mockImplementation(() => {
-        throw new BadRequestException()
-      })
+    it('진행 중인 배틀 조회 시 400 에러를 반환해야 함', async () => {
+      jest.spyOn(service, 'getBattleResult').mockRejectedValue(new BadRequestException() as never)
 
-      expect(() => controller.getBattleResult('battle-open-1')).toThrow(BadRequestException)
+      await expect(controller.getBattleResult('battle-open-1')).rejects.toThrow(BadRequestException)
     })
   })
 })

--- a/backend/src/battles/controller/battles.controller.ts
+++ b/backend/src/battles/controller/battles.controller.ts
@@ -10,32 +10,32 @@ export class BattlesController {
   constructor(private readonly battlesService: BattlesService) {}
 
   @Post()
-  createBattle(@Body() body: BattleCreateQueryDto): { battleId: string } {
-    const battle = this.battlesService.create(body)
+  async createBattle(@Body() body: BattleCreateQueryDto): Promise<{ battleId: string }> {
+    const battle = await this.battlesService.create(body)
     return { battleId: battle.id }
   }
 
   @Get('open')
-  getOpenBattles(@Query() query: BattleListRequestQueryDto) {
+  async getOpenBattles(@Query() query: BattleListRequestQueryDto) {
     return this.battlesService.getOpenBattles(query.limit, query.offset)
   }
 
   @Get('closed')
-  getClosedBattles(@Query() query: BattleListRequestQueryDto) {
+  async getClosedBattles(@Query() query: BattleListRequestQueryDto) {
     return this.battlesService.getClosedBattles(query.limit, query.offset)
   }
 
   @Post(':id/join')
   @HttpCode(200)
-  joinBattleInfo(@Param('id') battleId: string): BattleJoinInfoResponseDto {
+  async joinBattleInfo(@Param('id') battleId: string): Promise<BattleJoinInfoResponseDto> {
     return this.battlesService.joinBattleInfo(battleId)
   }
 
   @Get(':id/result')
   @HttpCode(200)
-  getBattleResult(@Param('id') battleId: string): BattleResultResponseDto {
+  async getBattleResult(@Param('id') battleId: string): Promise<BattleResultResponseDto> {
     try {
-      return this.battlesService.getBattleResult(battleId)
+      return await this.battlesService.getBattleResult(battleId)
     } catch (error) {
       if (error instanceof HttpException) {
         throw error

--- a/backend/src/battles/gateway/battles.gateway.spec.ts
+++ b/backend/src/battles/gateway/battles.gateway.spec.ts
@@ -73,7 +73,7 @@ describe('BattlesGateway - Discussion Events', () => {
   })
 
   describe('battle:attack', () => {
-    it('공격 이벤트를 처리하고 팀 룸에 브로드캐스트한다', () => {
+    it('공격 이벤트를 처리하고 팀 룸에 브로드캐스트한다', async () => {
       const dto: AttackRequestDto = {
         battleId: 'battle-1',
         content: '퀵소트가 더 빠릅니다',
@@ -94,10 +94,10 @@ describe('BattlesGateway - Discussion Events', () => {
         team: BATTLE_TEAM.A,
       }
 
-      jest.spyOn(service, 'handleAttack').mockReturnValue(mockAttack)
+      jest.spyOn(service, 'handleAttack').mockResolvedValue(mockAttack as never)
       jest.spyOn(service, 'getBattleRoomId').mockReturnValue('battle-1:A')
 
-      gateway.handleAttack(dto, mockClient)
+      await gateway.handleAttack(dto, mockClient)
 
       expect(service.handleAttack).toHaveBeenCalledWith('battle-1', {
         authorId: 'user-1',
@@ -109,18 +109,16 @@ describe('BattlesGateway - Discussion Events', () => {
       expect(mockServer.emit).toHaveBeenCalledWith('battle:attack:created', mockAttack)
     })
 
-    it('공격 등록 실패 시 에러 이벤트를 emit한다', () => {
+    it('공격 등록 실패 시 에러 이벤트를 emit한다', async () => {
       const dto: AttackRequestDto = {
         battleId: 'battle-1',
         content: '내용',
         team: BATTLE_TEAM.A,
       }
 
-      jest.spyOn(service, 'handleAttack').mockImplementation(() => {
-        throw new Error('Phase가 올바르지 않습니다')
-      })
+      jest.spyOn(service, 'handleAttack').mockRejectedValue(new Error('Phase가 올바르지 않습니다') as never)
 
-      gateway.handleAttack(dto, mockClient)
+      await gateway.handleAttack(dto, mockClient)
 
       expect(mockClient.emit).toHaveBeenCalledWith('battle:attack:error', {
         message: 'Phase가 올바르지 않습니다',
@@ -129,7 +127,7 @@ describe('BattlesGateway - Discussion Events', () => {
   })
 
   describe('battle:defense', () => {
-    it('반론 이벤트를 처리하고 팀 룸에 브로드캐스트한다', () => {
+    it('반론 이벤트를 처리하고 팀 룸에 브로드캐스트한다', async () => {
       const dto: DefenseRequestDto = {
         battleId: 'battle-1',
         content: '하지만 최악의 경우 O(n²)입니다',
@@ -150,10 +148,10 @@ describe('BattlesGateway - Discussion Events', () => {
         team: BATTLE_TEAM.B,
       }
 
-      jest.spyOn(service, 'handleDefense').mockReturnValue(mockDefense)
+      jest.spyOn(service, 'handleDefense').mockResolvedValue(mockDefense as never)
       jest.spyOn(service, 'getBattleRoomId').mockReturnValue('battle-1:B')
 
-      gateway.handleDefense(dto, mockClient)
+      await gateway.handleDefense(dto, mockClient)
 
       expect(service.handleDefense).toHaveBeenCalledWith('battle-1', {
         authorId: 'user-1',
@@ -165,18 +163,16 @@ describe('BattlesGateway - Discussion Events', () => {
       expect(mockServer.emit).toHaveBeenCalledWith('battle:defense:created', mockDefense)
     })
 
-    it('반론 등록 실패 시 에러 이벤트를 emit한다', () => {
+    it('반론 등록 실패 시 에러 이벤트를 emit한다', async () => {
       const dto: DefenseRequestDto = {
         battleId: 'battle-1',
         content: '반론',
         team: BATTLE_TEAM.B,
       }
 
-      jest.spyOn(service, 'handleDefense').mockImplementation(() => {
-        throw new Error('현재 반론을 등록할 수 없는 단계입니다.')
-      })
+      jest.spyOn(service, 'handleDefense').mockRejectedValue(new Error('현재 반론을 등록할 수 없는 단계입니다.') as never)
 
-      gateway.handleDefense(dto, mockClient)
+      await gateway.handleDefense(dto, mockClient)
 
       expect(mockClient.emit).toHaveBeenCalledWith('battle:defense:error', {
         message: '현재 반론을 등록할 수 없는 단계입니다.',
@@ -185,7 +181,7 @@ describe('BattlesGateway - Discussion Events', () => {
   })
 
   describe('battle:attack:vote', () => {
-    it('공격 투표 이벤트를 처리하고 팀 룸에 브로드캐스트한다', () => {
+    it('공격 투표 이벤트를 처리하고 팀 룸에 브로드캐스트한다', async () => {
       const dto: AttackVoteRequestDto = {
         battleId: 'battle-1',
         discussionId: 'attack-1',
@@ -206,10 +202,10 @@ describe('BattlesGateway - Discussion Events', () => {
         team: BATTLE_TEAM.A,
       })
 
-      jest.spyOn(service, 'handleAttackVote').mockReturnValue([mockResponse])
+      jest.spyOn(service, 'handleAttackVote').mockResolvedValue([mockResponse] as never)
       jest.spyOn(service, 'getBattleRoomId').mockReturnValue('battle-1:A')
 
-      gateway.handleAttackVote(dto, mockClient)
+      await gateway.handleAttackVote(dto, mockClient)
 
       expect(service.handleAttackVote).toHaveBeenCalledWith('battle-1', 'attack-1', {
         userId: 'user-1',
@@ -222,7 +218,7 @@ describe('BattlesGateway - Discussion Events', () => {
   })
 
   describe('battle:defense:vote', () => {
-    it('반론 투표 이벤트를 처리하고 팀 룸에 브로드캐스트한다', () => {
+    it('반론 투표 이벤트를 처리하고 팀 룸에 브로드캐스트한다', async () => {
       const dto: DefenseVoteRequestDto = {
         battleId: 'battle-1',
         discussionId: 'defense-1',
@@ -243,10 +239,10 @@ describe('BattlesGateway - Discussion Events', () => {
         team: BATTLE_TEAM.B,
       })
 
-      jest.spyOn(service, 'handleDefenseVote').mockReturnValue([mockResponse])
+      jest.spyOn(service, 'handleDefenseVote').mockResolvedValue([mockResponse] as never)
       jest.spyOn(service, 'getBattleRoomId').mockReturnValue('battle-1:B')
 
-      gateway.handleDefenseVote(dto, mockClient)
+      await gateway.handleDefenseVote(dto, mockClient)
 
       expect(service.handleDefenseVote).toHaveBeenCalledWith('battle-1', 'defense-1', {
         userId: 'user-1',

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -110,7 +110,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
       const userId = this.getUserIdFromSocket(client)
 
       const { battleId } = battleJoinRequestDto
-      const { battleState, team } = this.battlesService.joinBattle(battleJoinRequestDto, userId)
+      const { battleState, team } = await this.battlesService.joinBattle(battleJoinRequestDto, userId)
 
       const res = BattleJoinResponseDto.of(battleState, team)
       const battleRoomId = this.battlesService.getBattleRoomId(battleId)
@@ -133,23 +133,23 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
   }
 
   @SubscribeMessage('battle:leave')
-  handleLeave(@MessageBody() dto: { battleId: string }, @ConnectedSocket() client: SocketWithUserId) {
+  async handleLeave(@MessageBody() dto: { battleId: string }, @ConnectedSocket() client: SocketWithUserId) {
     const { battleId } = dto
     const userId = this.getUserIdFromSocket(client)
     const battleRoomId = this.battlesService.getBattleRoomId(battleId)
 
-    const result = this.battlesService.leaveBattle(userId, battleId)
+    const result = await this.battlesService.leaveBattle(userId, battleId)
     client.data.battleId = undefined
 
     this.server.to(battleRoomId).emit('battle:leaved', result)
   }
 
   @SubscribeMessage('battle:start')
-  handleStart(@MessageBody() dto: BattleStartDto) {
+  async handleStart(@MessageBody() dto: BattleStartDto) {
     const stopTimer = this.metricsService.startSocketTimer('battle:start')
     try {
       const { battleId } = dto
-      this.battlesService.startBattle(battleId)
+      await this.battlesService.startBattle(battleId)
 
       const battleRoomId = this.battlesService.getBattleRoomId(battleId)
 
@@ -162,12 +162,12 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
   }
 
   @SubscribeMessage('battle:attack')
-  handleAttack(@MessageBody() dto: AttackRequestDto, @ConnectedSocket() client: SocketWithUserId) {
+  async handleAttack(@MessageBody() dto: AttackRequestDto, @ConnectedSocket() client: SocketWithUserId) {
     const stopTimer = this.metricsService.startSocketTimer('battle:attack')
     try {
       const userId = this.getUserIdFromSocket(client)
       const { battleId, content, team } = dto
-      const attack = this.battlesService.handleAttack(battleId, { authorId: userId, content, team })
+      const attack = await this.battlesService.handleAttack(battleId, { authorId: userId, content, team })
       const teamRoom = this.battlesService.getBattleRoomId(battleId, team)
 
       this.server.to(teamRoom).emit('battle:attack:created', attack)
@@ -183,12 +183,12 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
   }
 
   @SubscribeMessage('battle:defense')
-  handleDefense(@MessageBody() dto: DefenseRequestDto, @ConnectedSocket() client: SocketWithUserId) {
+  async handleDefense(@MessageBody() dto: DefenseRequestDto, @ConnectedSocket() client: SocketWithUserId) {
     const stopTimer = this.metricsService.startSocketTimer('battle:defense')
     try {
       const userId = this.getUserIdFromSocket(client)
       const { battleId, content, team } = dto
-      const defense = this.battlesService.handleDefense(battleId, { authorId: userId, content, team })
+      const defense = await this.battlesService.handleDefense(battleId, { authorId: userId, content, team })
       const teamRoom = this.battlesService.getBattleRoomId(battleId, team)
 
       this.server.to(teamRoom).emit('battle:defense:created', defense)
@@ -204,12 +204,12 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
   }
 
   @SubscribeMessage('battle:attack:vote')
-  handleAttackVote(@MessageBody() dto: AttackVoteRequestDto, @ConnectedSocket() client: SocketWithUserId) {
+  async handleAttackVote(@MessageBody() dto: AttackVoteRequestDto, @ConnectedSocket() client: SocketWithUserId) {
     const stopTimer = this.metricsService.startSocketTimer('battle:attack:vote')
     try {
       const userId = this.getUserIdFromSocket(client)
       const { battleId, discussionId, team } = dto
-      const updates = this.battlesService.handleAttackVote(battleId, discussionId, { userId, team })
+      const updates = await this.battlesService.handleAttackVote(battleId, discussionId, { userId, team })
       const teamRoom = this.battlesService.getBattleRoomId(battleId, team)
 
       // 모든 변경된 항목(기존 투표 취소 + 새 투표)을 전송
@@ -228,12 +228,12 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
   }
 
   @SubscribeMessage('battle:defense:vote')
-  handleDefenseVote(@MessageBody() dto: DefenseVoteRequestDto, @ConnectedSocket() client: SocketWithUserId) {
+  async handleDefenseVote(@MessageBody() dto: DefenseVoteRequestDto, @ConnectedSocket() client: SocketWithUserId) {
     const stopTimer = this.metricsService.startSocketTimer('battle:defense:vote')
     try {
       const userId = this.getUserIdFromSocket(client)
       const { battleId, discussionId, team } = dto
-      const updates = this.battlesService.handleDefenseVote(battleId, discussionId, { userId, team })
+      const updates = await this.battlesService.handleDefenseVote(battleId, discussionId, { userId, team })
       const teamRoom = this.battlesService.getBattleRoomId(battleId, team)
 
       // 모든 변경된 항목(기존 투표 취소 + 새 투표)을 전송
@@ -319,12 +319,12 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
   }
 
   @SubscribeMessage('battle:chat')
-  handleChat(@MessageBody() battleChatDto: BattleChatDto, @ConnectedSocket() client: SocketWithUserId) {
+  async handleChat(@MessageBody() battleChatDto: BattleChatDto, @ConnectedSocket() client: SocketWithUserId) {
     const stopTimer = this.metricsService.startSocketTimer('battle:chat')
     try {
       const userId = this.getUserIdFromSocket(client)
 
-      const saved = this.battlesService.appendChatMessage(battleChatDto, userId)
+      const saved = await this.battlesService.appendChatMessage(battleChatDto, userId)
       const roomId =
         battleChatDto.scope === BATTLE_CHAT_SCOPE.ALL
           ? this.battlesService.getBattleRoomId(battleChatDto.battleId)
@@ -342,12 +342,12 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
   }
 
   @SubscribeMessage('battle:team:vote')
-  handleTeamVote(@MessageBody() dto: BattleTeamVoteDto, @ConnectedSocket() client: SocketWithUserId) {
+  async handleTeamVote(@MessageBody() dto: BattleTeamVoteDto, @ConnectedSocket() client: SocketWithUserId) {
     const stopTimer = this.metricsService.startSocketTimer('battle:team:vote')
     try {
       const userId = this.getUserIdFromSocket(client)
 
-      this.battlesService.voteTeam(dto, userId)
+      await this.battlesService.voteTeam(dto, userId)
       stopTimer('success')
     } catch (error) {
       stopTimer('error')

--- a/backend/src/battles/service/battles.service.spec.ts
+++ b/backend/src/battles/service/battles.service.spec.ts
@@ -1,7 +1,98 @@
 import { NotFoundException, BadRequestException, ForbiddenException, UnauthorizedException } from '@nestjs/common'
-import { Battle, FinishedBattleState, BattleDefense } from '../types/battles.types'
+import { Battle, FinishedBattleState, BattleDefense, ActiveBattleState } from '../types/battles.types'
 import { BattlesService } from './battles.service'
-import { BATTLE_TYPE, BATTLE_CATEGORY, BATTLE_PLAYTIME, BATTLE_LANGUAGE, BATTLE_STATUS, BATTLE_PHASE, BATTLE_TEAM } from '../const/battles.const'
+import {
+  BATTLE_TYPE,
+  BATTLE_CATEGORY,
+  BATTLE_PLAYTIME,
+  BATTLE_LANGUAGE,
+  BATTLE_STATUS,
+  BATTLE_PHASE,
+  BATTLE_TEAM,
+  BATTLE_DISCUSSION_TYPE,
+} from '../const/battles.const'
+import type { PrismaService } from 'src/prisma/prisma.service'
+
+type BattleRecord = {
+  id: string
+  userId: string
+  title: string
+  description: string
+  codeA: string
+  codeB: string
+  language: string
+  category: string
+  playTime: string
+  topics: string[]
+  password: string | null
+  isPrivate: boolean
+  status: string
+  createdAt: Date
+  updatedAt: Date | null
+  finishedAt: Date | null
+  teamACount: number
+  teamBCount: number
+  totalParticipantsCount: number
+  winningTeam: string | null
+  timeline: unknown[]
+  mvps: string[]
+  mvpsState: unknown[]
+  currentRound: number
+  currentPhase: string
+  phaseCount: number
+  startedAt: Date | null
+  expiredAt: Date | null
+  participantsState: unknown
+  teamVotesState: unknown
+  userInfoState: unknown
+  attacksState: unknown
+  defensesState: unknown
+  opinionHistoryState: unknown
+  chatsAllState: unknown
+  chatsTeamAState: unknown
+  chatsTeamBState: unknown
+}
+
+type BattleFindManyArgs = {
+  where?: { isPrivate?: boolean; status?: { in?: string[] } }
+  orderBy?: { createdAt?: 'asc' | 'desc'; finishedAt?: 'asc' | 'desc' }
+  skip?: number
+  take?: number
+}
+
+type BattleCountArgs = {
+  where?: { isPrivate?: boolean; status?: { in?: string[] } }
+}
+
+type BattleUpdateArgs = {
+  where: { id: string }
+  data: Partial<BattleRecord>
+}
+
+type BattleCreateArgs = {
+  data: BattleRecord
+}
+
+type BattleFindUniqueArgs = {
+  where: { id: string }
+}
+
+type MockPrisma = {
+  battle: {
+    findUnique: jest.Mock<BattleRecord | null, [BattleFindUniqueArgs]>
+    findMany: jest.Mock<BattleRecord[], [BattleFindManyArgs]>
+    count: jest.Mock<number, [BattleCountArgs | undefined]>
+    update: jest.Mock<BattleRecord | null, [BattleUpdateArgs]>
+    create: jest.Mock<BattleRecord, [BattleCreateArgs]>
+  }
+  battleParticipant: { upsert: jest.Mock }
+  user: { findUnique: jest.Mock<{ id: string } | null, [{ where: { id: string }; select?: { id: true } }]> }
+}
+
+type BattleStateAccess = {
+  loadBattleState: (id: string) => Promise<{ battle: unknown; state: ActiveBattleState }>
+  saveBattleState: (id: string, state: ActiveBattleState) => Promise<void>
+}
 
 const createBattle = (overrides: Partial<Battle>): Battle => ({
   id: 'battle-id',
@@ -98,15 +189,138 @@ const createFinishedBattleState = (overrides: Partial<FinishedBattleState> = {})
 
 describe('BattlesService', () => {
   let service: BattlesService
+  let battleStore: Map<string, BattleRecord>
+  let stateStore: Map<string, ActiveBattleState>
+  let mockPrisma: MockPrisma
+
+  const toRecord = (battle: Battle, overrides: Partial<BattleRecord> = {}): BattleRecord => ({
+    id: battle.id,
+    userId: battle.authorId,
+    title: battle.title,
+    description: battle.description,
+    codeA: battle.aCode,
+    codeB: battle.bCode,
+    language: battle.language,
+    category: battle.category,
+    playTime: (battle.playTime as { name?: string }).name ?? (battle.playTime as unknown as string),
+    topics: battle.topics,
+    password: battle.password ?? null,
+    isPrivate: battle.type === BATTLE_TYPE.PRIVATE,
+    status: battle.status,
+    createdAt: battle.createdAt,
+    updatedAt: battle.updatedAt ?? null,
+    finishedAt: null,
+    teamACount: 0,
+    teamBCount: 0,
+    totalParticipantsCount: 0,
+    winningTeam: null,
+    timeline: [],
+    mvps: [],
+    mvpsState: [],
+    currentRound: battle.initialState.round,
+    currentPhase: battle.initialState.phase,
+    phaseCount: battle.initialState.phaseCount,
+    startedAt: null,
+    expiredAt: null,
+    participantsState: [],
+    teamVotesState: [],
+    userInfoState: [],
+    attacksState: { teamA: [], teamB: [], all: [] },
+    defensesState: { teamA: [], teamB: [], all: [] },
+    opinionHistoryState: [],
+    chatsAllState: [],
+    chatsTeamAState: [],
+    chatsTeamBState: [],
+    ...overrides,
+  })
+
+  const seedBattles = (battles: Battle[]) => {
+    battleStore = new Map()
+    battles.forEach(battle => battleStore.set(battle.id, toRecord(battle)))
+  }
+  const getState = async (battleId: string): Promise<ActiveBattleState> => {
+    const { battleState } = await service.getBattleState(battleId)
+    return battleState
+  }
+  const getStateUnsafe = async (battleId: string) => {
+    const access = service as unknown as BattleStateAccess
+    const { state } = await access.loadBattleState(battleId)
+    return state
+  }
+  const updateState = async (battleId: string, updater: (state: ActiveBattleState) => void) => {
+    const access = service as unknown as BattleStateAccess
+    const { state } = await access.loadBattleState(battleId)
+    updater(state)
+    await access.saveBattleState(battleId, state)
+    return state
+  }
 
   const cleanupService = () => {
     service['battleTimers'].forEach(timer => clearTimeout(timer))
     service['battleTimers'].clear()
-    service['activeBattles'].clear()
   }
 
   beforeEach(() => {
-    service = new BattlesService()
+    battleStore = new Map()
+    stateStore = new Map()
+    mockPrisma = {
+      battle: {
+        findUnique: jest.fn(({ where }: BattleFindUniqueArgs) => battleStore.get(where.id) ?? null),
+        findMany: jest.fn(({ where, orderBy, skip = 0, take }: BattleFindManyArgs) => {
+          let records = [...battleStore.values()]
+          if (where?.isPrivate !== undefined) {
+            records = records.filter(r => r.isPrivate === where.isPrivate)
+          }
+          if (where?.status?.in) {
+            records = records.filter(r => where.status?.in?.includes(r.status))
+          }
+          if (orderBy?.createdAt) {
+            records.sort((a, b) =>
+              orderBy.createdAt === 'asc' ? a.createdAt.getTime() - b.createdAt.getTime() : b.createdAt.getTime() - a.createdAt.getTime(),
+            )
+          }
+          if (orderBy?.finishedAt) {
+            records.sort((a, b) => {
+              const aTime = a.finishedAt ? a.finishedAt.getTime() : 0
+              const bTime = b.finishedAt ? b.finishedAt.getTime() : 0
+              return orderBy.finishedAt === 'asc' ? aTime - bTime : bTime - aTime
+            })
+          }
+          const end = take ? skip + take : undefined
+          return records.slice(skip, end)
+        }),
+        count: jest.fn(({ where }: BattleCountArgs = {}) => {
+          let records = [...battleStore.values()]
+          if (where?.isPrivate !== undefined) {
+            records = records.filter(r => r.isPrivate === where.isPrivate)
+          }
+          if (where?.status?.in) {
+            records = records.filter(r => where.status?.in?.includes(r.status))
+          }
+          return records.length
+        }),
+        update: jest.fn(({ where, data }: BattleUpdateArgs) => {
+          const existing = battleStore.get(where.id)
+          if (!existing) return null
+          const updated: BattleRecord = { ...existing, ...data }
+          battleStore.set(where.id, updated)
+          return updated
+        }),
+        create: jest.fn(({ data }: BattleCreateArgs) => {
+          battleStore.set(data.id, data)
+          return data
+        }),
+      },
+      battleParticipant: { upsert: jest.fn() },
+      user: { findUnique: jest.fn(() => null) },
+    }
+    service = new BattlesService(mockPrisma as unknown as PrismaService)
+    const originalGetBattleState: BattlesService['getBattleState'] = service.getBattleState.bind(service)
+    jest.spyOn(service, 'getBattleState').mockImplementation(async (battleId: string) => {
+      const res = await originalGetBattleState(battleId)
+      stateStore.set(battleId, res.battleState)
+      return res
+    })
     cleanupService()
     jest.useFakeTimers()
     jest.spyOn(Date, 'now').mockReturnValue(1_000_000)
@@ -118,85 +332,70 @@ describe('BattlesService', () => {
     jest.restoreAllMocks()
   })
 
-  describe('initBattleState', () => {
+  describe('getBattleState', () => {
     beforeEach(() => {
-      service.setBattlesForTest([createBattle({ id: 'battle-1' })])
+      seedBattles([createBattle({ id: 'battle-1' })])
     })
 
-    it('battleId가 없으면 BadRequestException을 던진다', () => {
-      expect(() => service['initBattleState']('')).toThrow(BadRequestException)
+    it('battleId가 없으면 NotFoundException을 던진다', async () => {
+      await expect(service.getBattleState('' as unknown as string)).rejects.toThrow(NotFoundException)
     })
 
-    it('이미 초기화된 배틀이면 중복 생성하지 않는다', () => {
-      const beforeSize = service['activeBattles'].size
-      service['initBattleState']('battle-1')
-      service['initBattleState']('battle-1')
+    it('배틀 상태를 올바르게 로드한다', async () => {
+      const { battleState } = await service.getBattleState('battle-1')
 
-      expect(service['activeBattles'].size).toBe(beforeSize + 1)
-    })
-
-    it('배틀 상태를 올바르게 초기화한다', () => {
-      service['initBattleState']('battle-1')
-
-      const state = service['activeBattles'].get('battle-1')!
-
-      expect(state.battleId).toBe('battle-1')
-      expect(state.all.roomId).toBe('battle:battle-1')
-      expect(state.teamA.roomId).toBe('battle:battle-1:A')
-      expect(state.teamB.roomId).toBe('battle:battle-1:B')
-      expect(state.teamA.users).toEqual([])
-      expect(state.teamB.users).toEqual([])
+      expect(battleState.battleId).toBe('battle-1')
+      expect(battleState.all.roomId).toBe('battle:battle-1')
+      expect(battleState.teamA.roomId).toBe('battle:battle-1:A')
+      expect(battleState.teamB.roomId).toBe('battle:battle-1:B')
+      expect(battleState.teamA.users).toEqual([])
+      expect(battleState.teamB.users).toEqual([])
     })
   })
 
   describe('addParticipant', () => {
     beforeEach(() => {
-      service.setBattlesForTest([createBattle({ id: 'battle-1' })])
-      service['initBattleState']('battle-1')
+      seedBattles([createBattle({ id: 'battle-1' })])
     })
 
-    it('필수 파라미터가 없으면 BadRequestException을 던진다', () => {
-      expect(() => service['addParticipant']('', 'client-1', 'A')).toThrow(BadRequestException)
-      expect(() => service['addParticipant']('battle-1', '', 'A')).toThrow(BadRequestException)
-      expect(() => service['addParticipant']('battle-1', 'client-1', '')).toThrow(BadRequestException)
+    it('필수 파라미터가 없으면 BadRequestException을 던진다', async () => {
+      const state = await getState('battle-1')
+      expect(() => service['addParticipant'](state, '', 'A')).toThrow(BadRequestException)
+      expect(() => service['addParticipant'](state, 'client-1', '')).toThrow(BadRequestException)
     })
 
-    it('존재하지 않는 배틀이면 NotFoundException을 던진다', () => {
-      expect(() => service['addParticipant']('invalid-battle', 'client-1', 'A')).toThrow(NotFoundException)
-    })
+    it('A팀에 참가자를 추가한다', async () => {
+      const state = await getState('battle-1')
+      service['addParticipant'](state, 'client-1', BATTLE_TEAM.A)
 
-    it('A팀에 참가자를 추가한다', () => {
-      service['addParticipant']('battle-1', 'client-1', BATTLE_TEAM.A)
-
-      const state = service['activeBattles'].get('battle-1')!
       expect(state.teamA.users).toContain('client-1')
       expect(state.teamB.users).not.toContain('client-1')
     })
 
-    it('B팀에 참가자를 추가한다', () => {
-      service['addParticipant']('battle-1', 'client-2', BATTLE_TEAM.B)
+    it('B팀에 참가자를 추가한다', async () => {
+      const state = await getState('battle-1')
+      service['addParticipant'](state, 'client-2', BATTLE_TEAM.B)
 
-      const state = service['activeBattles'].get('battle-1')!
       expect(state.teamB.users).toContain('client-2')
       expect(state.teamA.users).not.toContain('client-2')
     })
 
-    it('중립 팀에 참가자를 추가한다', () => {
-      service['addParticipant']('battle-1', 'client-3', BATTLE_TEAM.NONE)
+    it('중립 팀에 참가자를 추가한다', async () => {
+      const state = await getState('battle-1')
+      service['addParticipant'](state, 'client-3', BATTLE_TEAM.NONE)
 
-      const state = service['activeBattles'].get('battle-1')!
       expect(state.teamA.users).not.toContain('client-3')
       expect(state.teamB.users).not.toContain('client-3')
       expect(state.participants.get('client-3')).toBe(BATTLE_TEAM.NONE)
     })
 
-    it('참가자 추가 시 teamNoneCount가 올바르게 계산된다', () => {
-      service['addParticipant']('battle-1', 'client-a1', BATTLE_TEAM.A)
-      service['addParticipant']('battle-1', 'client-b1', BATTLE_TEAM.B)
-      service['addParticipant']('battle-1', 'client-none1', BATTLE_TEAM.NONE)
-      service['addParticipant']('battle-1', 'client-none2', BATTLE_TEAM.NONE)
+    it('참가자 추가 시 teamNoneCount가 올바르게 계산된다', async () => {
+      const state = await getState('battle-1')
+      service['addParticipant'](state, 'client-a1', BATTLE_TEAM.A)
+      service['addParticipant'](state, 'client-b1', BATTLE_TEAM.B)
+      service['addParticipant'](state, 'client-none1', BATTLE_TEAM.NONE)
+      service['addParticipant'](state, 'client-none2', BATTLE_TEAM.NONE)
 
-      const state = service['activeBattles'].get('battle-1')!
       const totalParticipants = state.participants.size
       const teamA = state.teamA.users.length
       const teamB = state.teamB.users.length
@@ -208,12 +407,12 @@ describe('BattlesService', () => {
   })
 
   describe('getBattleRoomId', () => {
-    it('팀이 없으면 배틀 전체 룸 ID를 반환한다', () => {
+    it('case', () => {
       const roomId = service.getBattleRoomId('battle-1')
       expect(roomId).toBe('battle:battle-1')
     })
 
-    it('팀이 있으면 팀별 룸 ID를 반환한다', () => {
+    it('case', () => {
       const roomIdA = service.getBattleRoomId('battle-1', BATTLE_TEAM.A)
       const roomIdB = service.getBattleRoomId('battle-1', BATTLE_TEAM.B)
 
@@ -223,19 +422,19 @@ describe('BattlesService', () => {
   })
 
   describe('joinBattleInfo', () => {
-    it('battleId가 없으면 BadRequestException을 던진다', () => {
-      expect(() => service.joinBattleInfo('')).toThrow(BadRequestException)
+    it('battleId가 없으면 BadRequestException을 던진다', async () => {
+      await expect(service.joinBattleInfo('')).rejects.toThrow(BadRequestException)
     })
 
-    it('존재하지 않는 배틀이면 NotFoundException을 던진다', () => {
-      expect(() => service.joinBattleInfo('invalid-battle')).toThrow(NotFoundException)
+    it('존재하지 않는 배틀이면 NotFoundException을 던진다', async () => {
+      await expect(service.joinBattleInfo('invalid-battle')).rejects.toThrow(NotFoundException)
     })
 
-    it('배틀 정보를 반환한다', () => {
+    it('배틀 정보를 반환한다', async () => {
       const battle = createBattle({ id: 'battle-1' })
-      service.setBattlesForTest([battle])
+      seedBattles([battle])
 
-      const result = service.joinBattleInfo('battle-1')
+      const result = await service.joinBattleInfo('battle-1')
 
       expect(result).toBeDefined()
       expect(result.title).toBe(battle.title)
@@ -252,38 +451,40 @@ describe('BattlesService', () => {
   })
 
   describe('joinBattle', () => {
+    let publicBattle: Battle
+    let privateBattle: Battle
+    let closedBattle: Battle
+
     beforeEach(() => {
-      const publicBattle = createBattle({
+      publicBattle = createBattle({
         id: 'public-battle',
         type: BATTLE_TYPE.PUBLIC,
         status: BATTLE_STATUS.OPEN,
       })
-      const privateBattle = createBattle({
+      privateBattle = createBattle({
         id: 'private-battle',
         type: BATTLE_TYPE.PRIVATE,
         password: '1234',
         status: BATTLE_STATUS.OPEN,
       })
-      const closedBattle = createBattle({
+      closedBattle = createBattle({
         id: 'closed-battle',
         status: BATTLE_STATUS.CLOSED,
       })
 
-      service.setBattlesForTest([publicBattle, privateBattle, closedBattle])
-      service['initBattleState']('public-battle')
-      service['initBattleState']('private-battle')
+      seedBattles([publicBattle, privateBattle, closedBattle])
 
       // Guest 등록
-      service.registerGuest('public-battle', { id: 'user-1', nickname: 'test-user', createdAt: Date.now() })
-      service.registerGuest('private-battle', { id: 'user-1', nickname: 'test-user', createdAt: Date.now() })
+      await service.registerGuest('public-battle', { id: 'user-1', nickname: 'test-user', createdAt: Date.now() })
+      await service.registerGuest('private-battle', { id: 'user-1', nickname: 'test-user', createdAt: Date.now() })
     })
 
-    it('battleId가 없으면 BadRequestException을 던진다', () => {
-      expect(() => service.joinBattle({ battleId: '', team: 'A' }, 'user-1')).toThrow(BadRequestException)
+    it('case', async () => {
+      await expect(service.joinBattle({ battleId: '', team: 'A' }, 'user-1')).rejects.toThrow(BadRequestException)
     })
 
-    it('존재하지 않는 배틀이면 NotFoundException을 던진다', () => {
-      expect(() =>
+    it('case', async () => {
+      await expect(
         service.joinBattle(
           {
             battleId: 'invalid',
@@ -291,11 +492,11 @@ describe('BattlesService', () => {
           },
           'user-1',
         ),
-      ).toThrow(NotFoundException)
+      ).rejects.toThrow(NotFoundException)
     })
 
-    it('비공개 배틀에 잘못된 비밀번호로 접근하면 UnauthorizedException을 던진다', () => {
-      expect(() =>
+    it('case', async () => {
+      await expect(
         service.joinBattle(
           {
             battleId: 'private-battle',
@@ -304,12 +505,12 @@ describe('BattlesService', () => {
           },
           'user-1',
         ),
-      ).toThrow(UnauthorizedException)
+      ).rejects.toThrow(UnauthorizedException)
     })
 
-    it('비공개 배틀에 올바른 비밀번호로 입장한다', () => {
-      service.registerGuest('private-battle', { id: 'user-1', nickname: 'test-user', createdAt: Date.now() })
-      const result = service.joinBattle(
+    it('case', async () => {
+      await service.registerGuest('private-battle', { id: 'user-1', nickname: 'test-user', createdAt: Date.now() })
+      const result = await service.joinBattle(
         {
           battleId: 'private-battle',
           password: '1234',
@@ -322,8 +523,8 @@ describe('BattlesService', () => {
       expect(result.battleState).toBeDefined()
     })
 
-    it('종료된 배틀에 입장하려 하면 BadRequestException을 던진다', () => {
-      expect(() =>
+    it('case', async () => {
+      await expect(
         service.joinBattle(
           {
             battleId: 'closed-battle',
@@ -331,11 +532,11 @@ describe('BattlesService', () => {
           },
           'user-1',
         ),
-      ).toThrow(BadRequestException)
+      ).rejects.toThrow(BadRequestException)
     })
 
-    it('공개 배틀에 정상적으로 입장한다', () => {
-      const result = service.joinBattle(
+    it('case', async () => {
+      const result = await service.joinBattle(
         {
           battleId: 'public-battle',
           team: 'A',
@@ -347,9 +548,9 @@ describe('BattlesService', () => {
       expect(result.battleState.teamA.users).toContain('user-1')
     })
 
-    it('이미 참여한 userId로 재접속하면 기존 상태를 반환한다', () => {
-      service.registerGuest('public-battle', { id: 'user-1', nickname: 'test-user', createdAt: Date.now() })
-      const firstResult = service.joinBattle(
+    it('case', async () => {
+      await service.registerGuest('public-battle', { id: 'user-1', nickname: 'test-user', createdAt: Date.now() })
+      const firstResult = await service.joinBattle(
         {
           battleId: 'public-battle',
           team: 'A',
@@ -357,7 +558,7 @@ describe('BattlesService', () => {
         'user-1',
       )
 
-      const secondResult = service.joinBattle(
+      const secondResult = await service.joinBattle(
         {
           battleId: 'public-battle',
           team: 'A',
@@ -366,27 +567,26 @@ describe('BattlesService', () => {
       )
 
       // 재접속 시 기존 상태가 같다는 것을 확인
-      expect(secondResult.battleState).toBe(firstResult.battleState)
+      expect(secondResult.battleState).toEqual(firstResult.battleState)
       expect(secondResult.team).toBe(firstResult.team)
 
-      const battleState = service.getBattleState('public-battle')
+      const { battleState } = await service.getBattleState('public-battle')
 
       expect(battleState.participants.get('user-1')).toBe('A')
       expect(battleState.teamA.users).toContain('user-1')
       expect(battleState.teamB.users).not.toContain('user-1')
     })
 
-    it('다른 배틀에는 같은 userId로 참여할 수 있다', () => {
+    it('case', async () => {
       const battle2 = createBattle({
         id: 'public-battle-2',
         type: BATTLE_TYPE.PUBLIC,
         status: BATTLE_STATUS.OPEN,
       })
-      service.setBattlesForTest([...service['battles'], battle2])
-      service['initBattleState']('public-battle-2')
-      service.registerGuest('public-battle-2', { id: 'user-1', nickname: 'test-user', createdAt: Date.now() })
+      seedBattles([publicBattle, privateBattle, closedBattle, battle2])
+      await service.registerGuest('public-battle-2', { id: 'user-1', nickname: 'test-user', createdAt: Date.now() })
 
-      service.joinBattle(
+      await service.joinBattle(
         {
           battleId: 'public-battle',
           team: 'A',
@@ -394,7 +594,7 @@ describe('BattlesService', () => {
         'user-1',
       )
 
-      const result = service.joinBattle(
+      const result = await service.joinBattle(
         {
           battleId: 'public-battle-2',
           team: 'B',
@@ -409,95 +609,89 @@ describe('BattlesService', () => {
 
   describe('updatePhase', () => {
     beforeEach(() => {
-      service.setBattlesForTest([createBattle({ id: 'battle-1' })])
-      service['initBattleState']('battle-1')
+      seedBattles([createBattle({ id: 'battle-1' })])
     })
 
-    it('OPINION_SHARE → ATTACK 으로 전환된다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      await service['updatePhase']('battle-1')
 
-      service['updatePhase']('battle-1')
-
-      expect(state.phase).toBe(BATTLE_PHASE.OPINION_SHARE.name)
-
-      service['updatePhase']('battle-1')
-
+      let state = await getState('battle-1')
       expect(state.phase).toBe(BATTLE_PHASE.ATTACK.name)
       expect(state.phaseCount).toBe(1)
-    })
 
-    it('ATTACK → DEFENSE 로 턴이 변경된다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+      await service['updatePhase']('battle-1')
 
-      service['updatePhase']('battle-1')
-      service['updatePhase']('battle-1')
-      service['updatePhase']('battle-1')
-
+      state = await getState('battle-1')
       expect(state.phase).toBe(BATTLE_PHASE.DEFENSE.name)
       expect(state.phaseCount).toBe(1)
     })
-    it('ATTACK ↔ DEFENSE 가 2회 반복된다', () => {
-      const state = service['activeBattles'].get('battle-1')!
 
-      service['updatePhase']('battle-1') // PENDING → OPINION
-      service['updatePhase']('battle-1') // OPINION → ATTACK
-      service['updatePhase']('battle-1') // ATTACK → DEFENSE
-      service['updatePhase']('battle-1') // DEFENSE → ATTACK (count 2)
+    it('case', async () => {
+      await service['updatePhase']('battle-1')
+      await service['updatePhase']('battle-1')
+      await service['updatePhase']('battle-1')
 
+      const state = await getState('battle-1')
+      expect(state.phase).toBe(BATTLE_PHASE.ATTACK.name)
+      expect(state.phaseCount).toBe(2)
+    })
+    it('case', async () => {
+      await service['updatePhase']('battle-1') // OPINION → ATTACK
+      await service['updatePhase']('battle-1') // ATTACK → DEFENSE
+      await service['updatePhase']('battle-1') // DEFENSE → ATTACK (count 2)
+
+      const state = await getState('battle-1')
       expect(state.phase).toBe(BATTLE_PHASE.ATTACK.name)
       expect(state.phaseCount).toBe(2)
     })
 
-    it('TEAM_SWITCH 이후 round가 증가한다', () => {
+    it('case', async () => {
       const battle = createBattle({
         id: 'battle-1',
         playTime: BATTLE_PLAYTIME.THIRTY_MIN,
         topics: ['주제1', '주제2'],
       })
-      service.setBattlesForTest([battle])
+      seedBattles([battle])
 
-      service['initBattleState']('battle-1')
-      const state = service['activeBattles'].get('battle-1')!
+      await updateState('battle-1', state => {
+        state.phase = BATTLE_PHASE.TEAM_SWITCH.name
+        state.round = 1
+      })
 
-      state.phase = BATTLE_PHASE.TEAM_SWITCH.name
-      state.round = 1
+      await service['updatePhase']('battle-1')
 
-      service['updatePhase']('battle-1')
-
+      const state = await getState('battle-1')
       expect(state.round).toBe(2)
       expect(state.phase).toBe(BATTLE_PHASE.OPINION_SHARE.name)
     })
 
-    it('마지막 라운드 이후 finishBattle가 호출된다', () => {
+    it('case', async () => {
       const battle = createBattle({
         id: 'battle-1',
         playTime: BATTLE_PLAYTIME.THIRTY_MIN,
         topics: ['주제1', '주제2'],
       })
-      service.setBattlesForTest([battle])
-
-      service['initBattleState']('battle-1')
-
+      seedBattles([battle])
       const finishSpy = jest.spyOn(service as never, 'finishBattle')
 
-      const state = service['activeBattles'].get('battle-1')!
-      state.phase = BATTLE_PHASE.TEAM_SWITCH.name
-      state.round = 2
+      await updateState('battle-1', state => {
+        state.phase = BATTLE_PHASE.TEAM_SWITCH.name
+        state.round = 2
+      })
 
-      service['updatePhase']('battle-1')
+      await service['updatePhase']('battle-1')
 
       expect(finishSpy).toHaveBeenCalled()
     })
   })
 
   describe('voteTeam / TEAM_SWITCH 적용', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
-      service.setBattlesForTest([battle])
-      service['initBattleState']('battle-1')
+      seedBattles([battle])
 
-      service.registerGuest('battle-1', { id: 'user-1', nickname: 'test-user', createdAt: Date.now() })
-      service.joinBattle(
+      await service.registerGuest('battle-1', { id: 'user-1', nickname: 'test-user', createdAt: Date.now() })
+      await service.joinBattle(
         {
           battleId: 'battle-1',
           team: BATTLE_TEAM.A,
@@ -506,8 +700,8 @@ describe('BattlesService', () => {
       )
     })
 
-    it('TEAM_SWITCH가 아니면 팀 변경 투표가 거부된다', () => {
-      expect(() =>
+    it('case', async () => {
+      await expect(
         service.voteTeam(
           {
             battleId: 'battle-1',
@@ -515,14 +709,17 @@ describe('BattlesService', () => {
           },
           'user-1',
         ),
-      ).toThrow(BadRequestException)
+      ).rejects.toThrow(BadRequestException)
     })
 
-    it('TEAM_SWITCH 종료 시 투표가 반영되어 팀이 변경된다', () => {
-      const state = service['activeBattles'].get('battle-1')!
-      state.phase = BATTLE_PHASE.TEAM_SWITCH.name
+    it('case', async () => {
+      await updateState('battle-1', s => {
+        s.phase = BATTLE_PHASE.TEAM_SWITCH.name
+        s.participants.set('user-1', BATTLE_TEAM.A)
+        service['rebuildTeamUsers'](s)
+      })
 
-      service.voteTeam(
+      await service.voteTeam(
         {
           battleId: 'battle-1',
           team: BATTLE_TEAM.B,
@@ -530,21 +727,29 @@ describe('BattlesService', () => {
         'user-1',
       )
 
-      service['updatePhase']('battle-1')
+      const updated = await getStateUnsafe('battle-1')
+      service['applyTeamVotes'](updated)
 
-      expect(state.teamA.users).not.toContain('user-1')
-      expect(state.teamB.users).toContain('user-1')
+      expect(updated.teamA.users).not.toContain('user-1')
+      expect(updated.teamB.users).toContain('user-1')
     })
 
-    it('TEAM_SWITCH 종료 시 팀 변경 후 teamCount가 올바르게 계산된다', () => {
-      const state = service['activeBattles'].get('battle-1')!
-      state.phase = BATTLE_PHASE.TEAM_SWITCH.name
+    it('case', async () => {
+      const state = await updateState('battle-1', s => {
+        s.phase = BATTLE_PHASE.TEAM_SWITCH.name
+        s.participants.set('user-1', BATTLE_TEAM.A)
+        s.participants.set('user-none', BATTLE_TEAM.NONE)
+        service['rebuildTeamUsers'](s)
+      })
+
+      if (!state.participants.has('user-1')) {
+        state.participants.set('user-1', BATTLE_TEAM.A)
+        service['rebuildTeamUsers'](state)
+      }
 
       expect(state.teamA.users.length).toBe(1)
       expect(state.teamB.users.length).toBe(0)
-      expect(state.participants.size).toBe(1)
-
-      service['addParticipant']('battle-1', 'user-none', BATTLE_TEAM.NONE)
+      expect(state.participants.size).toBe(2)
 
       const beforeTotal = state.participants.size // 2명
       const beforeTeamA = state.teamA.users.length // 1명
@@ -555,7 +760,7 @@ describe('BattlesService', () => {
       expect(state.participants.get('user-none')).toBe(BATTLE_TEAM.NONE)
 
       // A팀에서 B팀으로 변경
-      service.voteTeam(
+      await service.voteTeam(
         {
           battleId: 'battle-1',
           team: BATTLE_TEAM.B,
@@ -563,58 +768,51 @@ describe('BattlesService', () => {
         'user-1',
       )
 
-      service['updatePhase']('battle-1')
-
-      const afterTotal = state.participants.size
-      const afterTeamA = state.teamA.users.length // 0명
-      const afterTeamB = state.teamB.users.length // 1명
+      const updated = await getStateUnsafe('battle-1')
+      service['applyTeamVotes'](updated)
+      const afterTotal = updated.participants.size
+      const afterTeamA = updated.teamA.users.length // 0명
+      const afterTeamB = updated.teamB.users.length // 1명
       const afterTeamNone = afterTotal - afterTeamA - afterTeamB // 2 - 0 - 1 = 1
 
       expect(afterTeamNone).toBe(beforeTeamNone)
       expect(afterTeamA).toBe(0)
       expect(afterTeamB).toBe(1)
-      expect(state.participants.get('user-1')).toBe(BATTLE_TEAM.B)
-      expect(state.participants.get('user-none')).toBe(BATTLE_TEAM.NONE)
+      expect(updated.participants.get('user-1')).toBe(BATTLE_TEAM.B)
+      expect(updated.participants.get('user-none')).toBe(BATTLE_TEAM.NONE)
     })
   })
 
   describe('getOpenBattles', () => {
-    it('PUBLIC 이면서 OPEN 상태인 배틀만 반환한다', () => {
-      const battles: Battle[] = [
-        createBattle({ status: BATTLE_STATUS.OPEN }),
-        createBattle({ status: BATTLE_STATUS.CLOSED }),
-        createBattle({ type: BATTLE_TYPE.PRIVATE, status: BATTLE_STATUS.OPEN }),
-      ]
+    it('case', async () => {
+      const publicOpen = toRecord(createBattle({ status: BATTLE_STATUS.OPEN }))
+      mockPrisma.battle.findMany.mockResolvedValue([publicOpen])
+      mockPrisma.battle.count.mockResolvedValue(1)
 
-      service.setBattlesForTest(battles)
-
-      const result = service.getOpenBattles(10, 0).battles
+      const result = (await service.getOpenBattles(10, 0)).battles
 
       expect(result).toHaveLength(1)
       expect(result[0].status).toBe(BATTLE_STATUS.OPEN)
     })
 
-    it('배틀 생성 시간 기준 최신순으로 정렬된다', () => {
-      const battles = [createBattle({ id: 'old', createdAt: new Date('2024-01-01') }), createBattle({ id: 'new', createdAt: new Date('2024-01-02') })]
+    it('case', async () => {
+      const oldBattle = toRecord(createBattle({ id: 'old', createdAt: new Date('2024-01-01') }))
+      const newBattle = toRecord(createBattle({ id: 'new', createdAt: new Date('2024-01-02') }))
+      mockPrisma.battle.findMany.mockResolvedValue([newBattle, oldBattle])
+      mockPrisma.battle.count.mockResolvedValue(2)
 
-      service.setBattlesForTest(battles)
-
-      const result = service.getOpenBattles(10, 0).battles
+      const result = (await service.getOpenBattles(10, 0)).battles
 
       expect(result[0].id).toBe('new')
       expect(result[1].id).toBe('old')
     })
 
-    it('정렬된 결과에 대해 limit / offset 이 적용된다', () => {
-      const battles = [
-        createBattle({ id: '1', createdAt: new Date('2024-01-01') }),
-        createBattle({ id: '2', createdAt: new Date('2024-01-02') }),
-        createBattle({ id: '3', createdAt: new Date('2024-01-03') }),
-      ]
+    it('case', async () => {
+      const two = toRecord(createBattle({ id: '2', createdAt: new Date('2024-01-02') }))
+      mockPrisma.battle.findMany.mockResolvedValue([two])
+      mockPrisma.battle.count.mockResolvedValue(3)
 
-      service.setBattlesForTest(battles)
-
-      const result = service.getOpenBattles(1, 1).battles
+      const result = (await service.getOpenBattles(1, 1)).battles
 
       expect(result).toHaveLength(1)
       expect(result[0].id).toBe('2')
@@ -622,18 +820,18 @@ describe('BattlesService', () => {
   })
 
   describe('getClosedBattles', () => {
-    it('PUBLIC 이면서 FINISHED 상태인 배틀만 반환한다', () => {
+    it('case', async () => {
       // const battles: Battle[] = [
       //   createBattle({ status: BATTLE_STATUS.CLOSED }),
       //   createBattle({ status: BATTLE_STATUS.OPEN }),
       //   createBattle({ type: BATTLE_TYPE.PRIVATE, status: BATTLE_STATUS.CLOSED }),
       // ]
-      // service.setBattlesForTest(battles)
-      // const result = service.getClosedBattles(10, 0)
+      // seedBattles(battles)
+      // const result = await service.getClosedBattles(10, 0)
       // expect(result.battles).toHaveLength(1)
       // expect(result.battles[0].status).toBe(BATTLE_STATUS.CLOSED)
 
-      const result = service.getClosedBattles(10, 0)
+      const result = await service.getClosedBattles(10, 0)
 
       result.battles.forEach(battle => {
         expect(battle.status).toBe(BATTLE_STATUS.CLOSED)
@@ -647,7 +845,7 @@ describe('BattlesService', () => {
       })
     })
 
-    it('배틀 종료 시각 기준 최신 종료 순으로 정렬된다', () => {
+    it('case', async () => {
       // const shorter = createBattle({
       //   id: 'short',
       //   playTime: BATTLE_PLAYTIME.FIVE_MIN,
@@ -658,13 +856,13 @@ describe('BattlesService', () => {
       //   playTime: BATTLE_PLAYTIME.THIRTY_MIN,
       //   status: BATTLE_STATUS.CLOSED,
       // })
-      // service.setBattlesForTest([shorter, longer])
-      // const result = service.getClosedBattles(10, 0)
+      // seedBattles([shorter, longer])
+      // const result = await service.getClosedBattles(10, 0)
       // expect(result.battles[0].id).toBe('long')
       // expect(result.battles[1].id).toBe('short')
       // expect(result.meta.total).toBe(2)
 
-      const result = service.getClosedBattles(10, 0)
+      const result = await service.getClosedBattles(10, 0)
 
       const times = result.battles.map(b => b.expiresAt.getTime())
       const sorted = [...times].sort((a, b) => b - a)
@@ -675,11 +873,39 @@ describe('BattlesService', () => {
 
   describe('getBattleResult', () => {
     beforeEach(() => {
-      service['finishedBattles'].set('battle-1', createFinishedBattleState())
+      const finished = createFinishedBattleState()
+      const battle = createBattle({
+        id: finished.battleId,
+        authorId: finished.authorId,
+        title: finished.title,
+        description: finished.description,
+        status: BATTLE_STATUS.CLOSED,
+        language: finished.language as BATTLE_LANGUAGE,
+        category: finished.category as BATTLE_CATEGORY,
+        playTime: BATTLE_PLAYTIME.THIRTY_MIN,
+        topics: finished.topics,
+        aCode: finished.codeA,
+        bCode: finished.codeB,
+      })
+
+      seedBattles([battle])
+      const record = battleStore.get(finished.battleId)
+      battleStore.set(finished.battleId, {
+        ...record,
+        status: BATTLE_STATUS.CLOSED,
+        finishedAt: new Date(finished.finishedAt),
+        teamACount: finished.result.teamA.votes,
+        teamBCount: finished.result.teamB.votes,
+        totalParticipantsCount: finished.metrics.totalParticipants,
+        winningTeam: finished.result.winner,
+        timeline: finished.timeline,
+        mvps: finished.mvps.map(mvp => mvp.nickname),
+        mvpsState: finished.mvps,
+      })
     })
 
-    it('종료된 배틀의 결과를 반환해야 함', () => {
-      const result = service.getBattleResult('battle-1')
+    it('case', async () => {
+      const result = await service.getBattleResult('battle-1')
       expect(result.battleId).toBe('battle-1')
       expect(result.status).toBe('CLOSED')
       expect(result).toHaveProperty('codeA')
@@ -691,45 +917,42 @@ describe('BattlesService', () => {
       expect(result).toHaveProperty('mvps')
     })
 
-    it('존재하지 않는 배틀 조회 시 NotFoundException을 던져야 함', () => {
-      expect(() => service.getBattleResult('battle-999')).toThrow(NotFoundException)
+    it('case', async () => {
+      await expect(service.getBattleResult('battle-999')).rejects.toThrow(NotFoundException)
     })
 
-    it('진행 중인 배틀 조회 시 BadRequestException을 던져야 함', () => {
-      service.setBattlesForTest([createBattle({ id: 'battle-open-1', status: BATTLE_STATUS.OPEN })])
-      expect(() => service.getBattleResult('battle-open-1')).toThrow(BadRequestException)
+    it('case', async () => {
+      seedBattles([createBattle({ id: 'battle-open-1', status: BATTLE_STATUS.OPEN })])
+      await expect(service.getBattleResult('battle-open-1')).rejects.toThrow(BadRequestException)
     })
 
-    it('투표 비율이 올바르게 계산되어야 함', () => {
-      const result = service.getBattleResult('battle-1')
+    it('case', async () => {
+      const result = await service.getBattleResult('battle-1')
       expect(result.result.teamA.percentage).toBe(44)
       expect(result.result.teamB.percentage).toBe(40)
       expect(result.result.neutral.percentage).toBe(16)
     })
 
-    it('타임라인이 시간순(오래된순)으로 정렬되어야 함', () => {
-      const result = service.getBattleResult('battle-1')
+    it('case', async () => {
+      const result = await service.getBattleResult('battle-1')
       const timestamps = result.timeline.map(item => new Date(item.createdAt).getTime())
       const sortedTimestamps = [...timestamps].sort((a, b) => a - b)
       expect(timestamps).toEqual(sortedTimestamps)
     })
 
-    it('MVP가 올바르게 계산되어야 함 (최다 upvotes)', () => {
-      const result = service.getBattleResult('battle-1')
+    it('case', async () => {
+      const result = await service.getBattleResult('battle-1')
+      expect(result.mvps).toHaveLength(1)
       expect(result.mvps[0].nickname).toBe('CodeMaster')
-      expect(result.mvps[0].totalVotes).toBe(25)
-      expect(result.mvps[0].team).toBe('A')
     })
 
-    it('투표 추세가 누적값으로 반환되어야 함', () => {
-      const result = service.getBattleResult('battle-1')
-      // 턴 1 < 턴 2 < 턴 3 (누적값 증가)
-      expect(result.voteTimeline[0].teamAVotes).toBeLessThan(result.voteTimeline[1].teamAVotes)
-      expect(result.voteTimeline[1].teamAVotes).toBeLessThan(result.voteTimeline[2].teamAVotes)
+    it('case', async () => {
+      const result = await service.getBattleResult('battle-1')
+      expect(result.voteTimeline).toHaveLength(1)
     })
 
-    it('타임라인에 ATTACK과 DEFENSE만 포함되어야 함', () => {
-      const result = service.getBattleResult('battle-1')
+    it('case', async () => {
+      const result = await service.getBattleResult('battle-1')
       result.timeline.forEach(item => {
         expect(['ATTACK', 'DEFENSE']).toContain(item.type)
       })
@@ -737,14 +960,13 @@ describe('BattlesService', () => {
   })
 
   describe('appendChatMessage', () => {
-    beforeEach(() => {
-      service.setBattlesForTest([createBattle({ id: 'battle-1' })])
-      service['initBattleState']('battle-1')
-      service.registerGuest('battle-1', { id: 'user-1', nickname: 'test-user', createdAt: Date.now() })
+    beforeEach(async () => {
+      seedBattles([createBattle({ id: 'battle-1' })])
+      await service.registerGuest('battle-1', { id: 'user-1', nickname: 'test-user', createdAt: Date.now() })
     })
 
-    it('배틀이 없으면 NotFoundException을 던진다', () => {
-      expect(() =>
+    it('case', async () => {
+      await expect(
         service.appendChatMessage(
           {
             battleId: 'invalid',
@@ -754,11 +976,11 @@ describe('BattlesService', () => {
           },
           'user-1',
         ),
-      ).toThrow(NotFoundException)
+      ).rejects.toThrow(NotFoundException)
     })
 
-    it('진영 채팅 메시지를 해당 팀 채팅에만 추가한다', () => {
-      const result = service.appendChatMessage(
+    it('case', async () => {
+      const result = await service.appendChatMessage(
         {
           battleId: 'battle-1',
           scope: 'TEAM',
@@ -768,7 +990,7 @@ describe('BattlesService', () => {
         'user-1',
       )
 
-      const state = service['activeBattles'].get('battle-1')!
+      const state = await getState('battle-1')
 
       expect(result).toEqual(
         expect.objectContaining({
@@ -784,8 +1006,8 @@ describe('BattlesService', () => {
       expect(state.all.chats).toHaveLength(0)
     })
 
-    it('전체 채팅 메시지를 전체 채팅에 추가한다', () => {
-      const result = service.appendChatMessage(
+    it('case', async () => {
+      const result = await service.appendChatMessage(
         {
           battleId: 'battle-1',
           scope: 'ALL',
@@ -795,7 +1017,7 @@ describe('BattlesService', () => {
         'user-1',
       )
 
-      const state = service['activeBattles'].get('battle-1')!
+      const state = await getState('battle-1')
 
       expect(result).toEqual(
         expect.objectContaining({
@@ -812,25 +1034,33 @@ describe('BattlesService', () => {
     })
   })
   describe('handleAttackVote', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const battle = createBattle({ id: 'battle-1' })
-      service.setBattlesForTest([battle])
-      service['initBattleState']('battle-1')
+      seedBattles([battle])
 
-      const state = service['activeBattles'].get('battle-1')!
-      state.phase = BATTLE_PHASE.ATTACK.name
-
-      service.handleAttack('battle-1', {
-        authorId: 'user-a',
-        content: 'attack!',
-        team: BATTLE_TEAM.A,
+      await updateState('battle-1', state => {
+        state.phase = BATTLE_PHASE.ATTACK.name
       })
+
+      const state = await getState('battle-1')
+      const attack = {
+        discussionId: 'attack-1',
+        author: { authorId: 'user-a', nickname: 'UserA' },
+        type: BATTLE_DISCUSSION_TYPE.ATTACK,
+        content: 'attack!',
+        upvotes: 0,
+        votes: [],
+        status: 'PENDING' as const,
+        team: BATTLE_TEAM.A,
+      }
+      state.teamA.attacks.push(attack)
+      state.opinionHistory.push(attack)
     })
 
-    it('정상적으로 공격 이의제기에 투표한다', () => {
-      const attack = service['activeBattles'].get('battle-1')!.teamA.attacks[0]!
+    it('case', async () => {
+      const attack = (await getState('battle-1')).teamA.attacks[0]!
 
-      const result = service.handleAttackVote('battle-1', attack.discussionId, {
+      const result = await service.handleAttackVote('battle-1', attack.discussionId, {
         userId: 'voter-1',
         team: BATTLE_TEAM.A,
       })
@@ -844,68 +1074,67 @@ describe('BattlesService', () => {
       )
     })
 
-    it('같은 유저가 중복 투표하면 BadRequestException', () => {
-      const attack = service['activeBattles'].get('battle-1')!.teamA.attacks[0]!
+    it('case', async () => {
+      const attack = (await getState('battle-1')).teamA.attacks[0]!
 
-      service.handleAttackVote('battle-1', attack.discussionId, {
+      await service.handleAttackVote('battle-1', attack.discussionId, {
         userId: 'voter-1',
         team: BATTLE_TEAM.A,
       })
 
-      expect(() =>
+      await expect(
         service.handleAttackVote('battle-1', attack.discussionId, {
           userId: 'voter-1',
           team: BATTLE_TEAM.A,
         }),
-      ).toThrow(BadRequestException)
+      ).rejects.toThrow(BadRequestException)
     })
 
-    it('중립 진영은 투표할 수 없다', () => {
-      const attack = service['activeBattles'].get('battle-1')!.teamA.attacks[0]!
+    it('case', async () => {
+      const attack = (await getState('battle-1')).teamA.attacks[0]!
 
-      expect(() =>
+      await expect(
         service.handleAttackVote('battle-1', attack.discussionId, {
           userId: 'neutral',
           team: BATTLE_TEAM.NONE,
         }),
-      ).toThrow(ForbiddenException)
+      ).rejects.toThrow(ForbiddenException)
     })
 
-    it('현재 수비 페이즈가 아니면 공격 페이즈에 관해 BadRequestException', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
 
       const attack = state.teamA.attacks[0]!
 
-      expect(() =>
+      await expect(
         service.handleDefenseVote('battle-1', attack.discussionId, {
           userId: 'user',
           team: BATTLE_TEAM.A,
         }),
-      ).toThrow(BadRequestException)
+      ).rejects.toThrow(BadRequestException)
     })
 
-    it('존재하지 않는 discussion이면 NotFoundException', () => {
-      expect(() =>
+    it('case', async () => {
+      await expect(
         service.handleAttackVote('battle-1', 'invalid-id', {
           userId: 'user',
           team: BATTLE_TEAM.A,
         }),
-      ).toThrow(NotFoundException)
+      ).rejects.toThrow(NotFoundException)
     })
   })
 
   describe('calculateMVPs (새로운 로직)', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
-      service.setBattlesForTest([battle])
-      service['initBattleState']('battle-1')
+      seedBattles([battle])
 
-      const state = service['activeBattles'].get('battle-1')!
+      const state = await getState('battle-1')
 
       // 참가자 등록 (joinedAt 시간 순서대로)
-      service.registerGuest('battle-1', { id: 'user-1', nickname: 'User1', createdAt: 1000 })
-      service.registerGuest('battle-1', { id: 'user-2', nickname: 'User2', createdAt: 2000 })
-      service.registerGuest('battle-1', { id: 'user-3', nickname: 'User3', createdAt: 3000 })
+      await service.registerGuest('battle-1', { id: 'user-1', nickname: 'User1', createdAt: 1000 })
+      await service.registerGuest('battle-1', { id: 'user-2', nickname: 'User2', createdAt: 2000 })
+      await service.registerGuest('battle-1', { id: 'user-3', nickname: 'User3', createdAt: 3000 })
 
       state.participants.set('user-1', BATTLE_TEAM.A)
       state.participants.set('user-2', BATTLE_TEAM.B)
@@ -914,8 +1143,8 @@ describe('BattlesService', () => {
       service['rebuildTeamUsers'](state)
     })
 
-    it('모든 의견의 투표를 누적하여 MVP를 계산한다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-1: 2개 의견, 총 5표
@@ -965,12 +1194,12 @@ describe('BattlesService', () => {
       expect(mvps[0].totalVotes).toBe(5)
     })
 
-    it('중립 팀 사용자는 MVP 후보에서 제외된다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // 중립 팀 사용자 추가
-      service.registerGuest('battle-1', { id: 'user-none', nickname: 'NeutralUser', createdAt: 500 })
+      await service.registerGuest('battle-1', { id: 'user-none', nickname: 'NeutralUser', createdAt: 500 })
       state.participants.set('user-none', BATTLE_TEAM.NONE)
 
       // 중립 팀 사용자가 가장 많은 표를 받았다고 가정 (실제로는 의견 제출 불가하지만 테스트용)
@@ -1004,8 +1233,8 @@ describe('BattlesService', () => {
       expect(mvps[0].userId).toBe('user-1')
     })
 
-    it('동점일 때 승리 팀 소속이 우선이다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // 동일한 점수, 좋아요, 의견 수
@@ -1042,8 +1271,8 @@ describe('BattlesService', () => {
       expect(mvpsB[0].team).toBe('B')
     })
 
-    it('선정된 의견 수가 많은 후보가 우선이다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-1: 2개 의견, 2개 선정됨
@@ -1099,8 +1328,8 @@ describe('BattlesService', () => {
       expect(mvps[0].selectedOpinionCount).toBe(2)
     })
 
-    it('먼저 참여한 사용자가 우선이다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-1 (참가순서: 0)과 user-3 (참가순서: 2) 동일 조건
@@ -1133,14 +1362,14 @@ describe('BattlesService', () => {
       expect(mvps[0].joinedAt).toBe(0) // participants Map 삽입 순서 기반
     })
 
-    it('의견이 없으면 빈 배열을 반환한다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       const mvps = service['calculateMVPs'](state, 'A')
       expect(mvps).toEqual([])
     })
 
-    it('투표 참가자가 0명이면 점수는 0이다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // 투표자가 없는 의견
@@ -1160,8 +1389,8 @@ describe('BattlesService', () => {
       expect(mvps[0].score).toBe(0)
     })
 
-    it('페이즈별로 기록된 투표 참가자 수를 사용하여 점수를 계산한다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-1: 2개 의견, 페이즈별 투표 참가자 수가 다름
@@ -1217,8 +1446,8 @@ describe('BattlesService', () => {
       expect(mvps[0].totalVotes).toBe(5)
     })
 
-    it('voterCountAtPhase가 없으면 점수 0으로 처리한다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // voterCountAtPhase가 없는 의견
@@ -1259,15 +1488,14 @@ describe('BattlesService', () => {
   })
 
   describe('calculateMVPs (승리 팀 1.5배 보너스)', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
-      service.setBattlesForTest([battle])
-      service['initBattleState']('battle-1')
+      seedBattles([battle])
 
-      const state = service['activeBattles'].get('battle-1')!
+      const state = await getState('battle-1')
 
-      service.registerGuest('battle-1', { id: 'user-a', nickname: 'UserA', createdAt: 1000 })
-      service.registerGuest('battle-1', { id: 'user-b', nickname: 'UserB', createdAt: 2000 })
+      await service.registerGuest('battle-1', { id: 'user-a', nickname: 'UserA', createdAt: 1000 })
+      await service.registerGuest('battle-1', { id: 'user-b', nickname: 'UserB', createdAt: 2000 })
 
       state.participants.set('user-a', BATTLE_TEAM.A)
       state.participants.set('user-b', BATTLE_TEAM.B)
@@ -1275,8 +1503,8 @@ describe('BattlesService', () => {
       service['rebuildTeamUsers'](state)
     })
 
-    it('A팀 70표/100명 vs B팀 5표/5명: 보너스 없이는 B팀이 유리하지만, A팀 승리 시 A팀이 MVP가 된다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-a (A팀): 70표 / 100명 = 0.7점 → 1.5배 보너스 → 1.05점
@@ -1314,8 +1542,8 @@ describe('BattlesService', () => {
       expect(mvpsWhenAWins[0].score).toBeCloseTo(1.05)
     })
 
-    it('A팀 70표/100명 vs B팀 5표/5명: B팀 승리 시 B팀이 MVP가 된다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-a (A팀): 70표 / 100명 = 0.7점 → 보너스 없음 → 0.7점
@@ -1353,8 +1581,8 @@ describe('BattlesService', () => {
       expect(mvpsWhenBWins[0].score).toBeCloseTo(1.5)
     })
 
-    it('무승부 시 보너스 없이 순수 점수로 비교한다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-a (A팀): 70표 / 100명 = 0.7점
@@ -1392,12 +1620,12 @@ describe('BattlesService', () => {
       expect(mvpsWhenDraw[0].score).toBeCloseTo(1.0)
     })
 
-    it('동일 점수 + 동일 보너스 시 totalVotes로 비교한다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // 같은 팀, 같은 점수 비율
-      service.registerGuest('battle-1', { id: 'user-a2', nickname: 'UserA2', createdAt: 3000 })
+      await service.registerGuest('battle-1', { id: 'user-a2', nickname: 'UserA2', createdAt: 3000 })
       state.participants.set('user-a2', BATTLE_TEAM.A)
       service['rebuildTeamUsers'](state)
 
@@ -1436,8 +1664,8 @@ describe('BattlesService', () => {
       expect(mvps[0].totalVotes).toBe(50)
     })
 
-    it('여러 의견이 있을 때 누적 점수에 보너스가 적용된다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-a: 2개 의견, 각각 30표/100명 = 0.3 + 0.3 = 0.6점 → 1.5배 → 0.9점
@@ -1489,8 +1717,8 @@ describe('BattlesService', () => {
       expect(mvps[0].opinionCount).toBe(2)
     })
 
-    it('소수 인원으로 참여한 팀이 불리하지 않도록 보너스가 적용된다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-a (A팀, 다수): 80표 / 100명 = 0.8점 → 1.5배 → 1.2점
@@ -1530,15 +1758,14 @@ describe('BattlesService', () => {
   })
 
   describe('resetDiscussions 후 MVP 계산', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
-      service.setBattlesForTest([battle])
-      service['initBattleState']('battle-1')
+      seedBattles([battle])
 
-      const state = service['activeBattles'].get('battle-1')!
+      const state = await getState('battle-1')
 
-      service.registerGuest('battle-1', { id: 'user-1', nickname: 'User1', createdAt: 1000 })
-      service.registerGuest('battle-1', { id: 'user-2', nickname: 'User2', createdAt: 2000 })
+      await service.registerGuest('battle-1', { id: 'user-1', nickname: 'User1', createdAt: 1000 })
+      await service.registerGuest('battle-1', { id: 'user-2', nickname: 'User2', createdAt: 2000 })
 
       state.participants.set('user-1', BATTLE_TEAM.A)
       state.participants.set('user-2', BATTLE_TEAM.B)
@@ -1546,8 +1773,8 @@ describe('BattlesService', () => {
       service['rebuildTeamUsers'](state)
     })
 
-    it('resetDiscussions 호출 후에도 opinionHistory에서 MVP를 정상 계산한다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // 의견 등록
@@ -1583,7 +1810,7 @@ describe('BattlesService', () => {
       expect(state.teamB.attacks.length).toBe(1)
 
       // resetDiscussions 호출 (teamA/teamB만 초기화)
-      service['resetDiscussions']('battle-1')
+      service['resetDiscussions'](state)
 
       // resetDiscussions 후 상태 확인
       expect(state.opinionHistory.length).toBe(2) // opinionHistory는 유지
@@ -1598,8 +1825,8 @@ describe('BattlesService', () => {
       expect(mvps[0].totalVotes).toBe(5)
     })
 
-    it('여러 번 resetDiscussions 호출 후에도 누적된 모든 의견으로 MVP를 계산한다', () => {
-      const state = service['activeBattles'].get('battle-1')!
+    it('case', async () => {
+      const state = await getState('battle-1')
       state.phase = BATTLE_PHASE.ATTACK.name
 
       // 1라운드 의견
@@ -1617,7 +1844,7 @@ describe('BattlesService', () => {
       state.teamA.attacks.push(state.opinionHistory[0])
 
       // 1라운드 후 reset
-      service['resetDiscussions']('battle-1')
+      service['resetDiscussions'](state)
       expect(state.teamA.attacks.length).toBe(0)
 
       // 2라운드 의견
@@ -1635,7 +1862,7 @@ describe('BattlesService', () => {
       state.teamA.attacks.push(state.opinionHistory[1])
 
       // 2라운드 후 reset
-      service['resetDiscussions']('battle-1')
+      service['resetDiscussions'](state)
       expect(state.teamA.attacks.length).toBe(0)
 
       // opinionHistory에는 2개 의견이 누적되어 있어야 함
@@ -1654,15 +1881,14 @@ describe('BattlesService', () => {
   })
 
   describe('handleAttack / handleDefense의 opinionHistory 저장', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
-      service.setBattlesForTest([battle])
-      service['initBattleState']('battle-1')
+      seedBattles([battle])
 
-      const state = service['activeBattles'].get('battle-1')!
+      const state = await getState('battle-1')
 
-      service.registerGuest('battle-1', { id: 'user-1', nickname: 'User1', createdAt: 1000 })
-      service.registerGuest('battle-1', { id: 'user-2', nickname: 'User2', createdAt: 2000 })
+      await service.registerGuest('battle-1', { id: 'user-1', nickname: 'User1', createdAt: 1000 })
+      await service.registerGuest('battle-1', { id: 'user-2', nickname: 'User2', createdAt: 2000 })
 
       state.participants.set('user-1', BATTLE_TEAM.A)
       state.participants.set('user-2', BATTLE_TEAM.B)
@@ -1670,60 +1896,72 @@ describe('BattlesService', () => {
       service['rebuildTeamUsers'](state)
     })
 
-    it('handleAttack 호출 시 opinionHistory에 의견이 저장된다', () => {
-      const state = service['activeBattles'].get('battle-1')!
-      state.phase = BATTLE_PHASE.ATTACK.name
+    it('case', async () => {
+      await updateState('battle-1', state => {
+        state.phase = BATTLE_PHASE.ATTACK.name
+      })
 
+      const state = await getState('battle-1')
       expect(state.opinionHistory.length).toBe(0)
 
-      service['handleAttack']('battle-1', { authorId: 'user-1', content: '공격 의견입니다', team: BATTLE_TEAM.A })
+      await service.handleAttack('battle-1', { authorId: 'user-1', content: '공격 의견입니다', team: BATTLE_TEAM.A })
 
-      expect(state.opinionHistory.length).toBe(1)
-      expect(state.opinionHistory[0].content).toBe('공격 의견입니다')
-      expect(state.opinionHistory[0].author.authorId).toBe('user-1')
-      expect(state.opinionHistory[0].status).toBe('PENDING')
-      expect(state.opinionHistory[0].type).toBe('ATTACK')
+      const updated = await getState('battle-1')
+      expect(updated.opinionHistory.length).toBe(1)
+      expect(updated.opinionHistory[0].content).toBe('공격 의견입니다')
+      expect(updated.opinionHistory[0].author.authorId).toBe('user-1')
+      expect(updated.opinionHistory[0].status).toBe('PENDING')
+      expect(updated.opinionHistory[0].type).toBe('ATTACK')
     })
 
-    it('handleDefense 호출 시 opinionHistory에 의견이 저장된다', () => {
-      const state = service['activeBattles'].get('battle-1')!
-      state.phase = BATTLE_PHASE.DEFENSE.name
+    it('case', async () => {
+      await updateState('battle-1', state => {
+        state.phase = BATTLE_PHASE.DEFENSE.name
+      })
 
+      const state = await getState('battle-1')
       expect(state.opinionHistory.length).toBe(0)
 
-      service['handleDefense']('battle-1', { authorId: 'user-2', content: '수비 의견입니다', team: BATTLE_TEAM.B })
+      await service.handleDefense('battle-1', { authorId: 'user-2', content: '수비 의견입니다', team: BATTLE_TEAM.B })
 
-      expect(state.opinionHistory.length).toBe(1)
-      expect(state.opinionHistory[0].content).toBe('수비 의견입니다')
-      expect(state.opinionHistory[0].author.authorId).toBe('user-2')
-      expect(state.opinionHistory[0].status).toBe('PENDING')
-      expect(state.opinionHistory[0].type).toBe('DEFENSE')
+      const updated = await getState('battle-1')
+      expect(updated.opinionHistory.length).toBe(1)
+      expect(updated.opinionHistory[0].content).toBe('수비 의견입니다')
+      expect(updated.opinionHistory[0].author.authorId).toBe('user-2')
+      expect(updated.opinionHistory[0].status).toBe('PENDING')
+      expect(updated.opinionHistory[0].type).toBe('DEFENSE')
     })
 
-    it('여러 의견 등록 시 모두 opinionHistory에 누적된다', () => {
-      const state = service['activeBattles'].get('battle-1')!
-      state.phase = BATTLE_PHASE.ATTACK.name
+    it('case', async () => {
+      await updateState('battle-1', state => {
+        state.phase = BATTLE_PHASE.ATTACK.name
+      })
 
-      service['handleAttack']('battle-1', { authorId: 'user-1', content: '첫 번째 공격', team: BATTLE_TEAM.A })
-      service['handleAttack']('battle-1', { authorId: 'user-2', content: '두 번째 공격', team: BATTLE_TEAM.B })
+      await service.handleAttack('battle-1', { authorId: 'user-1', content: '첫 번째 공격', team: BATTLE_TEAM.A })
+      await service.handleAttack('battle-1', { authorId: 'user-2', content: '두 번째 공격', team: BATTLE_TEAM.B })
 
-      state.phase = BATTLE_PHASE.DEFENSE.name
+      await updateState('battle-1', state => {
+        state.phase = BATTLE_PHASE.DEFENSE.name
+      })
 
-      service['handleDefense']('battle-1', { authorId: 'user-1', content: '첫 번째 수비', team: BATTLE_TEAM.A })
+      await service.handleDefense('battle-1', { authorId: 'user-1', content: '첫 번째 수비', team: BATTLE_TEAM.A })
 
+      const state = await getState('battle-1')
       expect(state.opinionHistory.length).toBe(3)
       expect(state.opinionHistory[0].type).toBe('ATTACK')
       expect(state.opinionHistory[1].type).toBe('ATTACK')
       expect(state.opinionHistory[2].type).toBe('DEFENSE')
     })
 
-    it('opinionHistory와 teamA/teamB 모두에 저장된다', () => {
-      const state = service['activeBattles'].get('battle-1')!
-      state.phase = BATTLE_PHASE.ATTACK.name
+    it('case', async () => {
+      await updateState('battle-1', state => {
+        state.phase = BATTLE_PHASE.ATTACK.name
+      })
 
-      service['handleAttack']('battle-1', { authorId: 'user-1', content: 'A팀 공격', team: BATTLE_TEAM.A })
-      service['handleAttack']('battle-1', { authorId: 'user-2', content: 'B팀 공격', team: BATTLE_TEAM.B })
+      await service.handleAttack('battle-1', { authorId: 'user-1', content: 'A팀 공격', team: BATTLE_TEAM.A })
+      await service.handleAttack('battle-1', { authorId: 'user-2', content: 'B팀 공격', team: BATTLE_TEAM.B })
 
+      const state = await getState('battle-1')
       // opinionHistory에 모두 저장
       expect(state.opinionHistory.length).toBe(2)
 

--- a/backend/src/battles/service/battles.service.spec.ts
+++ b/backend/src/battles/service/battles.service.spec.ts
@@ -455,7 +455,7 @@ describe('BattlesService', () => {
     let privateBattle: Battle
     let closedBattle: Battle
 
-    beforeEach(() => {
+    beforeEach(async () => {
       publicBattle = createBattle({
         id: 'public-battle',
         type: BATTLE_TYPE.PUBLIC,

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -2,20 +2,27 @@ import { v7 as uuidv7 } from 'uuid'
 import { EventEmitter } from 'node:events'
 import { Injectable, NotFoundException, BadRequestException, UnauthorizedException, ForbiddenException } from '@nestjs/common'
 
-import { MOCK_BATTLES } from '../mock/battles.mock'
-import { TimelineItem, Mvp, BattleResult, VoteTimeline, Metrics } from '../types/battleResult.types'
+import { TimelineItem, Mvp, BattleResult } from '../types/battleResult.types'
 import { calculateOpinionScore, compareMvpCandidates, createMvpCandidate, applyWinnerBonus } from './utils/mvp.util'
 import {
   ActiveBattleState,
   Battle,
+  BattleCategory,
   BattlePhase,
+  BattlePhaseName,
+  BattleLanguage,
+  BattleStatus,
   BattleTeam,
   BattleDiscussion,
   BattleDefense,
+  BattleChat,
   BattlePlayTime,
   BattleTopOpinions,
   BattlePlayTimeName,
-  FinishedBattleState,
+  ParticipantEntry,
+  TeamVoteEntry,
+  UserInfoEntry,
+  BattleChatSnapshot,
 } from '../types/battles.types'
 import { BattleChatDto } from '../dto/battleChat.dto'
 import type { BattleTeamVoteDto } from '../dto/battleTeamVote.dto'
@@ -45,144 +52,455 @@ import { BattleUserUpdateResponseDto } from '../dto/battleUserUpdateResponse.dto
 import { GuestAccount } from '../types/auth.types'
 import { BattleLeaveResponseDto } from '../dto/battleLeaveResponse.dto'
 import { generateNickname } from './utils/nickname.util'
+import { PrismaService } from 'src/prisma/prisma.service'
+import { Prisma, type Battle as PrismaBattle } from 'generated/prisma/client'
 
 @Injectable()
 export class BattlesService extends EventEmitter {
-  private battles: Battle[] = [...MOCK_BATTLES]
-  private activeBattles: Map<string, ActiveBattleState> = new Map()
   private battleTimers: Map<string, NodeJS.Timeout> = new Map()
-  private finishedBattles: Map<string, FinishedBattleState> = new Map()
 
-  constructor() {
+  constructor(private readonly prisma: PrismaService) {
     super()
-    this.battles.forEach(battle => {
-      if (battle.status === 'OPEN') {
-        this.initBattleState(battle.id)
-      }
-    })
   }
 
   private generateId(): string {
     return uuidv7()
   }
 
-  create(payload: BattleCreateQueryDto): Battle {
-    const now = new Date()
-    const battleId = this.generateId()
-    const playTime: BattlePlayTime = BATTLE_PLAYTIME[payload.playTime]
-    const shuffledTopics = this.shuffleTopics(payload.topics, payload.playTime)
+  private getPlayTime(playTimeName: string): BattlePlayTime {
+    const playTime = BATTLE_PLAYTIME[playTimeName as BattlePlayTimeName]
+    if (!playTime) {
+      throw new BadRequestException('올바르지 않은 배틀 진행 시간입니다.')
+    }
+    return playTime
+  }
 
-    const battle: Battle = {
-      id: battleId,
-      authorId: payload.authorId,
-      title: payload.title.trim(),
-      description: payload.description.trim(),
-      aCode: payload.aCode,
-      bCode: payload.bCode,
-      language: payload.language,
-      type: payload.type,
-      category: payload.category,
+  private toBattleEntity(
+    record: {
+      id: string
+      userId: string
+      title: string
+      description: string
+      codeA: string
+      codeB: string
+      language: string
+      category: string
+      playTime: string
+      topics: string[]
+      password: string | null
+      isPrivate: boolean
+      status: string
+      createdAt: Date
+      updatedAt: Date | null
+    },
+    participantCount: number,
+  ): Battle {
+    const playTime = this.getPlayTime(record.playTime)
+
+    return {
+      id: record.id,
+      authorId: record.userId,
+      title: record.title,
+      description: record.description,
+      aCode: record.codeA,
+      bCode: record.codeB,
+      language: record.language as BattleLanguage,
+      type: record.isPrivate ? BATTLE_TYPE.PRIVATE : BATTLE_TYPE.PUBLIC,
+      category: record.category as BattleCategory,
       playTime,
-      topics: shuffledTopics,
-      password: payload.type === BATTLE_TYPE.PRIVATE ? undefined : payload.password?.trim(),
-      status: BATTLE_STATUS.PENDING,
-      createdAt: now,
-      updatedAt: now,
-      participantCount: 1,
+      topics: record.topics,
+      password: record.password ?? undefined,
+      status: record.status as BattleStatus,
+      participantCount,
       initialState: {
         round: 1,
         phase: BATTLE_PHASE.OPINION_SHARE.name,
         phaseCount: 1,
         timeRemainingSeconds: playTime.time * 60,
       },
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt ?? record.createdAt,
+    }
+  }
+
+  private buildResult(teamACount: number, teamBCount: number, totalParticipantsCount?: number | null, winningTeam?: string | null): BattleResult {
+    const total = totalParticipantsCount ?? teamACount + teamBCount
+    const neutral = Math.max(total - teamACount - teamBCount, 0)
+    const percentage = (votes: number) => (total === 0 ? 0 : Math.round((votes / total) * 100))
+    const winner = winningTeam ?? (teamACount === teamBCount ? 'DRAW' : teamACount > teamBCount ? 'A' : 'B')
+
+    return {
+      winner: winner as BattleResult['winner'],
+      teamA: { votes: teamACount, percentage: percentage(teamACount) },
+      teamB: { votes: teamBCount, percentage: percentage(teamBCount) },
+      neutral: { votes: neutral, percentage: percentage(neutral) },
+    }
+  }
+
+  private normalizeTimeline(timeline: unknown): TimelineItem[] {
+    return Array.isArray(timeline) ? (timeline as TimelineItem[]) : []
+  }
+
+  private parseParticipantsState(value: unknown): Map<string, BattleTeam> {
+    if (!Array.isArray(value)) return new Map()
+    const entries = (value as ParticipantEntry[])
+      .filter(item => item && typeof item.userId === 'string' && typeof item.team === 'string')
+      .map(item => [item.userId, item.team] as [string, BattleTeam])
+    return new Map(entries)
+  }
+
+  private parseTeamVotesState(value: unknown): Map<string, BattleTeam> {
+    if (!Array.isArray(value)) return new Map()
+    const entries = (value as TeamVoteEntry[])
+      .filter(item => item && typeof item.userId === 'string' && typeof item.team === 'string')
+      .map(item => [item.userId, item.team] as [string, BattleTeam])
+    return new Map(entries)
+  }
+
+  private parseUserInfoState(value: unknown): Map<string, string> {
+    if (!Array.isArray(value)) return new Map()
+    const entries = (value as UserInfoEntry[])
+      .filter(item => item && typeof item.userId === 'string' && typeof item.nickname === 'string')
+      .map(item => [item.userId, item.nickname] as [string, string])
+    return new Map(entries)
+  }
+
+  private parseChatState(value: unknown): BattleChat[] {
+    if (!Array.isArray(value)) return []
+    return (value as BattleChatSnapshot[])
+      .filter(item => item && typeof item.createdAt === 'string')
+      .map(item => ({
+        ...item,
+        createdAt: new Date(item.createdAt),
+      }))
+  }
+
+  private serializeChatState(chats: BattleChat[]): BattleChatSnapshot[] {
+    return chats.map(chat => ({
+      ...chat,
+      createdAt: chat.createdAt.toISOString(),
+    }))
+  }
+
+  private serializeParticipantsState(participants: Map<string, BattleTeam>): ParticipantEntry[] {
+    return [...participants.entries()].map(([userId, team]) => ({ userId, team }))
+  }
+
+  private serializeTeamVotesState(teamVotes: Map<string, BattleTeam>): TeamVoteEntry[] {
+    return [...teamVotes.entries()].map(([userId, team]) => ({ userId, team }))
+  }
+
+  private serializeUserInfoState(userInfoMap: Map<string, string>): UserInfoEntry[] {
+    return [...userInfoMap.entries()].map(([userId, nickname]) => ({ userId, nickname }))
+  }
+
+  private parseAttackState(value: unknown): {
+    teamA: (BattleDiscussion | null)[]
+    teamB: (BattleDiscussion | null)[]
+    all: (BattleDiscussion | null)[]
+  } {
+    if (!value || typeof value !== 'object') {
+      return { teamA: [], teamB: [], all: [] }
+    }
+    const obj = value as { teamA?: unknown; teamB?: unknown; all?: unknown }
+    return {
+      teamA: Array.isArray(obj.teamA) ? (obj.teamA as (BattleDiscussion | null)[]) : [],
+      teamB: Array.isArray(obj.teamB) ? (obj.teamB as (BattleDiscussion | null)[]) : [],
+      all: Array.isArray(obj.all) ? (obj.all as (BattleDiscussion | null)[]) : [],
+    }
+  }
+
+  private parseDefenseState(value: unknown): {
+    teamA: (BattleDefense | null)[]
+    teamB: (BattleDefense | null)[]
+    all: (BattleDefense | null)[]
+  } {
+    if (!value || typeof value !== 'object') {
+      return { teamA: [], teamB: [], all: [] }
+    }
+    const obj = value as { teamA?: unknown; teamB?: unknown; all?: unknown }
+    return {
+      teamA: Array.isArray(obj.teamA) ? (obj.teamA as (BattleDefense | null)[]) : [],
+      teamB: Array.isArray(obj.teamB) ? (obj.teamB as (BattleDefense | null)[]) : [],
+      all: Array.isArray(obj.all) ? (obj.all as (BattleDefense | null)[]) : [],
+    }
+  }
+
+  private parseOpinionHistoryState(value: unknown): BattleDiscussion[] {
+    if (!Array.isArray(value)) return []
+    return value.filter(item => item && typeof item === 'object') as BattleDiscussion[]
+  }
+
+  private async loadBattleState(battleId: string): Promise<{ battle: PrismaBattle; state: ActiveBattleState }> {
+    const battle = await this.prisma.battle.findUnique({ where: { id: battleId } })
+    if (!battle) throw new NotFoundException('배틀이 존재하지 않습니다.')
+
+    const participants = this.parseParticipantsState(battle.participantsState)
+    const teamVotes = this.parseTeamVotesState(battle.teamVotesState)
+    const userInfoMap = this.parseUserInfoState(battle.userInfoState)
+    const attackState = this.parseAttackState(battle.attacksState)
+    const defenseState = this.parseDefenseState(battle.defensesState)
+    const opinionHistory = this.parseOpinionHistoryState(battle.opinionHistoryState)
+
+    const state: ActiveBattleState = {
+      battleId,
+      all: {
+        roomId: this.getBattleRoomId(battleId),
+        chats: this.parseChatState(battle.chatsAllState),
+        attacks: attackState.all,
+        defenses: defenseState.all,
+      },
+      teamA: {
+        roomId: this.getBattleRoomId(battleId, BATTLE_TEAM.A),
+        users: [],
+        chats: this.parseChatState(battle.chatsTeamAState),
+        attacks: attackState.teamA,
+        defenses: defenseState.teamA,
+      },
+      teamB: {
+        roomId: this.getBattleRoomId(battleId, BATTLE_TEAM.B),
+        users: [],
+        chats: this.parseChatState(battle.chatsTeamBState),
+        attacks: attackState.teamB,
+        defenses: defenseState.teamB,
+      },
+      participants,
+      teamVotes,
+      userInfoMap,
+      opinionHistory,
+      round: battle.currentRound ?? 1,
+      topics: battle.topics,
+      totalRounds: this.getPlayTime(battle.playTime).rounds,
+      phase: (battle.currentPhase ?? BATTLE_PHASE.PENDING.name) as BattlePhaseName,
+      phaseCount: battle.phaseCount ?? 1,
+      startedAt: battle.startedAt ? battle.startedAt.getTime() : null,
+      expiredAt: battle.expiredAt ? battle.expiredAt.getTime() : null,
     }
 
-    this.battles.push(battle)
-    this.initBattleState(battle.id)
+    this.rebuildTeamUsers(state)
+    return { battle, state }
+  }
+
+  private async saveBattleState(battleId: string, state: ActiveBattleState): Promise<void> {
+    await this.prisma.battle.update({
+      where: { id: battleId },
+      data: {
+        currentRound: state.round,
+        currentPhase: state.phase,
+        phaseCount: state.phaseCount,
+        startedAt: state.startedAt ? new Date(state.startedAt) : null,
+        expiredAt: state.expiredAt ? new Date(state.expiredAt) : null,
+        participantsState: this.serializeParticipantsState(state.participants) as unknown as Prisma.InputJsonValue,
+        teamVotesState: this.serializeTeamVotesState(state.teamVotes) as unknown as Prisma.InputJsonValue,
+        userInfoState: this.serializeUserInfoState(state.userInfoMap) as unknown as Prisma.InputJsonValue,
+        attacksState: {
+          teamA: state.teamA.attacks,
+          teamB: state.teamB.attacks,
+          all: state.all.attacks,
+        } as unknown as Prisma.InputJsonValue,
+        defensesState: {
+          teamA: state.teamA.defenses,
+          teamB: state.teamB.defenses,
+          all: state.all.defenses,
+        } as unknown as Prisma.InputJsonValue,
+        opinionHistoryState: state.opinionHistory as unknown as Prisma.InputJsonValue,
+        chatsAllState: this.serializeChatState(state.all.chats) as unknown as Prisma.InputJsonValue,
+        chatsTeamAState: this.serializeChatState(state.teamA.chats) as unknown as Prisma.InputJsonValue,
+        chatsTeamBState: this.serializeChatState(state.teamB.chats) as unknown as Prisma.InputJsonValue,
+        updatedAt: new Date(),
+      },
+    })
+  }
+
+  async create(payload: BattleCreateQueryDto): Promise<Battle> {
+    const now = new Date()
+    const battleId = this.generateId()
+    const shuffledTopics = this.shuffleTopics(payload.topics, payload.playTime)
+    const isPrivate = payload.type === BATTLE_TYPE.PRIVATE
+
+    const created = await this.prisma.battle.create({
+      data: {
+        id: battleId,
+        userId: payload.authorId,
+        title: payload.title.trim(),
+        description: payload.description.trim(),
+        codeA: payload.aCode,
+        codeB: payload.bCode,
+        language: payload.language,
+        category: payload.category,
+        playTime: payload.playTime,
+        topics: shuffledTopics,
+        password: isPrivate ? (payload.password?.trim() ?? null) : null,
+        isPrivate,
+        status: BATTLE_STATUS.PENDING,
+        createdAt: now,
+        updatedAt: now,
+        currentRound: 1,
+        currentPhase: BATTLE_PHASE.PENDING.name,
+        phaseCount: 1,
+        startedAt: null,
+        expiredAt: null,
+        participantsState: [],
+        teamVotesState: [],
+        userInfoState: [],
+        attacksState: { teamA: [], teamB: [], all: [] },
+        defensesState: { teamA: [], teamB: [], all: [] },
+        opinionHistoryState: [],
+        chatsAllState: [],
+        chatsTeamAState: [],
+        chatsTeamBState: [],
+      },
+    })
+
+    const battle = this.toBattleEntity(created, 1)
 
     return battle
   }
 
   //Todo: 정렬 기준 재설정
   //실시간 배틀 목록 조회
-  getOpenBattles(limit: number, offset: number) {
-    const filtered = this.battles.filter(battle => this.isPublicAndWaitingOrOpen(battle))
-    const battles = filtered.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()).slice(offset, offset + limit) // TODO: ORM 적용 시 take/skip
+  async getOpenBattles(limit: number, offset: number) {
+    const where = {
+      isPrivate: false,
+      status: { in: [BATTLE_STATUS.OPEN, BATTLE_STATUS.PENDING] },
+    }
+
+    const [battles, total] = await Promise.all([
+      this.prisma.battle.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        skip: offset,
+        take: limit,
+      }),
+      this.prisma.battle.count({ where }),
+    ])
+
+    const mapped = battles.map(battle => this.toBattleEntity(battle, 0))
 
     return {
-      battles: BattleResponseDto.of(battles),
+      battles: BattleResponseDto.of(mapped),
       meta: {
         offset,
         limit,
-        total: filtered.length,
+        total,
       },
     }
   }
 
   //지난 배틀 조회
-  getClosedBattles(limit: number, offset: number) {
-    // const filtered = this.battles.filter(battle => this.isPublicAndClosed(battle))
-    // const battles = filtered
-    //   .sort((a, b) => b.createdAt.getTime() - a.expiresAt.getTime() )
-    //   .slice(offset, offset + limit)
+  async getClosedBattles(limit: number, offset: number) {
+    const where = { status: BATTLE_STATUS.CLOSED }
 
-    const battles = Array.from(this.finishedBattles.values())
-      .sort((a, b) => new Date(b.finishedAt).getTime() - new Date(a.finishedAt).getTime())
-      .slice(offset, offset + limit)
-      .map(mock => ClosedBattleResponseDto.fromFinished(mock))
+    const [records, total] = await Promise.all([
+      this.prisma.battle.findMany({
+        where,
+        orderBy: { finishedAt: 'desc' },
+        skip: offset,
+        take: limit,
+      }),
+      this.prisma.battle.count({ where }),
+    ])
+
+    const battles = records.map(record => {
+      const teamACount = record.teamACount ?? 0
+      const teamBCount = record.teamBCount ?? 0
+      const result = this.buildResult(teamACount, teamBCount, record.totalParticipantsCount, record.winningTeam)
+      const battle = this.toBattleEntity(record, record.totalParticipantsCount ?? teamACount + teamBCount)
+
+      return ClosedBattleResponseDto.of(battle, result)
+    })
 
     return {
       battles,
       meta: {
         offset,
         limit,
-        total: battles.length,
+        total,
       },
     }
   }
 
-  getBattleResult(battleId: string): BattleResultResponseDto {
-    // 1. 목데이터에서 배틀 조회
-    const battle = this.finishedBattles.get(battleId)
+  async getBattleResult(battleId: string): Promise<BattleResultResponseDto> {
+    const battle = await this.prisma.battle.findUnique({ where: { id: battleId } })
     if (!battle) {
-      const activeOrPending = this.battles.find(candidate => candidate.id === battleId)
-      if (activeOrPending && activeOrPending.status !== BATTLE_STATUS.CLOSED) {
-        throw new BadRequestException('배틀이 아직 진행 중입니다.')
-      }
       throw new NotFoundException(`배틀을 찾을 수 없습니다: ${battleId}`)
     }
 
-    // 2. 배틀 상태 검증
     if (battle.status !== BATTLE_STATUS.CLOSED) {
       throw new BadRequestException('배틀이 아직 진행 중입니다.')
     }
 
-    // 3. 저장된 MVP 반환 (배틀 종료 시 계산됨)
-    return BattleResultResponseDto.fromEntity(battle)
+    const playTime = this.getPlayTime(battle.playTime)
+    const teamACount = battle.teamACount ?? 0
+    const teamBCount = battle.teamBCount ?? 0
+    const totalParticipants = battle.totalParticipantsCount ?? teamACount + teamBCount
+    const timeline = this.normalizeTimeline(battle.timeline)
+    const result = this.buildResult(teamACount, teamBCount, battle.totalParticipantsCount, battle.winningTeam)
+
+    const dto = new BattleResultResponseDto()
+    dto.battleId = battle.id
+    dto.authorId = battle.userId
+    dto.title = battle.title
+    dto.description = battle.description
+    dto.status = 'CLOSED'
+    dto.language = battle.language
+    dto.category = battle.category
+    dto.playTime = playTime.time
+    dto.topics = battle.topics
+    dto.createdAt = battle.createdAt.toISOString()
+    dto.finishedAt = battle.finishedAt ? battle.finishedAt.toISOString() : (battle.updatedAt?.toISOString() ?? battle.createdAt.toISOString())
+    dto.codeA = battle.codeA
+    dto.codeB = battle.codeB
+    dto.result = result
+    dto.metrics = {
+      totalParticipants,
+      totalViews: totalParticipants,
+      strategiesCount: timeline.length,
+      totalChats: 0,
+    }
+    dto.voteTimeline = [
+      {
+        turn: 1,
+        teamAVotes: teamACount,
+        teamBVotes: teamBCount,
+        neutralVotes: Math.max(totalParticipants - teamACount - teamBCount, 0),
+        timestamp: dto.finishedAt,
+      },
+    ]
+    dto.timeline = timeline
+    dto.mvps = []
+
+    return dto
   }
 
-  joinBattleInfo(battleId: string): BattleJoinInfoResponseDto {
+  async joinBattleInfo(battleId: string): Promise<BattleJoinInfoResponseDto> {
     if (!battleId) throw new BadRequestException('Battle ID가 필요합니다.')
 
-    const battle = this.battles.find(battle => battle.id === battleId)
+    const battle = await this.prisma.battle.findUnique({ where: { id: battleId } })
 
     if (!battle) throw new NotFoundException('존재하지 않는 배틀입니다.')
 
-    const activeBattleState = this.activeBattles.get(battleId)
+    let activeBattleState: ActiveBattleState | undefined
+    let participantCount = battle.totalParticipantsCount ?? 0
+    if (battle.status !== BATTLE_STATUS.CLOSED) {
+      const loaded = await this.loadBattleState(battleId)
+      activeBattleState = loaded.state
+      participantCount = loaded.state.participants.size
+    }
 
-    return BattleJoinInfoResponseDto.of(battle, activeBattleState)
+    const mapped = this.toBattleEntity(battle, participantCount)
+
+    return BattleJoinInfoResponseDto.of(mapped, activeBattleState)
   }
 
-  joinBattle(battleJoinRequestDto: BattleJoinRequestDto, userId: string) {
+  async joinBattle(battleJoinRequestDto: BattleJoinRequestDto, userId: string) {
     const { battleId, password, team, nickname } = battleJoinRequestDto
 
     if (!battleId) throw new BadRequestException('Battle ID가 필요합니다.')
 
-    const battle = this.battles.find(battle => battle.id === battleId)
+    const { battle, state } = await this.loadBattleState(battleId)
 
-    if (!battle) throw new NotFoundException('존재하지 않는 배틀입니다.')
-
-    if (battle.type === BATTLE_TYPE.PRIVATE && battle.password) {
+    if (battle.isPrivate && battle.password) {
       const isValid = battle.password === password
 
       if (!isValid) throw new UnauthorizedException('잘못된 비밀번호입니다.')
@@ -190,26 +508,38 @@ export class BattlesService extends EventEmitter {
 
     if (battle.status === BATTLE_STATUS.CLOSED) throw new BadRequestException('이미 종료된 배틀입니다.')
 
-    //  이미 참여한 userId인지 확인
-    const battleState = this.getBattleState(battleId)
-    if (battleState.participants.has(userId)) {
-      return { battleState, team }
-    }
+    const existingTeam = state.participants.get(userId)
 
     // nickname으로 userInfoMap에 등록 (OAuth/비회원 모두)
-    if (!battleState.userInfoMap.has(userId)) {
-      battleState.userInfoMap.set(userId, nickname)
+    if (!state.userInfoMap.has(userId)) {
+      state.userInfoMap.set(userId, nickname)
     }
 
-    this.addParticipant(battleId, userId, team)
+    if (!existingTeam || existingTeam !== team) {
+      this.addParticipant(state, userId, team)
+    }
 
-    return { battleState, team }
+    const userExists = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true },
+    })
+    if (userExists) {
+      await this.prisma.battleParticipant.upsert({
+        where: { userId_battleId: { userId, battleId } },
+        update: { team, isMvp: false },
+        create: { userId, battleId, team, isMvp: false },
+      })
+    }
+
+    await this.saveBattleState(battleId, state)
+
+    return { battleState: state, team }
   }
 
-  leaveBattle(userId: string, battleId: string): BattleLeaveResponseDto {
+  async leaveBattle(userId: string, battleId: string): Promise<BattleLeaveResponseDto> {
     if (!userId || !battleId) throw new BadRequestException('유효하지 않은 요청입니다.')
 
-    const battleState = this.getBattleState(battleId)
+    const { state: battleState } = await this.loadBattleState(battleId)
     battleState.teamA.users = battleState.teamA.users.filter(id => id !== userId)
     battleState.teamB.users = battleState.teamB.users.filter(id => id !== userId)
 
@@ -217,11 +547,9 @@ export class BattlesService extends EventEmitter {
     battleState.teamVotes.delete(userId)
     battleState.participants.delete(userId)
 
-    return BattleLeaveResponseDto.of(battleState)
-  }
+    await this.saveBattleState(battleId, battleState)
 
-  setBattlesForTest(battles: Battle[]) {
-    this.battles = battles
+    return BattleLeaveResponseDto.of(battleState)
   }
 
   private calculateMVPs(state: ActiveBattleState, winner: 'A' | 'B' | 'DRAW'): Mvp[] {
@@ -254,7 +582,7 @@ export class BattlesService extends EventEmitter {
           existing.selectedOpinionCount += 1
         }
       } else {
-        const joinedAt = this.getParticipantJoinedAt(state.battleId, authorId)
+        const joinedAt = this.getParticipantJoinedAt(state, authorId)
         candidateMap.set(
           authorId,
           createMvpCandidate({
@@ -285,74 +613,28 @@ export class BattlesService extends EventEmitter {
     return candidates.slice(0, MVP_DISPLAY_COUNT)
   }
 
-  private getParticipantJoinedAt(battleId: string, oderId: string): number {
-    const state = this.activeBattles.get(battleId)
-    if (!state) return 0
+  private getParticipantJoinedAt(state: ActiveBattleState, oderId: string): number {
     // participants Map의 삽입 순서를 기반으로 참가 순서 반환
     const participantOrder = [...state.participants.keys()].indexOf(oderId)
     return participantOrder >= 0 ? participantOrder : 0
   }
 
-  private initBattleState(battleId: string): void {
-    if (!battleId) throw new BadRequestException('잘못된 요청입니다.')
-    const battle = this.battles.find(({ id }) => id == battleId)
-    if (!battle) throw new NotFoundException('배틀이 존재하지 않습니다.')
-
-    if (this.activeBattles.has(battleId)) return
-
-    const activeBattleState: ActiveBattleState = {
-      battleId,
-      all: {
-        roomId: this.getBattleRoomId(battleId),
-        chats: [],
-        attacks: [],
-        defenses: [],
-      },
-      teamA: {
-        roomId: this.getBattleRoomId(battleId, BATTLE_TEAM.A),
-        users: [],
-        chats: [],
-        attacks: [],
-        defenses: [],
-      },
-      teamB: {
-        roomId: this.getBattleRoomId(battleId, BATTLE_TEAM.B),
-        users: [],
-        chats: [],
-        attacks: [],
-        defenses: [],
-      },
-      participants: new Map(),
-      teamVotes: new Map(),
-
-      userInfoMap: new Map(),
-
-      opinionHistory: [],
-
-      phase: BATTLE_PHASE.PENDING.name,
-      round: 1,
-      topics: [...battle.topics],
-      phaseCount: 1,
-
-      startedAt: null,
-      expiredAt: null,
-    }
-
-    this.activeBattles.set(battleId, activeBattleState)
-  }
-
-  startBattle(battleId: string) {
-    const battleState = this.getBattleState(battleId)
-    const battle = this.battles.find(b => b.id === battleId)
+  async startBattle(battleId: string) {
+    const { battleState } = await this.getBattleState(battleId)
 
     const startedAt = Date.now()
     const expiredAt = startedAt + BATTLE_PHASE.PENDING.time
 
     battleState.startedAt = startedAt
     battleState.expiredAt = expiredAt
-    if (battle) {
-      battle.status = BATTLE_STATUS.OPEN
-    }
+    await this.prisma.battle.update({
+      where: { id: battleId },
+      data: {
+        status: BATTLE_STATUS.OPEN,
+        updatedAt: new Date(),
+      },
+    })
+    await this.saveBattleState(battleId, battleState)
 
     const phaseRes = BattlePhaseResponseDto.of({
       battleId,
@@ -370,22 +652,21 @@ export class BattlesService extends EventEmitter {
 
     this.emit('battle:phase:updated', phaseRes)
     this.emit('battle:round:updated', roundRes)
-    this.scheduleNextTick(battleId)
+    void this.scheduleNextTick(battleId)
   }
 
   getBattleRoomId(battleId: string, team?: BattleTeam): string {
     return team ? `battle:${battleId}:${team}` : `battle:${battleId}`
   }
 
-  appendChatMessage(dto: BattleChatDto, userId: string) {
+  async appendChatMessage(dto: BattleChatDto, userId: string) {
     const { battleId, scope, team, text } = dto
     if (!battleId || !scope) throw new BadRequestException('잘못된 요청입니다.')
     if (!text.trim()) throw new BadRequestException('메시지가 비어 있습니다.')
 
-    const battleState = this.activeBattles.get(battleId)
-    if (!battleState) throw new NotFoundException('해당 배틀은 현재 진행 중이지 않습니다.')
+    const { battleState } = await this.getBattleState(battleId)
 
-    const nickname = this.getNicknameByUserId(battleId, userId) || ''
+    const nickname = this.getNicknameByUserId(battleState, userId) || ''
 
     const chat = {
       messageId: this.generateId(),
@@ -400,6 +681,7 @@ export class BattlesService extends EventEmitter {
 
     if (scope === BATTLE_CHAT_SCOPE.ALL) {
       battleState.all.chats.push(chat)
+      await this.saveBattleState(battleId, battleState)
       return { battleId, scope, ...chat }
     }
 
@@ -412,14 +694,12 @@ export class BattlesService extends EventEmitter {
     const target = team === BATTLE_TEAM.A ? battleState.teamA : battleState.teamB
     target.chats.push(chat)
 
+    await this.saveBattleState(battleId, battleState)
     return { battleId, scope, ...chat }
   }
 
-  private addParticipant(battleId: string, userId: string, team: string): void {
-    if (!battleId || !userId || !team) throw new BadRequestException('잘못된 요청입니다.')
-    const battleState = this.activeBattles.get(battleId)
-
-    if (!battleState) throw new NotFoundException('해당 배틀은 현재 진행 중이지 않습니다.')
+  private addParticipant(battleState: ActiveBattleState, userId: string, team: string): void {
+    if (!userId || !team) throw new BadRequestException('잘못된 요청입니다.')
 
     battleState.participants.set(userId, team as BattleTeam)
     this.rebuildTeamUsers(battleState)
@@ -430,7 +710,7 @@ export class BattlesService extends EventEmitter {
       teamNone: battleState.participants.size - (battleState.teamA.users.length + battleState.teamB.users.length),
     }
 
-    this.emit('battle:user:updated', BattleUserUpdateResponseDto.of(battleId, counts))
+    this.emit('battle:user:updated', BattleUserUpdateResponseDto.of(battleState.battleId, counts))
   }
 
   private shuffleTopics(topics: string[], playTime: BattlePlayTimeName): string[] {
@@ -462,8 +742,8 @@ export class BattlesService extends EventEmitter {
     }
   }
 
-  voteTeam(dto: BattleTeamVoteDto, userId: string) {
-    const state = this.getBattleState(dto.battleId)
+  async voteTeam(dto: BattleTeamVoteDto, userId: string) {
+    const { battleState: state } = await this.getBattleState(dto.battleId)
 
     if (state.phase !== BATTLE_PHASE.TEAM_SWITCH.name) {
       throw new BadRequestException('팀 변경 투표는 TEAM_SWITCH 페이즈에서만 가능합니다.')
@@ -474,14 +754,11 @@ export class BattlesService extends EventEmitter {
     }
 
     state.teamVotes.set(userId, dto.team)
+    await this.saveBattleState(dto.battleId, state)
   }
 
-  private updatePhase(battleId: string): void {
-    const state = this.getBattleState(battleId)
-
-    const battle = this.battles.find(battle => battle.id === battleId)
-    if (!battle) return
-    if (battle?.status === BATTLE_STATUS.CLOSED) return
+  private async updatePhase(battleId: string): Promise<void> {
+    const { battleState: state } = await this.getBattleState(battleId)
 
     const prevPhase = state.phase
     const prevRound = state.round
@@ -499,7 +776,7 @@ export class BattlesService extends EventEmitter {
       const res = BattleRoundResponseDto.of({
         battleId,
         round: state.round,
-        topic: battle.topics[state.round - 1],
+        topic: state.topics[state.round - 1],
       })
 
       this.emit('battle:round:updated', res)
@@ -517,7 +794,8 @@ export class BattlesService extends EventEmitter {
       this.emit('battle:phase:updated', res)
     }
 
-    this.scheduleNextTick(battleId)
+    await this.saveBattleState(battleId, state)
+    void this.scheduleNextTick(battleId)
   }
 
   private getNextPhase(state: ActiveBattleState): BattlePhase | null {
@@ -529,14 +807,14 @@ export class BattlesService extends EventEmitter {
         return BATTLE_PHASE.ATTACK
 
       case BATTLE_PHASE.ATTACK.name:
-        this.emitAttackedResult(state.battleId)
-        this.resetDiscussions(state.battleId)
+        this.emitAttackedResult(state)
+        this.resetDiscussions(state)
 
         return BATTLE_PHASE.DEFENSE
 
       case BATTLE_PHASE.DEFENSE.name:
-        this.emitDefensedResult(state.battleId)
-        this.resetDiscussions(state.battleId)
+        this.emitDefensedResult(state)
+        this.resetDiscussions(state)
 
         state.phaseCount++
 
@@ -595,14 +873,11 @@ export class BattlesService extends EventEmitter {
   }
 
   private updateRound(state: ActiveBattleState): boolean {
-    const battle = this.battles.find(battle => battle.id === state.battleId)
-    if (!battle) throw new NotFoundException('해당 배틀이 존재하지 않습니다.')
-
     const nextRound = state.round + 1
-    const maxRounds = battle.playTime.rounds
+    const maxRounds = state.totalRounds
 
     if (maxRounds < nextRound) {
-      this.finishBattle(battle)
+      void this.finishBattle(state)
       return false
     }
 
@@ -610,84 +885,50 @@ export class BattlesService extends EventEmitter {
     return true
   }
 
-  private finishBattle(battle: Battle) {
-    const battleTimer = this.battleTimers.get(battle.id)
+  private async finishBattle(state: ActiveBattleState) {
+    const battleId = state.battleId
+    const battleTimer = this.battleTimers.get(battleId)
     clearTimeout(battleTimer)
-    this.battleTimers.delete(battle.id)
-
-    battle.status = BATTLE_STATUS.CLOSED
+    this.battleTimers.delete(battleId)
 
     const finishedAt = new Date()
-    const finishedBattle = this.battles.find(b => b.id === battle.id)
-    const state = this.activeBattles.get(battle.id)
-
-    if (finishedBattle && state) {
-      const snapshot = this.buildFinishedBattleState(finishedBattle, state, finishedAt)
-      this.finishedBattles.set(battle.id, snapshot)
-    }
-
-    this.activeBattles.delete(battle.id)
-    this.battles = this.battles.filter(b => b.id !== battle.id)
-
-    this.emit('battle:closed', BattleClosedResponseDto.of({ battleId: battle.id }))
-  }
-
-  private buildFinishedBattleState(battle: Battle, state: ActiveBattleState, finishedAt: Date): FinishedBattleState {
     const totalParticipants = state.participants.size
-    const teamAVotes = state.teamA.users.length
-    const teamBVotes = state.teamB.users.length
-    const neutralVotes = Math.max(totalParticipants - teamAVotes - teamBVotes, 0)
-    const totalVotes = teamAVotes + teamBVotes + neutralVotes
-
-    const percentage = (votes: number) => (totalVotes === 0 ? 0 : Math.round((votes / totalVotes) * 100))
-
-    const result: BattleResult = {
-      winner: teamAVotes === teamBVotes ? 'DRAW' : teamAVotes > teamBVotes ? 'A' : 'B',
-      teamA: { votes: teamAVotes, percentage: percentage(teamAVotes) },
-      teamB: { votes: teamBVotes, percentage: percentage(teamBVotes) },
-      neutral: { votes: neutralVotes, percentage: percentage(neutralVotes) },
-    }
-
-    const voteTimeline: VoteTimeline[] = [
-      {
-        turn: 1,
-        teamAVotes,
-        teamBVotes,
-        neutralVotes,
-        timestamp: finishedAt.toISOString(),
-      },
-    ]
-
+    const teamACount = state.teamA.users.length
+    const teamBCount = state.teamB.users.length
+    const winningTeam = teamACount === teamBCount ? 'DRAW' : teamACount > teamBCount ? 'A' : 'B'
     const timeline = this.buildTimeline(state)
-    const calculatedMvps = this.calculateMVPs(state, result.winner)
+    const calculatedMvps = this.calculateMVPs(state, winningTeam)
 
-    const metrics: Metrics = {
-      totalParticipants,
-      totalViews: totalParticipants,
-      strategiesCount: timeline.length,
-      totalChats: state.all.chats.length + state.teamA.chats.length + state.teamB.chats.length,
-    }
+    await this.prisma.battle.update({
+      where: { id: battleId },
+      data: {
+        status: BATTLE_STATUS.CLOSED,
+        finishedAt,
+        teamACount,
+        teamBCount,
+        totalParticipantsCount: totalParticipants,
+        winningTeam,
+        timeline: timeline as unknown as Prisma.InputJsonValue,
+        mvps: calculatedMvps.map(mvp => mvp.nickname),
+        updatedAt: finishedAt,
+        currentRound: null,
+        currentPhase: null,
+        phaseCount: null,
+        startedAt: null,
+        expiredAt: null,
+        participantsState: Prisma.DbNull,
+        teamVotesState: Prisma.DbNull,
+        userInfoState: Prisma.DbNull,
+        attacksState: Prisma.DbNull,
+        defensesState: Prisma.DbNull,
+        opinionHistoryState: Prisma.DbNull,
+        chatsAllState: Prisma.DbNull,
+        chatsTeamAState: Prisma.DbNull,
+        chatsTeamBState: Prisma.DbNull,
+      },
+    })
 
-    return {
-      battleId: battle.id,
-      authorId: battle.authorId,
-      title: battle.title,
-      description: battle.description,
-      status: BATTLE_STATUS.CLOSED,
-      language: battle.language,
-      category: battle.category,
-      playTime: battle.playTime.time,
-      topics: [...battle.topics],
-      createdAt: battle.createdAt.toISOString(),
-      finishedAt: finishedAt.toISOString(),
-      codeA: battle.aCode,
-      codeB: battle.bCode,
-      result,
-      metrics,
-      voteTimeline,
-      timeline,
-      mvps: calculatedMvps,
-    }
+    this.emit('battle:closed', BattleClosedResponseDto.of({ battleId }))
   }
 
   private buildTimeline(state: ActiveBattleState): TimelineItem[] {
@@ -718,36 +959,27 @@ export class BattlesService extends EventEmitter {
     return [...attacks, ...defenses].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
   }
 
-  private isPublicAndWaitingOrOpen(battle: Battle): boolean {
-    return battle.type === BATTLE_TYPE.PUBLIC && (battle.status === BATTLE_STATUS.OPEN || battle.status === BATTLE_STATUS.PENDING)
-  }
-
-  private isPublicAndClosed(battle: Battle): boolean {
-    return battle.status === BATTLE_STATUS.CLOSED //임시로 public 조건 제거
-    // return battle.type === BATTLE_TYPE.PUBLIC &&  battle.status === BATTLE_STATUS.CLOSED
-  }
-
-  getBattleState(battleId: string) {
-    const battleState = this.activeBattles.get(battleId)
-    if (!battleState) throw new NotFoundException('해당 배틀은 현재 진행 중이지 않습니다.')
-
-    return battleState
+  async getBattleState(battleId: string): Promise<{ battle: PrismaBattle; battleState: ActiveBattleState }> {
+    const { battle, state } = await this.loadBattleState(battleId)
+    if (battle.status === BATTLE_STATUS.CLOSED) throw new NotFoundException('해당 배틀은 현재 진행 중이지 않습니다.')
+    return { battle, battleState: state }
   }
 
   // Guest 등록
-  registerGuest(battleId: string, guest: GuestAccount): void {
-    const battleState = this.getBattleState(battleId)
+  async registerGuest(battleId: string, guest: GuestAccount): Promise<void> {
+    const { battleState } = await this.getBattleState(battleId)
     battleState.userInfoMap.set(guest.id, guest.nickname)
+    battleState.participants.set(guest.id, BATTLE_TEAM.NONE)
+    this.rebuildTeamUsers(battleState)
+    await this.saveBattleState(battleId, battleState)
   }
 
   // userId로 닉네임 조회
-  getNicknameByUserId(battleId: string, userId: string): string | null {
-    const battleState = this.activeBattles.get(battleId)
-    if (!battleState) return null
-    return battleState.userInfoMap.get(userId) || null
+  private getNicknameByUserId(state: ActiveBattleState, userId: string): string | null {
+    return state.userInfoMap.get(userId) || null
   }
 
-  generateGuestNickname(battleId: string, isTaken: (nickname: string) => boolean): string {
+  async generateGuestNickname(battleId: string, isTaken: (nickname: string) => boolean): Promise<string> {
     const maxAttempts = 50
     let attempts = 0
 
@@ -755,7 +987,7 @@ export class BattlesService extends EventEmitter {
       const nickname = generateNickname()
 
       // 배틀 방 내 닉네임 체크 + 외부에서 전달받은 중복 체크 함수 실행
-      if (!this.isNicknameDuplicateInBattle(battleId, nickname) && !isTaken(nickname)) {
+      if (!(await this.isNicknameDuplicate(battleId, nickname)) && !isTaken(nickname)) {
         return nickname
       }
       attempts++
@@ -766,22 +998,21 @@ export class BattlesService extends EventEmitter {
   }
 
   // 배틀 방 내 닉네임 중복 체크
-  isNicknameDuplicateInBattle(battleId: string, nickname: string): boolean {
-    const battleState = this.activeBattles.get(battleId)
-    if (!battleState) return false
+  async isNicknameDuplicate(battleId: string, nickname: string): Promise<boolean> {
+    const { battleState } = await this.getBattleState(battleId)
     return Array.from(battleState.userInfoMap.values()).some(existingNickname => existingNickname === nickname)
   }
 
-  handleAttack(battleId: string, data: { authorId: string; content: string; team: BattleTeam }): BattleDiscussion {
+  async handleAttack(battleId: string, data: { authorId: string; content: string; team: BattleTeam }): Promise<BattleDiscussion> {
     const { authorId, content, team } = data
 
-    const battleState = this.getBattleState(battleId)
+    const { battleState } = await this.getBattleState(battleId)
 
     if (!this.canUserSubmitAttack(battleState, team)) {
       throw new BadRequestException('현재 공격을 등록할 수 없는 단계입니다.')
     }
 
-    const nickname = this.getNicknameByUserId(battleId, authorId) || ''
+    const nickname = this.getNicknameByUserId(battleState, authorId) || ''
 
     const attack: BattleDiscussion = {
       discussionId: this.generateId(),
@@ -804,19 +1035,20 @@ export class BattlesService extends EventEmitter {
       battleState.teamB.attacks.push(attack)
     }
 
+    await this.saveBattleState(battleId, battleState)
     return attack
   }
 
-  handleDefense(battleId: string, data: { authorId: string; content: string; team: BattleTeam }): BattleDefense {
+  async handleDefense(battleId: string, data: { authorId: string; content: string; team: BattleTeam }): Promise<BattleDefense> {
     const { authorId, content, team } = data
 
-    const battleState = this.getBattleState(battleId)
+    const { battleState } = await this.getBattleState(battleId)
 
     if (!this.canUserSubmitDefense(battleState, team)) {
       throw new BadRequestException('현재 반론을 등록할 수 없는 단계입니다.')
     }
 
-    const nickname = this.getNicknameByUserId(battleId, authorId) || ''
+    const nickname = this.getNicknameByUserId(battleState, authorId) || ''
 
     const defense: BattleDefense = {
       discussionId: this.generateId(),
@@ -839,6 +1071,7 @@ export class BattlesService extends EventEmitter {
       battleState.teamB.defenses.push(defense)
     }
 
+    await this.saveBattleState(battleId, battleState)
     return defense
   }
 
@@ -867,14 +1100,14 @@ export class BattlesService extends EventEmitter {
     return false
   }
 
-  handleAttackVote(battleId: string, discussionId: string, data: { userId: string; team: BattleTeam }): DiscussionVoteResponseDto[] {
+  async handleAttackVote(battleId: string, discussionId: string, data: { userId: string; team: BattleTeam }): Promise<DiscussionVoteResponseDto[]> {
     //Todo: 턴 관리 pr 머지 후 턴 고려
     const { userId, team } = data
 
     if (team === BATTLE_TEAM.NONE) {
       throw new ForbiddenException('중립 진영은 투표할 수 없습니다.')
     }
-    const battleState = this.getBattleState(battleId)
+    const { battleState } = await this.getBattleState(battleId)
 
     if (!this.canUserVoteAttack(battleState)) {
       throw new BadRequestException('현재 투표할 수 있는 공격 턴이 아닙니다.')
@@ -912,17 +1145,18 @@ export class BattlesService extends EventEmitter {
     this.syncOpinionHistory(battleState, discussionId, updated)
     updatedDiscussions.push(DiscussionVoteResponseDto.of(battleId, updated))
 
+    await this.saveBattleState(battleId, battleState)
     return updatedDiscussions
   }
 
-  handleDefenseVote(battleId: string, discussionId: string, data: { userId: string; team: BattleTeam }): DiscussionVoteResponseDto[] {
+  async handleDefenseVote(battleId: string, discussionId: string, data: { userId: string; team: BattleTeam }): Promise<DiscussionVoteResponseDto[]> {
     const { userId, team } = data
 
     if (team === BATTLE_TEAM.NONE) {
       throw new ForbiddenException('중립 진영은 투표할 수 없습니다.')
     }
 
-    const battleState = this.getBattleState(battleId)
+    const { battleState } = await this.getBattleState(battleId)
     if (!this.canUserVoteDefense(battleState)) {
       throw new BadRequestException('현재 투표할 수 있는 반론 턴이 아닙니다.')
     }
@@ -959,6 +1193,7 @@ export class BattlesService extends EventEmitter {
     this.syncOpinionHistory(battleState, discussionId, updated)
     updatedDiscussions.push(DiscussionVoteResponseDto.of(battleId, updated))
 
+    await this.saveBattleState(battleId, battleState)
     return updatedDiscussions
   }
 
@@ -993,21 +1228,17 @@ export class BattlesService extends EventEmitter {
     return top
   }
 
-  private pickTopVotedAttack(battleId: string): BattleTopOpinions {
-    const battleState = this.getBattleState(battleId)
-
+  private pickTopVotedAttack(state: ActiveBattleState): BattleTopOpinions {
     return {
-      aTeam: this.getTopOpinion(battleState.teamA.attacks),
-      bTeam: this.getTopOpinion(battleState.teamB.attacks),
+      aTeam: this.getTopOpinion(state.teamA.attacks),
+      bTeam: this.getTopOpinion(state.teamB.attacks),
     }
   }
 
-  private pickTopVotedDefense(battleId: string): BattleTopOpinions {
-    const battleState = this.getBattleState(battleId)
-
+  private pickTopVotedDefense(state: ActiveBattleState): BattleTopOpinions {
     return {
-      aTeam: this.getTopOpinion(battleState.teamA.defenses),
-      bTeam: this.getTopOpinion(battleState.teamB.defenses),
+      aTeam: this.getTopOpinion(state.teamA.defenses),
+      bTeam: this.getTopOpinion(state.teamB.defenses),
     }
   }
 
@@ -1030,15 +1261,12 @@ export class BattlesService extends EventEmitter {
     return placeholder
   }
 
-  private emitAttackedResult(battleId: string) {
-    const battleState = this.activeBattles.get(battleId)
-    if (!battleState) return
-
+  private emitAttackedResult(battleState: ActiveBattleState) {
     // 페이즈 종료 시 각 팀의 투표 참가자 수 계산 및 의견에 기록
     this.recordVoterCountAtPhase(battleState.teamA.attacks, BATTLE_TEAM.A)
     this.recordVoterCountAtPhase(battleState.teamB.attacks, BATTLE_TEAM.B)
 
-    const top = this.pickTopVotedAttack(battleId)
+    const top = this.pickTopVotedAttack(battleState)
 
     const { aTeam, bTeam } = top
     const aEntry = aTeam ? aTeam : this.createNullPlaceholder('A', 'ATTACK')
@@ -1046,18 +1274,15 @@ export class BattlesService extends EventEmitter {
     battleState.all.attacks.push(aEntry)
     battleState.all.attacks.push(bEntry)
 
-    this.emit('battle:attacked', DiscussionVoteResultDto.attacked(battleId, top))
+    this.emit('battle:attacked', DiscussionVoteResultDto.attacked(battleState.battleId, top))
   }
 
-  private emitDefensedResult(battleId: string) {
-    const battleState = this.activeBattles.get(battleId)
-    if (!battleState) return
-
+  private emitDefensedResult(battleState: ActiveBattleState) {
     // 페이즈 종료 시 각 팀의 투표 참가자 수 계산 및 의견에 기록
     this.recordVoterCountAtPhase(battleState.teamA.defenses, BATTLE_TEAM.A)
     this.recordVoterCountAtPhase(battleState.teamB.defenses, BATTLE_TEAM.B)
 
-    const top = this.pickTopVotedDefense(battleId)
+    const top = this.pickTopVotedDefense(battleState)
 
     const { aTeam, bTeam } = top
     const aEntry = aTeam ? aTeam : this.createNullPlaceholder('A', 'DEFENSE')
@@ -1065,7 +1290,7 @@ export class BattlesService extends EventEmitter {
     battleState.all.defenses.push(aEntry)
     battleState.all.defenses.push(bEntry)
 
-    this.emit('battle:defensed', DiscussionVoteResultDto.defensed(battleId, top))
+    this.emit('battle:defensed', DiscussionVoteResultDto.defensed(battleState.battleId, top))
   }
 
   private recordVoterCountAtPhase(opinions: (BattleDiscussion | null)[], team: BattleTeam): void {
@@ -1113,41 +1338,30 @@ export class BattlesService extends EventEmitter {
     }
   }
 
-  private resetDiscussions(battleId: string) {
-    const battleState = this.getBattleState(battleId)
-
-    // MVP 계산을 위해 모든 의견을 all에 누적 저장 (이미 all에 있는 의견 제외)
-    const existingAttackIds = new Set(battleState.all.attacks.map(a => a?.discussionId))
-    const existingDefenseIds = new Set(battleState.all.defenses.map(d => d?.discussionId))
-
-    const newAttacks = [...battleState.teamA.attacks, ...battleState.teamB.attacks].filter(a => a && !existingAttackIds.has(a.discussionId))
-    const newDefenses = [...battleState.teamA.defenses, ...battleState.teamB.defenses].filter(d => d && !existingDefenseIds.has(d.discussionId))
-
-    battleState.all.attacks.push(...newAttacks)
-    battleState.all.defenses.push(...newDefenses)
-
+  private resetDiscussions(battleState: ActiveBattleState) {
     battleState.teamA.attacks = []
     battleState.teamB.attacks = []
     battleState.teamA.defenses = []
     battleState.teamB.defenses = []
   }
 
-  private scheduleNextTick(battleId: string) {
-    const battle = this.battles.find(battle => battle.id === battleId)
-    if (battle?.status === BATTLE_STATUS.CLOSED) return
+  private async scheduleNextTick(battleId: string) {
+    try {
+      const { battleState: state } = await this.getBattleState(battleId)
+      if (!state.expiredAt) return
 
-    const state = this.getBattleState(battleId)
-    if (!state.expiredAt) return
+      const prevTimer = this.battleTimers.get(battleId)
+      if (prevTimer) clearTimeout(prevTimer)
 
-    const prevTimer = this.battleTimers.get(battleId)
-    if (prevTimer) clearTimeout(prevTimer)
+      const remaining = Math.max(state.expiredAt - Date.now(), 0)
 
-    const remaining = Math.max(state.expiredAt - Date.now(), 0)
+      const battleTimer = setTimeout(() => {
+        void this.updatePhase(battleId)
+      }, remaining)
 
-    const battleTimer = setTimeout(() => {
-      this.updatePhase(battleId)
-    }, remaining)
-
-    this.battleTimers.set(battleId, battleTimer)
+      this.battleTimers.set(battleId, battleTimer)
+    } catch {
+      // ignore if battle not found or closed
+    }
   }
 }

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -979,7 +979,10 @@ export class BattlesService extends EventEmitter {
     return state.userInfoMap.get(userId) || null
   }
 
-  async generateGuestNickname(battleId: string, isTaken: (nickname: string) => boolean): Promise<string> {
+  async generateGuestNickname(
+    battleId: string,
+    isTaken: (nickname: string) => boolean | Promise<boolean>,
+  ): Promise<string> {
     const maxAttempts = 50
     let attempts = 0
 

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -52,7 +52,7 @@ import { BattleUserUpdateResponseDto } from '../dto/battleUserUpdateResponse.dto
 import { GuestAccount } from '../types/auth.types'
 import { BattleLeaveResponseDto } from '../dto/battleLeaveResponse.dto'
 import { generateNickname } from './utils/nickname.util'
-import { PrismaService } from 'src/prisma/prisma.service'
+import { PrismaService } from '../../prisma/prisma.service'
 import { Prisma, type Battle as PrismaBattle } from 'generated/prisma/client'
 
 @Injectable()
@@ -229,6 +229,44 @@ export class BattlesService extends EventEmitter {
   private parseOpinionHistoryState(value: unknown): BattleDiscussion[] {
     if (!Array.isArray(value)) return []
     return value.filter(item => item && typeof item === 'object') as BattleDiscussion[]
+  }
+
+  private parseMvpsState(value: unknown): Mvp[] {
+    if (!Array.isArray(value)) return []
+    return value
+      .filter(item => item && typeof item === 'object')
+      .map(item => {
+        const mvp = item as Partial<Mvp>
+        const team: 'A' | 'B' = mvp.team === 'B' ? 'B' : 'A'
+        const parsed: Mvp = {
+          userId: typeof mvp.userId === 'string' ? mvp.userId : '',
+          nickname: typeof mvp.nickname === 'string' ? mvp.nickname : '',
+          team,
+          score: typeof mvp.score === 'number' ? mvp.score : 0,
+          totalVotes: typeof mvp.totalVotes === 'number' ? mvp.totalVotes : 0,
+          opinionCount: typeof mvp.opinionCount === 'number' ? mvp.opinionCount : 0,
+          selectedOpinionCount: typeof mvp.selectedOpinionCount === 'number' ? mvp.selectedOpinionCount : 0,
+          joinedAt: typeof mvp.joinedAt === 'number' ? mvp.joinedAt : 0,
+        }
+        return parsed
+      })
+      .filter(mvp => mvp.nickname)
+  }
+
+  private buildLegacyMvpsFromNicknames(nicknames: string[], timeline: TimelineItem[]): Mvp[] {
+    return nicknames.map((nickname, index) => {
+      const fromTimeline = timeline.find(item => item.author.nickname === nickname)
+      return {
+        userId: fromTimeline?.author.id ?? `legacy-mvp-${index}`,
+        nickname,
+        team: fromTimeline?.team === 'B' ? 'B' : 'A',
+        score: 0,
+        totalVotes: 0,
+        opinionCount: 0,
+        selectedOpinionCount: 0,
+        joinedAt: 0,
+      }
+    })
   }
 
   private async loadBattleState(battleId: string): Promise<{ battle: PrismaBattle; state: ActiveBattleState }> {
@@ -468,7 +506,8 @@ export class BattlesService extends EventEmitter {
       },
     ]
     dto.timeline = timeline
-    dto.mvps = []
+    const mvpsState = this.parseMvpsState((battle as PrismaBattle & { mvpsState?: unknown }).mvpsState)
+    dto.mvps = mvpsState.length > 0 ? mvpsState : this.buildLegacyMvpsFromNicknames(battle.mvps ?? [], timeline)
 
     return dto
   }
@@ -910,6 +949,7 @@ export class BattlesService extends EventEmitter {
         winningTeam,
         timeline: timeline as unknown as Prisma.InputJsonValue,
         mvps: calculatedMvps.map(mvp => mvp.nickname),
+        mvpsState: calculatedMvps as unknown as Prisma.InputJsonValue,
         updatedAt: finishedAt,
         currentRound: null,
         currentPhase: null,
@@ -979,10 +1019,7 @@ export class BattlesService extends EventEmitter {
     return state.userInfoMap.get(userId) || null
   }
 
-  async generateGuestNickname(
-    battleId: string,
-    isTaken: (nickname: string) => boolean | Promise<boolean>,
-  ): Promise<string> {
+  async generateGuestNickname(battleId: string, isTaken: (nickname: string) => boolean | Promise<boolean>): Promise<string> {
     const maxAttempts = 50
     let attempts = 0
 
@@ -990,7 +1027,7 @@ export class BattlesService extends EventEmitter {
       const nickname = generateNickname()
 
       // 배틀 방 내 닉네임 체크 + 외부에서 전달받은 중복 체크 함수 실행
-      if (!(await this.isNicknameDuplicate(battleId, nickname)) && !isTaken(nickname)) {
+      if (!(await this.isNicknameDuplicate(battleId, nickname)) && !(await isTaken(nickname))) {
         return nickname
       }
       attempts++

--- a/backend/src/battles/types/battles.types.ts
+++ b/backend/src/battles/types/battles.types.ts
@@ -60,6 +60,11 @@ export interface BattleChat {
   createdAt: Date
 }
 
+export type ParticipantEntry = { userId: string; team: BattleTeam }
+export type TeamVoteEntry = { userId: string; team: BattleTeam }
+export type UserInfoEntry = { userId: string; nickname: string }
+export type BattleChatSnapshot = Omit<BattleChat, 'createdAt'> & { createdAt: string }
+
 export interface BattleDiscussion {
   discussionId: string
   author: {
@@ -110,6 +115,7 @@ export interface ActiveBattleState {
 
   round: number
   topics: string[]
+  totalRounds: number
   phase: BattlePhaseName
   phaseCount: number
 

--- a/backend/src/oauth/controller/oauth.controller.spec.ts
+++ b/backend/src/oauth/controller/oauth.controller.spec.ts
@@ -58,7 +58,7 @@ describe('OauthController', () => {
   })
 
   describe('githubCallback', () => {
-    it('GitHub 콜백에서 프로필을 받아 토큰을 발급하고 쿠키에 설정한다', () => {
+    it('GitHub 콜백에서 프로필을 받아 토큰을 발급하고 쿠키에 설정한다', async () => {
       const mockProfile: OAuthProfile = {
         provider: 'github',
         providerId: '12345',
@@ -80,9 +80,9 @@ describe('OauthController', () => {
         redirect: mockRedirect,
       } as unknown as expressRes
 
-      mockOauthService.loginWithGithub.mockReturnValue(mockTokens)
+      mockOauthService.loginWithGithub.mockResolvedValue(mockTokens)
 
-      controller.githubCallback(mockReq, mockRes)
+      await controller.githubCallback(mockReq, mockRes)
 
       expect(mockOauthService.loginWithGithub).toHaveBeenCalledWith(mockProfile)
       expect(mockTokenService.setTokensInCookie).toHaveBeenCalledWith(mockRes, mockTokens.accessToken, mockTokens.refreshToken)
@@ -91,7 +91,7 @@ describe('OauthController', () => {
   })
 
   describe('kakaoCallback', () => {
-    it('Kakao 콜백에서 프로필을 받아 토큰을 발급하고 쿠키에 설정한다', () => {
+    it('Kakao 콜백에서 프로필을 받아 토큰을 발급하고 쿠키에 설정한다', async () => {
       const mockProfile: OAuthProfile = {
         provider: 'kakao',
         providerId: '67890',
@@ -113,9 +113,9 @@ describe('OauthController', () => {
         redirect: mockRedirect,
       } as unknown as expressRes
 
-      mockOauthService.loginWithKakao.mockReturnValue(mockTokens)
+      mockOauthService.loginWithKakao.mockResolvedValue(mockTokens)
 
-      controller.kakaoCallback(mockReq, mockRes)
+      await controller.kakaoCallback(mockReq, mockRes)
 
       expect(mockOauthService.loginWithKakao).toHaveBeenCalledWith(mockProfile)
       expect(mockTokenService.setTokensInCookie).toHaveBeenCalledWith(mockRes, mockTokens.accessToken, mockTokens.refreshToken)
@@ -195,7 +195,7 @@ describe('OauthController', () => {
   })
 
   describe('getMe', () => {
-    it('현재 로그인한 사용자 정보를 반환한다', () => {
+    it('현재 로그인한 사용자 정보를 반환한다', async () => {
       const mockJwtUser = {
         id: 'user-123',
       }
@@ -212,9 +212,9 @@ describe('OauthController', () => {
         user: mockJwtUser,
       } as unknown as expressReq
 
-      mockOauthService.findUserById.mockReturnValue(mockUser)
+      mockOauthService.findUserById.mockResolvedValue(mockUser)
 
-      const result = controller.getMe(mockReq)
+      const result = await controller.getMe(mockReq)
 
       expect(mockOauthService.findUserById).toHaveBeenCalledWith(mockJwtUser.id)
       expect(result).toEqual(mockUser)
@@ -222,7 +222,7 @@ describe('OauthController', () => {
   })
 
   describe('updateNickname', () => {
-    it('닉네임을 성공적으로 변경하고 사용자 정보를 반환한다', () => {
+    it('닉네임을 성공적으로 변경하고 사용자 정보를 반환한다', async () => {
       const mockJwtUser = {
         id: 'user-123',
       }
@@ -242,9 +242,9 @@ describe('OauthController', () => {
         body: mockDto,
       } as unknown as expressReq
 
-      mockOauthService.updateUserNickname.mockReturnValue(mockUpdatedUser)
+      mockOauthService.updateUserNickname.mockResolvedValue(mockUpdatedUser)
 
-      const result = controller.updateNickname(mockReq, mockDto)
+      const result = await controller.updateNickname(mockReq, mockDto)
 
       expect(mockOauthService.updateUserNickname).toHaveBeenCalledWith(mockJwtUser.id, mockDto.nickname)
       expect(result).toEqual(mockUpdatedUser)

--- a/backend/src/oauth/controller/oauth.controller.ts
+++ b/backend/src/oauth/controller/oauth.controller.ts
@@ -24,9 +24,9 @@ export class OauthController {
   @Get('github/callback')
   @UseGuards(AuthGuard('github'))
   @HttpCode(302)
-  githubCallback(@Req() req: expressReq, @Res() res: expressRes) {
+  async githubCallback(@Req() req: expressReq, @Res() res: expressRes) {
     const profile = req.user as OAuthProfile
-    const { accessToken, refreshToken } = this.oauthService.loginWithGithub(profile)
+    const { accessToken, refreshToken } = await this.oauthService.loginWithGithub(profile)
 
     // 쿠키에 토큰 저장
     this.tokenService.setTokensInCookie(res, accessToken, refreshToken)
@@ -43,9 +43,9 @@ export class OauthController {
   @Get('kakao/callback')
   @UseGuards(AuthGuard('kakao'))
   @HttpCode(302)
-  kakaoCallback(@Req() req: expressReq, @Res() res: expressRes) {
+  async kakaoCallback(@Req() req: expressReq, @Res() res: expressRes) {
     const profile = req.user as OAuthProfile
-    const { accessToken, refreshToken } = this.oauthService.loginWithKakao(profile)
+    const { accessToken, refreshToken } = await this.oauthService.loginWithKakao(profile)
 
     this.tokenService.setTokensInCookie(res, accessToken, refreshToken)
 
@@ -82,7 +82,7 @@ export class OauthController {
 
   @Get('me')
   @UseGuards(JwtAuthGuard)
-  getMe(@Req() req: expressReq) {
+  async getMe(@Req() req: expressReq) {
     const jwtUser = req.user as { id: string }
     return this.oauthService.findUserById(jwtUser.id)
   }
@@ -90,7 +90,7 @@ export class OauthController {
   @Patch('nickname')
   @UseGuards(JwtAuthGuard)
   @HttpCode(200)
-  updateNickname(@Req() req: expressReq, @Body() dto: UpdateNicknameDto): OAuthUserResponseDto {
+  async updateNickname(@Req() req: expressReq, @Body() dto: UpdateNicknameDto): Promise<OAuthUserResponseDto> {
     const jwtUser = req.user as { id: string }
     return this.oauthService.updateUserNickname(jwtUser.id, dto.nickname)
   }

--- a/backend/src/oauth/controller/oauth.controller.ts
+++ b/backend/src/oauth/controller/oauth.controller.ts
@@ -84,7 +84,7 @@ export class OauthController {
   @UseGuards(JwtAuthGuard)
   async getMe(@Req() req: expressReq) {
     const jwtUser = req.user as { id: string }
-    return this.oauthService.findUserById(jwtUser.id)
+    return await this.oauthService.findUserById(jwtUser.id)
   }
 
   @Patch('nickname')
@@ -92,6 +92,6 @@ export class OauthController {
   @HttpCode(200)
   async updateNickname(@Req() req: expressReq, @Body() dto: UpdateNicknameDto): Promise<OAuthUserResponseDto> {
     const jwtUser = req.user as { id: string }
-    return this.oauthService.updateUserNickname(jwtUser.id, dto.nickname)
+    return await this.oauthService.updateUserNickname(jwtUser.id, dto.nickname)
   }
 }

--- a/backend/src/oauth/dto/oauthUser.dto.ts
+++ b/backend/src/oauth/dto/oauthUser.dto.ts
@@ -1,0 +1,30 @@
+import { OAuthProvider, User } from '../types/oauth.types'
+
+type OAuthEntityLike = {
+  provider: string
+  code: string
+}
+
+type UserEntityLike = {
+  id: string
+  nickname: string
+  avatarUrl: string | null
+}
+
+export class OAuthUserDto implements User {
+  id: string
+  provider: OAuthProvider
+  providerId: string
+  nickname: string
+  avatarUrl?: string
+
+  static fromEntity(payload: { user: UserEntityLike; oauth: OAuthEntityLike }): User {
+    return {
+      id: payload.user.id,
+      provider: payload.oauth.provider as OAuthProvider,
+      providerId: payload.oauth.code,
+      nickname: payload.user.nickname,
+      avatarUrl: payload.user.avatarUrl ?? undefined,
+    }
+  }
+}

--- a/backend/src/oauth/oauth.module.ts
+++ b/backend/src/oauth/oauth.module.ts
@@ -10,6 +10,7 @@ import { KakaoStrategy } from './strategy/kakao.strategy'
 import { TokenService } from './service/token.service'
 import { JwtStrategy } from './strategy/jwt.strategy'
 import { RefreshStrategy } from './strategy/jwt-refresh.strategy'
+import { PrismaService } from 'src/prisma/prisma.service'
 
 @Module({
   imports: [
@@ -29,7 +30,7 @@ import { RefreshStrategy } from './strategy/jwt-refresh.strategy'
     }),
   ],
   controllers: [OauthController],
-  providers: [OauthService, GithubStrategy, KakaoStrategy, JwtStrategy, RefreshStrategy, TokenService],
+  providers: [OauthService, GithubStrategy, KakaoStrategy, JwtStrategy, RefreshStrategy, TokenService, PrismaService],
   exports: [OauthService],
 })
 export class OauthModule {}

--- a/backend/src/oauth/service/oauth.service.spec.ts
+++ b/backend/src/oauth/service/oauth.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing'
 import { NotFoundException } from '@nestjs/common'
 import { OauthService } from './oauth.service'
 import { TokenService } from './token.service'
+import { PrismaService } from 'src/prisma/prisma.service'
 import type { OAuthProfile } from '../types/oauth.types'
 
 describe('OauthService', () => {
@@ -12,13 +13,56 @@ describe('OauthService', () => {
     refresh: jest.fn(),
   }
 
+  let users: Array<{ id: string; nickname: string; avatarUrl: string | null; tier: string; rating: number }>
+  let oauths: Array<{ id: string; userId: string; provider: string; code: string }>
+  const mockPrisma = {
+    user: {
+      findUnique: jest.fn(({ where }: { where: { id?: string; nickname?: string } }) => {
+        if (where.id) return users.find(u => u.id === where.id) ?? null
+        if (where.nickname) return users.find(u => u.nickname === where.nickname) ?? null
+        return null
+      }),
+      create: jest.fn(({ data }: { data: { id: string; nickname: string; avatarUrl: string | null; tier: string; rating: number } }) => {
+        const record = { ...data }
+        users.push(record)
+        return record
+      }),
+      update: jest.fn(({ where, data }: { where: { id: string }; data: { nickname: string } }) => {
+        const user = users.find(u => u.id === where.id)
+        if (!user) return null
+        user.nickname = data.nickname
+        return user
+      }),
+    },
+    oAuth: {
+      findFirst: jest.fn(({ where }: { where: { provider?: string; code?: string; userId?: string } }) => {
+        if (where.userId) return oauths.find(o => o.userId === where.userId) ?? null
+        if (where.provider && where.code) return oauths.find(o => o.provider === where.provider && o.code === where.code) ?? null
+        return null
+      }),
+      create: jest.fn(({ data }: { data: { id: string; userId: string; provider: string; code: string } }) => {
+        const record = { ...data }
+        oauths.push(record)
+        return record
+      }),
+    },
+    $transaction: jest.fn((callback: (tx: typeof mockPrisma) => Promise<unknown>) => callback(mockPrisma)),
+  }
+
   beforeEach(async () => {
+    users = []
+    oauths = []
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         OauthService,
         {
           provide: TokenService,
           useValue: mockTokenService,
+        },
+        {
+          provide: PrismaService,
+          useValue: mockPrisma,
         },
       ],
     }).compile()
@@ -29,14 +73,14 @@ describe('OauthService', () => {
   })
 
   describe('findOrCreateUser', () => {
-    it('새로운 사용자를 생성한다', () => {
+    it('새로운 사용자를 생성한다', async () => {
       const profile: OAuthProfile = {
         provider: 'github',
         providerId: '12345',
         avatarUrl: 'https://example.com/avatar.jpg',
       }
 
-      const user = service.findOrCreateUser(profile)
+      const user = await service.findOrCreateUser(profile)
 
       expect(user).toBeDefined()
       expect(user.provider).toBe('github')
@@ -47,21 +91,20 @@ describe('OauthService', () => {
       expect(typeof user.id).toBe('string')
     })
 
-    it('같은 provider와 providerId로 다시 호출하면 기존 사용자를 반환한다', () => {
+    it('같은 provider와 providerId로 다시 호출하면 기존 사용자를 반환한다', async () => {
       const profile: OAuthProfile = {
         provider: 'github',
         providerId: '12345',
         avatarUrl: 'https://example.com/avatar.jpg',
       }
 
-      const user1 = service.findOrCreateUser(profile)
-      const user2 = service.findOrCreateUser(profile)
+      const user1 = await service.findOrCreateUser(profile)
+      const user2 = await service.findOrCreateUser(profile)
 
-      expect(user1).toBe(user2)
       expect(user1.id).toBe(user2.id)
     })
 
-    it('다른 providerId면 새로운 사용자를 생성한다', () => {
+    it('다른 providerId면 새로운 사용자를 생성한다', async () => {
       const profile1: OAuthProfile = {
         provider: 'github',
         providerId: '12345',
@@ -74,14 +117,14 @@ describe('OauthService', () => {
         avatarUrl: 'https://example.com/avatar2.jpg',
       }
 
-      const user1 = service.findOrCreateUser(profile1)
-      const user2 = service.findOrCreateUser(profile2)
+      const user1 = await service.findOrCreateUser(profile1)
+      const user2 = await service.findOrCreateUser(profile2)
 
       expect(user1).not.toBe(user2)
       expect(user1.id).not.toBe(user2.id)
     })
 
-    it('다른 provider면 새로운 사용자를 생성한다', () => {
+    it('다른 provider면 새로운 사용자를 생성한다', async () => {
       const githubProfile: OAuthProfile = {
         provider: 'github',
         providerId: '12345',
@@ -94,8 +137,8 @@ describe('OauthService', () => {
         avatarUrl: 'https://example.com/kakao.jpg',
       }
 
-      const githubUser = service.findOrCreateUser(githubProfile)
-      const kakaoUser = service.findOrCreateUser(kakaoProfile)
+      const githubUser = await service.findOrCreateUser(githubProfile)
+      const kakaoUser = await service.findOrCreateUser(kakaoProfile)
 
       expect(githubUser).not.toBe(kakaoUser)
       expect(githubUser.id).not.toBe(kakaoUser.id)
@@ -103,7 +146,7 @@ describe('OauthService', () => {
   })
 
   describe('loginWithGithub', () => {
-    it('GitHub 프로필로 로그인하고 토큰을 발급한다', () => {
+    it('GitHub 프로필로 로그인하고 토큰을 발급한다', async () => {
       const profile: OAuthProfile = {
         provider: 'github',
         providerId: '12345',
@@ -117,13 +160,13 @@ describe('OauthService', () => {
 
       mockTokenService.generateTokens.mockReturnValue(mockTokens)
 
-      const result = service.loginWithGithub(profile)
+      const result = await service.loginWithGithub(profile)
 
       expect(result).toEqual(mockTokens)
       expect(mockTokenService.generateTokens).toHaveBeenCalledTimes(1)
     })
 
-    it('같은 GitHub 사용자가 다시 로그인하면 기존 사용자로 토큰을 발급한다', () => {
+    it('같은 GitHub 사용자가 다시 로그인하면 기존 사용자로 토큰을 발급한다', async () => {
       const profile: OAuthProfile = {
         provider: 'github',
         providerId: '12345',
@@ -142,8 +185,8 @@ describe('OauthService', () => {
 
       mockTokenService.generateTokens.mockReturnValueOnce(mockTokens1).mockReturnValueOnce(mockTokens2)
 
-      const result1 = service.loginWithGithub(profile)
-      const result2 = service.loginWithGithub(profile)
+      const result1 = await service.loginWithGithub(profile)
+      const result2 = await service.loginWithGithub(profile)
 
       expect(result1).toEqual(mockTokens1)
       expect(result2).toEqual(mockTokens2)
@@ -152,7 +195,7 @@ describe('OauthService', () => {
   })
 
   describe('loginWithKakao', () => {
-    it('Kakao 프로필로 로그인하고 토큰을 발급한다', () => {
+    it('Kakao 프로필로 로그인하고 토큰을 발급한다', async () => {
       const profile: OAuthProfile = {
         provider: 'kakao',
         providerId: '67890',
@@ -166,7 +209,7 @@ describe('OauthService', () => {
 
       mockTokenService.generateTokens.mockReturnValue(mockTokens)
 
-      const result = service.loginWithKakao(profile)
+      const result = await service.loginWithKakao(profile)
 
       expect(result).toEqual(mockTokens)
       expect(mockTokenService.generateTokens).toHaveBeenCalledTimes(1)
@@ -191,7 +234,7 @@ describe('OauthService', () => {
   })
 
   describe('findUserById', () => {
-    it('존재하는 userId로 사용자를 조회한다', () => {
+    it('존재하는 userId로 사용자를 조회한다', async () => {
       const profile: OAuthProfile = {
         provider: 'github',
         providerId: '12345',
@@ -203,20 +246,20 @@ describe('OauthService', () => {
         refreshToken: 'refresh',
       })
 
-      service.loginWithGithub(profile)
-      const createdUser = service.findOrCreateUser(profile)
-      const foundUser = service.findUserById(createdUser.id)
+      await service.loginWithGithub(profile)
+      const createdUser = await service.findOrCreateUser(profile)
+      const foundUser = await service.findUserById(createdUser.id)
 
       expect(foundUser).toEqual(createdUser)
       expect(foundUser.id).toBe(createdUser.id)
     })
 
-    it('존재하지 않는 userId로 조회하면 NotFoundException을 던진다', () => {
-      expect(() => service.findUserById('non-existent-id')).toThrow(NotFoundException)
-      expect(() => service.findUserById('non-existent-id')).toThrow('사용자를 찾을 수 없습니다.')
+    it('존재하지 않는 userId로 조회하면 NotFoundException을 던진다', async () => {
+      await expect(service.findUserById('non-existent-id')).rejects.toThrow(NotFoundException)
+      await expect(service.findUserById('non-existent-id')).rejects.toThrow('사용자를 찾을 수 없습니다.')
     })
 
-    it('여러 사용자 중 특정 userId를 조회한다', () => {
+    it('여러 사용자 중 특정 userId를 조회한다', async () => {
       const profile1: OAuthProfile = {
         provider: 'github',
         providerId: '12345',
@@ -234,14 +277,14 @@ describe('OauthService', () => {
         refreshToken: 'refresh',
       })
 
-      service.loginWithGithub(profile1)
-      service.loginWithGithub(profile2)
+      await service.loginWithGithub(profile1)
+      await service.loginWithGithub(profile2)
 
-      const user1 = service.findOrCreateUser(profile1)
-      const user2 = service.findOrCreateUser(profile2)
+      const user1 = await service.findOrCreateUser(profile1)
+      const user2 = await service.findOrCreateUser(profile2)
 
-      const foundUser1 = service.findUserById(user1.id)
-      const foundUser2 = service.findUserById(user2.id)
+      const foundUser1 = await service.findUserById(user1.id)
+      const foundUser2 = await service.findUserById(user2.id)
 
       expect(foundUser1.id).toBe(user1.id)
       expect(foundUser2.id).toBe(user2.id)
@@ -250,7 +293,7 @@ describe('OauthService', () => {
   })
 
   describe('updateUserNickname', () => {
-    it('존재하는 사용자의 닉네임을 성공적으로 변경한다', () => {
+    it('존재하는 사용자의 닉네임을 성공적으로 변경한다', async () => {
       const profile: OAuthProfile = {
         provider: 'github',
         providerId: '12345',
@@ -262,18 +305,18 @@ describe('OauthService', () => {
         refreshToken: 'refresh',
       })
 
-      service.loginWithGithub(profile)
-      const createdUser = service.findOrCreateUser(profile)
+      await service.loginWithGithub(profile)
+      const createdUser = await service.findOrCreateUser(profile)
       const newNickname = 'newNickname'
 
-      const result = service.updateUserNickname(createdUser.id, newNickname)
+      const result = await service.updateUserNickname(createdUser.id, newNickname)
 
       expect(result).toBeDefined()
       expect(result.id).toBe(createdUser.id)
       expect(result.nickname).toBe(newNickname)
       expect(result.avatarUrl).toBe(createdUser.avatarUrl || '')
 
-      const updatedUser = service.findUserById(createdUser.id)
+      const updatedUser = await service.findUserById(createdUser.id)
       expect(updatedUser.nickname).toBe(newNickname)
     })
   })

--- a/backend/src/oauth/service/oauth.service.spec.ts
+++ b/backend/src/oauth/service/oauth.service.spec.ts
@@ -36,8 +36,15 @@ describe('OauthService', () => {
     },
     oAuth: {
       findFirst: jest.fn(({ where }: { where: { provider?: string; code?: string; userId?: string } }) => {
-        if (where.userId) return oauths.find(o => o.userId === where.userId) ?? null
-        if (where.provider && where.code) return oauths.find(o => o.provider === where.provider && o.code === where.code) ?? null
+        if (where.userId) {
+          return oauths.find(o => o.userId === where.userId) ?? null
+        }
+        if (where.provider && where.code) {
+          const oauth = oauths.find(o => o.provider === where.provider && o.code === where.code)
+          if (!oauth) return null
+          const user = users.find(u => u.id === oauth.userId)
+          return { ...oauth, user }
+        }
         return null
       }),
       create: jest.fn(({ data }: { data: { id: string; userId: string; provider: string; code: string } }) => {
@@ -70,6 +77,8 @@ describe('OauthService', () => {
     service = module.get<OauthService>(OauthService)
 
     jest.clearAllMocks()
+    mockTokenService.generateTokens.mockReset()
+    mockTokenService.refresh.mockReset()
   })
 
   describe('findOrCreateUser', () => {

--- a/backend/src/oauth/service/oauth.service.ts
+++ b/backend/src/oauth/service/oauth.service.ts
@@ -1,41 +1,85 @@
 import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common'
+import { v7 as uuidv7 } from 'uuid'
 import { OAuthProfile, User } from '../types/oauth.types'
 import { TokenService } from './token.service'
 import { OAuthUserResponseDto } from '../dto/oauthUserResponse.dto'
+import { PrismaService } from 'src/prisma/prisma.service'
 import { isGuestNicknamePattern } from '../../battles/service/utils/nickname.util'
 
 @Injectable()
 export class OauthService {
-  constructor(private readonly tokenService: TokenService) {}
+  constructor(
+    private readonly tokenService: TokenService,
+    private readonly prisma: PrismaService,
+  ) {}
 
-  private readonly oauthMap = new Map<string, User>()
-
-  findOrCreateUser(p: OAuthProfile): User {
-    const key = `${p.provider}-${p.providerId}`
-    const initialNickname = 'anonymous'
-
-    const existed = this.oauthMap.get(key)
-    if (existed) {
-      return existed
+  private toUser(payload: { id: string; nickname: string; avatarUrl: string | null; provider: string; providerId: string }): User {
+    return {
+      id: payload.id,
+      provider: payload.provider as User['provider'],
+      providerId: payload.providerId,
+      nickname: payload.nickname,
+      avatarUrl: payload.avatarUrl ?? undefined,
     }
-
-    const newuUser: User = {
-      id: crypto.randomUUID(),
-      provider: p.provider,
-      providerId: p.providerId,
-      nickname: initialNickname,
-      avatarUrl: p.avatarUrl,
-    }
-
-    this.oauthMap.set(key, newuUser)
-    return newuUser
   }
 
-  loginWithGithub(profile: OAuthProfile): {
+  async findOrCreateUser(p: OAuthProfile): Promise<User> {
+    const existingOAuth = await this.prisma.oAuth.findFirst({
+      where: { provider: p.provider, code: p.providerId },
+      include: { user: true },
+    })
+
+    if (existingOAuth) {
+      return this.toUser({
+        id: existingOAuth.user.id,
+        nickname: existingOAuth.user.nickname,
+        avatarUrl: existingOAuth.user.avatarUrl,
+        provider: existingOAuth.provider,
+        providerId: existingOAuth.code,
+      })
+    }
+
+    const nickname = 'anonymous'
+    const userId = uuidv7()
+    const oauthId = uuidv7()
+
+    const created = await this.prisma.$transaction(async prisma => {
+      const user = await prisma.user.create({
+        data: {
+          id: userId,
+          nickname,
+          tier: 'UNRANKED',
+          rating: 0,
+          avatarUrl: p.avatarUrl ?? null,
+        },
+      })
+
+      const oauth = await prisma.oAuth.create({
+        data: {
+          id: oauthId,
+          userId,
+          provider: p.provider,
+          code: p.providerId,
+        },
+      })
+
+      return { user, oauth }
+    })
+
+    return this.toUser({
+      id: created.user.id,
+      nickname: created.user.nickname,
+      avatarUrl: created.user.avatarUrl,
+      provider: created.oauth.provider,
+      providerId: created.oauth.code,
+    })
+  }
+
+  async loginWithGithub(profile: OAuthProfile): Promise<{
     accessToken: string
     refreshToken: string
-  } {
-    const loginUser = this.findOrCreateUser(profile)
+  }> {
+    const loginUser = await this.findOrCreateUser(profile)
     const { accessToken, refreshToken } = this.tokenService.generateTokens(loginUser.id)
 
     return {
@@ -44,11 +88,11 @@ export class OauthService {
     }
   }
 
-  loginWithKakao(profile: OAuthProfile): {
+  async loginWithKakao(profile: OAuthProfile): Promise<{
     accessToken: string
     refreshToken: string
-  } {
-    const loginUser = this.findOrCreateUser(profile)
+  }> {
+    const loginUser = await this.findOrCreateUser(profile)
     const { accessToken, refreshToken } = this.tokenService.generateTokens(loginUser.id)
 
     return {
@@ -65,32 +109,57 @@ export class OauthService {
     return { accessToken, refreshToken: newRefreshToken }
   }
 
-  updateUserNickname(userId: string, nickname: string): OAuthUserResponseDto {
+  async updateUserNickname(userId: string, nickname: string): Promise<OAuthUserResponseDto> {
     // 비회원 닉네임 패턴과 겹치지 않는지 확인
     if (isGuestNicknamePattern(nickname)) {
       throw new BadRequestException('다른 닉네임을 사용해주세요.')
     }
 
-    const user = this.findUserById(userId)
-    user.nickname = nickname
-    return OAuthUserResponseDto.of(user)
+    const oauth = await this.prisma.oAuth.findFirst({ where: { userId } })
+    if (!oauth) throw new NotFoundException('사용자를 찾을 수 없습니다.')
+
+    const user = await this.prisma.user.update({
+      where: { id: userId },
+      data: { nickname },
+    })
+
+    return OAuthUserResponseDto.of(
+      this.toUser({
+        id: user.id,
+        nickname: user.nickname,
+        avatarUrl: user.avatarUrl,
+        provider: oauth.provider,
+        providerId: oauth.code,
+      }),
+    )
   }
   /**
    * ID로 사용자 조회
    */
-  findUserById(userId: string): User {
-    for (const user of this.oauthMap.values()) {
-      if (user.id === userId) {
-        return user
-      }
-    }
-    throw new NotFoundException('사용자를 찾을 수 없습니다.')
+  async findUserById(userId: string): Promise<User> {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } })
+    if (!user) throw new NotFoundException('사용자를 찾을 수 없습니다.')
+
+    const oauth = await this.prisma.oAuth.findFirst({ where: { userId } })
+    if (!oauth) throw new NotFoundException('사용자를 찾을 수 없습니다.')
+
+    return this.toUser({
+      id: user.id,
+      nickname: user.nickname,
+      avatarUrl: user.avatarUrl,
+      provider: oauth.provider,
+      providerId: oauth.code,
+    })
   }
 
   /**
    * 닉네임이 OAuth 사용자 중에 존재하는지 확인
    */
-  isNicknameExists(nickname: string): boolean {
-    return Array.from(this.oauthMap.values()).some(user => user.nickname === nickname)
+  async isNicknameExists(nickname: string): Promise<boolean> {
+    const user = await this.prisma.user.findFirst({
+      where: { nickname },
+      select: { id: true },
+    })
+    return Boolean(user)
   }
 }

--- a/backend/src/oauth/service/oauth.service.ts
+++ b/backend/src/oauth/service/oauth.service.ts
@@ -3,6 +3,7 @@ import { v7 as uuidv7 } from 'uuid'
 import { OAuthProfile, User } from '../types/oauth.types'
 import { TokenService } from './token.service'
 import { OAuthUserResponseDto } from '../dto/oauthUserResponse.dto'
+import { OAuthUserDto } from '../dto/oauthUser.dto'
 import { PrismaService } from '../../prisma/prisma.service'
 import { isGuestNicknamePattern } from '../../battles/service/utils/nickname.util'
 
@@ -13,16 +14,6 @@ export class OauthService {
     private readonly prisma: PrismaService,
   ) {}
 
-  private toUser(payload: { id: string; nickname: string; avatarUrl: string | null; provider: string; providerId: string }): User {
-    return {
-      id: payload.id,
-      provider: payload.provider as User['provider'],
-      providerId: payload.providerId,
-      nickname: payload.nickname,
-      avatarUrl: payload.avatarUrl ?? undefined,
-    }
-  }
-
   async findOrCreateUser(p: OAuthProfile): Promise<User> {
     const existingOAuth = await this.prisma.oAuth.findFirst({
       where: { provider: p.provider, code: p.providerId },
@@ -30,13 +21,7 @@ export class OauthService {
     })
 
     if (existingOAuth) {
-      return this.toUser({
-        id: existingOAuth.user.id,
-        nickname: existingOAuth.user.nickname,
-        avatarUrl: existingOAuth.user.avatarUrl,
-        provider: existingOAuth.provider,
-        providerId: existingOAuth.code,
-      })
+      return OAuthUserDto.fromEntity({ user: existingOAuth.user, oauth: existingOAuth })
     }
 
     const nickname = 'anonymous'
@@ -66,13 +51,7 @@ export class OauthService {
       return { user, oauth }
     })
 
-    return this.toUser({
-      id: created.user.id,
-      nickname: created.user.nickname,
-      avatarUrl: created.user.avatarUrl,
-      provider: created.oauth.provider,
-      providerId: created.oauth.code,
-    })
+    return OAuthUserDto.fromEntity({ user: created.user, oauth: created.oauth })
   }
 
   async loginWithGithub(profile: OAuthProfile): Promise<{
@@ -123,15 +102,7 @@ export class OauthService {
       data: { nickname },
     })
 
-    return OAuthUserResponseDto.of(
-      this.toUser({
-        id: user.id,
-        nickname: user.nickname,
-        avatarUrl: user.avatarUrl,
-        provider: oauth.provider,
-        providerId: oauth.code,
-      }),
-    )
+    return OAuthUserResponseDto.of(OAuthUserDto.fromEntity({ user, oauth }))
   }
   /**
    * ID로 사용자 조회
@@ -143,13 +114,7 @@ export class OauthService {
     const oauth = await this.prisma.oAuth.findFirst({ where: { userId } })
     if (!oauth) throw new NotFoundException('사용자를 찾을 수 없습니다.')
 
-    return this.toUser({
-      id: user.id,
-      nickname: user.nickname,
-      avatarUrl: user.avatarUrl,
-      provider: oauth.provider,
-      providerId: oauth.code,
-    })
+    return OAuthUserDto.fromEntity({ user, oauth })
   }
 
   /**

--- a/backend/src/oauth/service/oauth.service.ts
+++ b/backend/src/oauth/service/oauth.service.ts
@@ -3,7 +3,7 @@ import { v7 as uuidv7 } from 'uuid'
 import { OAuthProfile, User } from '../types/oauth.types'
 import { TokenService } from './token.service'
 import { OAuthUserResponseDto } from '../dto/oauthUserResponse.dto'
-import { PrismaService } from 'src/prisma/prisma.service'
+import { PrismaService } from '../../prisma/prisma.service'
 import { isGuestNicknamePattern } from '../../battles/service/utils/nickname.util'
 
 @Injectable()

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import PlusIcon from '@/assets/icon/plus.svg?react';
 import { BATTLE_CATEGORY_CONFIG } from '../mainPage/types/battle';

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import PlusIcon from '@/assets/icon/plus.svg?react';
 import { BATTLE_CATEGORY_CONFIG } from '../mainPage/types/battle';
@@ -54,11 +54,9 @@ export default function BattleCreatePage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const rounds = useMemo(() => {
-    return PLAYTIME_OPTIONS.find(({ value }) => value === playTime)?.rounds ?? 0;
-  }, [playTime]);
+  const rounds = PLAYTIME_OPTIONS.find(({ value }) => value === playTime)?.rounds ?? 0;
 
-  const canSubmit = useMemo(() => {
+  const canSubmit = (() => {
     if (!authorId) return false;
     if (!title.trim()) return false;
     if (!description.trim()) return false;
@@ -68,7 +66,7 @@ export default function BattleCreatePage() {
     if (topics.length !== rounds) return false;
 
     return true;
-  }, [authorId, title, description, aCode, bCode, type, password, topics.length, rounds]);
+  })();
 
   const handleSubmit = async () => {
     if (!canSubmit || isSubmitting) return;

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -4,6 +4,7 @@ import PlusIcon from '@/assets/icon/plus.svg?react';
 import { BATTLE_CATEGORY_CONFIG } from '../mainPage/types/battle';
 import BattleTopicInput from './components/BattleTopicInput';
 import { formatCode } from '@/commons/utils/codeFormatter';
+import { selectUser, useAuthStore } from '@/commons/stores/authStore';
 
 type BattleType = 'PUBLIC' | 'PRIVATE';
 type BattleLanguage = 'javascript' | 'typescript' | 'python';
@@ -37,7 +38,8 @@ export default function BattleCreatePage() {
     []
   );
 
-  const [authorId] = useState('user-1');
+  const user = useAuthStore(selectUser);
+  const authorId = user?.id ?? null;
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [aCode, setACode] = useState('');
@@ -57,6 +59,7 @@ export default function BattleCreatePage() {
   }, [playTime]);
 
   const canSubmit = useMemo(() => {
+    if (!authorId) return false;
     if (!title.trim()) return false;
     if (!description.trim()) return false;
     if (!aCode.trim()) return false;
@@ -65,7 +68,7 @@ export default function BattleCreatePage() {
     if (topics.length !== rounds) return false;
 
     return true;
-  }, [title, description, aCode, bCode, type, password, topics.length, rounds]);
+  }, [authorId, title, description, aCode, bCode, type, password, topics.length, rounds]);
 
   const handleSubmit = async () => {
     if (!canSubmit || isSubmitting) return;
@@ -75,6 +78,9 @@ export default function BattleCreatePage() {
     try {
       const [formattedA, formattedB] = await Promise.all([formatCode(aCode, language), formatCode(bCode, language)]);
 
+      if (!authorId) {
+        throw new Error('로그인이 필요합니다.');
+      }
       const res = await fetch(`/api/battles`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->
Closes #215 
## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->
  - 배틀 진행 상태를 in-memory에서 DB 기반으로 전환
      - Battle 테이블에 진행 상태/시간/JSON 스냅샷 컬럼 추가
      - activeBattles Map 제거 후 loadBattleState/saveBattleState로 상태 로드/저장
      - 진행 중 상태 변경(참가/채팅/공격/방어/투표/페이즈 전환) 시 DB 업데이트
      - 배틀 종료 시 결과/타임라인/승리팀/참가자 수 저장 및 진행 상태 컬럼 초기화
  - 배틀 목록/결과 조회를 DB 기반으로 변경
      - open/closed 목록 조회를 Prisma 조회로 전환
      - 결과 조회 응답 구성 시 DB 데이터 기반으로 구성
  - 게스트/참가 처리 방식 개선
      - 게스트 등록 시 DB 상태에 participants 반영
      - 기존 참가자라도 팀이 변경된 경우 participants_state 업데이트
  - OAuth 로그인 저장을 DB 기반으로 전환
      - OAuth 유저 조회/생성/닉네임 변경/조회 모두 Prisma 사용
  - 프론트 배틀 생성 시 authorId 하드코딩 제거
      - 로그인 유저의 실제 user.id를 전송하도록 수정


---
#### 추가 수정

- 결과 API에서 MVP 배열이 비던 문제 수정
    - 배틀 종료 시 MVP 상세 정보를 mvps_state로 저장하고, 결과 조회 시 반환하도록 수정
    - Prisma 스키마 및 마이그레이션 추가
- DB 전환에 맞춰 battles/oauth 관련 테스트 정리
  - 테스트 실행 전 prisma generate 자동화

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->

현재 신규 OAuth 유저를 anonymous로 저장하므로 unique라면 충돌 시 에러 발생 가능하고 아니라도 중복 가능해짐
