### PR TITLE
[Fix] MVP opinionCount, totalVotes가 0으로 반환되는 버그 수정

### DIFF
--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -882,6 +882,7 @@ export class BattlesService extends EventEmitter {
       if (i !== idx && discussion && this.hasAlreadyVoted(discussion.votes, userId)) {
         const canceled = this.removeVote(discussion, userId)
         discussions[i] = canceled
+        this.syncOpinionHistory(battleState, discussion.discussionId, canceled)
         updatedDiscussions.push(DiscussionVoteResponseDto.of(battleId, canceled))
       }
     })
@@ -889,6 +890,7 @@ export class BattlesService extends EventEmitter {
     // 새 항목에 투표 적용
     const updated = this.applyVote(target, userId)
     discussions[idx] = updated
+    this.syncOpinionHistory(battleState, discussionId, updated)
     updatedDiscussions.push(DiscussionVoteResponseDto.of(battleId, updated))
 
     return updatedDiscussions
@@ -927,6 +929,7 @@ export class BattlesService extends EventEmitter {
       if (i !== idx && discussion && this.hasAlreadyVoted(discussion.votes, userId)) {
         const canceled = this.removeVote(discussion, userId)
         discussions[i] = canceled
+        this.syncOpinionHistory(battleState, discussion.discussionId, canceled)
         updatedDiscussions.push(DiscussionVoteResponseDto.of(battleId, canceled))
       }
     })
@@ -934,6 +937,7 @@ export class BattlesService extends EventEmitter {
     // 새 항목에 투표 적용
     const updated = this.applyVote(target, userId)
     discussions[idx] = updated
+    this.syncOpinionHistory(battleState, discussionId, updated)
     updatedDiscussions.push(DiscussionVoteResponseDto.of(battleId, updated))
 
     return updatedDiscussions
@@ -1080,6 +1084,13 @@ export class BattlesService extends EventEmitter {
       ...discussion,
       votes: discussion.votes.filter(id => id !== userId),
       upvotes: discussion.upvotes - 1,
+    }
+  }
+
+  private syncOpinionHistory(battleState: ActiveBattleState, discussionId: string, updated: BattleDiscussion): void {
+    const idx = battleState.opinionHistory.findIndex(o => o.discussionId === discussionId)
+    if (idx !== -1) {
+      battleState.opinionHistory[idx] = updated
     }
   }
 

--- a/frontend/src/pages/battleResultPage/components/MvpCard.tsx
+++ b/frontend/src/pages/battleResultPage/components/MvpCard.tsx
@@ -98,7 +98,7 @@ export default function MvpCard({ mvpList, bestOpinion }: MvpCardProps) {
                       className="flex items-center justify-between bg-black/10 rounded-lg px-3 py-2"
                     >
                       <div className="flex items-center gap-2">
-                        <Medal className={`w-4 h-4 ${index === 0 ? 'text-gray-300' : 'text-amber-600'}`} />
+                        <Medal className={`w-4 h-4 ${index === 0 ? 'text-gray-300' : 'text-amber-900'}`} />
                         <span className="text-white/80 text-sm">{index + 2}등</span>
                         <span className="text-white font-medium">{runner.nickname}</span>
                       </div>


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #211

## ✅ 작업 내용

### 💡개선 사항
- 투표 시 `opinionHistory`가 동기화되지 않아 MVP의 `totalVotes`, `opinionCount`가 0으로 표시되는 버그 수정
- 3등 메달 아이콘 색상을 더 진한 갈색(`text-amber-900`)으로 변경하여 가시성 개선

<br />

## 📸 참고 사항

### 버그 원인
- `applyVote()` 함수가 새 객체를 반환하여 `teamA.attacks`는 업데이트되지만, `opinionHistory`는 원본 객체를 계속 참조
- `calculateMVPs`에서 `opinionHistory`를 사용하므로 `upvotes: 0`인 원본 데이터로 계산됨

### 해결 방법
- `syncOpinionHistory` 헬퍼 함수 추가
- `handleAttackVote`, `handleDefenseVote`에서 투표 적용/취소 시 `opinionHistory`도 함께 동기화

### 변경 파일
- `backend/src/battles/service/battles.service.ts`
- `frontend/src/pages/battleResultPage/components/MvpCard.tsx`

<img width="1045" height="956" alt="image" src="https://github.com/user-attachments/assets/7ebb528b-8898-45f0-96bc-5e7a55231f5d" />

<br />

## 💬 질문사항 (고민했던 부분)
- 없음
