### PR TITLE
[Hotfix] 배틀 돌아가기 에러 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,15 +10,16 @@ import LoginPage from './pages/loginPage';
 import NicknamePage from './pages/nicknamePage';
 import OAuthCallbackPage from './pages/OAuthCallbackPage';
 import { useAuthStore } from './commons/stores/authStore';
+import { useEffect } from 'react';
 
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <MainPage />,
-    loader: async () => {
-      // OAuth 로그인 후 리다이렉트 시 인증 상태 확인
-      return await useAuthStore.getState().getOAuthUser();
-    }
+    element: <MainPage />
+    // loader: async () => {
+    //   // OAuth 로그인 후 리다이렉트 시 인증 상태 확인
+    //   return await useAuthStore.getState().getOAuthUser();
+    // }
   },
   {
     path: '/auth/callback',
@@ -61,6 +62,14 @@ const router = createBrowserRouter([
 ]);
 
 function App() {
+  useEffect(() => {
+    async function getUserInfo() {
+      await useAuthStore.getState().getOAuthUser();
+    }
+
+    getUserInfo();
+  }, []);
+
   return <RouterProvider router={router} />;
 }
 


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

## ✅ 작업 내용

배틀 중 돌아가기 버튼을 클릭하면 "진입할 수 없다"는 에러가 발생함

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

- 메인페이지에서 비동기로 `loader`로 돌리고 있는데 메인 페이지가 렌더링 되기 전에 배틀 페이지의 `useEffect()`가 먼저 실행되어 버림.
- `loader()`에서 비동기를 빼고 컴포넌트 내에서 `useEffect()`로 돌려서 개선

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
