### PR TITLE
[fix] : 배틀 페이지 게임 가이드 라인 UI 버그 개선

### DIFF
--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -1,4 +1,5 @@
-import { selectBattleProgress, selectProgressBoardCollapsed, useBattleStore } from '../../stores/battleStore';
+import { useState } from 'react';
+import { selectBattleProgress, useBattleStore } from '../../stores/battleStore';
 import { CollapseButton } from './CollapseButton';
 import { ExpandButton } from './ExpandButton';
 import { ProgressBar } from './ProgressBar';
@@ -6,8 +7,7 @@ import { StageList } from './StageList';
 
 export default function BattleProgressBoard() {
   const battleProgress = useBattleStore(selectBattleProgress);
-  const collapsed = useBattleStore(selectProgressBoardCollapsed);
-  const setCollapsed = useBattleStore((state) => state.setProgressBoardCollapsed);
+  const [collapsed, setCollapsed] = useState(false);
 
   const shouldShow =
     battleProgress &&

--- a/frontend/src/pages/battlePage/components/sidebar/index.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/index.tsx
@@ -24,7 +24,8 @@ export default function BattleSidebar({
   description,
   language,
   category,
-  topics
+  topics,
+  raiseZIndex = false
 }: BattleSidebarProps) {
   const [activeTab, setActiveTab] = useState<Tab>('info');
   const { width, isResizing, setIsResizing } = useResize({
@@ -48,11 +49,12 @@ export default function BattleSidebar({
 
   return (
     <aside
+      data-tutorial="sidebar-panel"
       ref={asideRef}
       style={{ width: `${width}px` }}
-      className={`fixed top-0 left-0 h-full sidebar-width bg-[#0a0a1a] border-r border-[#1A1A2E] z-100 transform transition-transform duration-300 ease-in-out shadow-2xl ${
-        isOpen ? 'translate-x-0' : '-translate-x-full'
-      } ${isResizing ? 'select-none' : ''}`}
+      className={`fixed top-0 left-0 h-full sidebar-width bg-[#0a0a1a] border-r border-[#1A1A2E] transform transition-transform duration-300 ease-in-out shadow-2xl ${
+        raiseZIndex ? 'z-[101]' : 'z-100'
+      } ${isOpen ? 'translate-x-0' : '-translate-x-full'} ${isResizing ? 'select-none' : ''}`}
     >
       <SidebarHeader activeTab={activeTab} onTabChange={setActiveTab} onClose={onClose} />
       <div className="flex justify-between">

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialDiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialDiscussionInput.tsx
@@ -1,0 +1,39 @@
+import BattleIcon from '@/assets/icon/battle.svg?react';
+
+export default function TutorialDiscussionInput() {
+  return (
+    <section className="discussion-input-width relative rounded-xl overflow-visible border-2 transition-all duration-500 bg-gradient-to-br from-[#1E1E2F] via-[#2D1B3D] to-[#1E1E2F] border-[#FF6900]/30 shadow-[0_0_30px_rgba(255,105,0,0.15)]">
+      <div className="absolute top-0 left-1/2 -translate-x-1/2 px-4 py-1 rounded-b-lg text-xs font-bold tracking-wider uppercase border-x border-b bg-gradient-to-r from-[#FF6900] to-[#FB2C36] border-[#FF6900]/50 text-white">
+        <span className="flex items-center gap-1.5">
+          <span className="w-2 h-2 rounded-full bg-current animate-pulse" />
+          1R 이의제기
+        </span>
+      </div>
+
+      <div className="relative px-5 py-6 pt-8">
+        <div className="flex items-center gap-4">
+          <div className="rounded-xl flex items-center justify-center shrink-0 w-16 h-16 border-2 border-[#FF6900]/30 bg-[#FF6900]/10 animate-pulse">
+            <BattleIcon className="w-8 h-8 text-[#FF6900]" />
+          </div>
+
+          <div className="flex-1 flex gap-3">
+            <input
+              type="text"
+              value=""
+              readOnly
+              placeholder="상대 코드의 문제점을 지적해보세요"
+              className="w-full bg-black/30 backdrop-blur-sm rounded-lg px-4 py-3.5 text-sm text-white placeholder-gray-500/60 border-2 border-[#FF6900]/20 focus:outline-none"
+            />
+
+            <button
+              disabled
+              className="px-5 py-3.5 rounded-lg font-semibold text-sm flex items-center justify-center gap-2 transition-all whitespace-nowrap shrink-0 bg-gradient-to-r from-[#FF6900] to-[#FB2C36] text-white disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              이의제기
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialProgressBoard.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { CollapseButton } from '../progressBoard/CollapseButton';
+import { ExpandButton } from '../progressBoard/ExpandButton';
+import { StageList } from '../progressBoard/StageList';
+import { ProgressBar } from '../progressBoard/ProgressBar';
+
+const MOCK_ROUND = 1;
+const MOCK_PHASE = 'ATTACK';
+const MOCK_PHASE_COUNT = 1;
+const MOCK_STARTED_AT = Date.now();
+const MOCK_EXPIRED_AT = Date.now() + 5 * 60 * 1000;
+
+export default function TutorialProgressBoard() {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div
+      data-tutorial="progress-board"
+      className={`
+        pointer-events-auto relative w-full max-w-3xl rounded-lg bg-[#1a1a2ef2]
+        border-b-[1.333px] border-b-[#1E2939]
+        shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.25)]
+        transition-all duration-300 ease-in-out animate-slideDown
+        ${collapsed ? '-translate-y-[7.5rem] h-8' : 'h-24 pb-3'}
+      `}
+    >
+      {!collapsed && <CollapseButton onClick={() => setCollapsed(true)} />}
+      {collapsed && <ExpandButton onClick={() => setCollapsed(false)} />}
+
+      <div
+        className={`
+          absolute left-[1.638rem] top-3
+          max-w-2xl
+          flex flex-col gap-1.5
+          transition-opacity duration-200
+          ${collapsed ? 'opacity-0 pointer-events-none' : 'opacity-100'}
+        `}
+      >
+        <StageList round={MOCK_ROUND} phase={MOCK_PHASE as any} phaseCount={MOCK_PHASE_COUNT} />
+        <ProgressBar expiredAt={MOCK_EXPIRED_AT} startedAt={MOCK_STARTED_AT} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
@@ -2,6 +2,7 @@ import type { TutorialStep } from '../../hooks/useTutorial';
 import { useSpotlight } from '../../hooks/useSpotlight';
 import SpotlightOverlay from './SpotlightOverlay';
 import TutorialVoteExample from './TutorialVoteExample';
+import TutorialDiscussionInput from './TutorialDiscussionInput';
 import { TUTORIAL_STEPS, TOTAL_STEPS } from './const/tutorialSteps';
 import QuestionIcon from '@/assets/icon/question.svg?react';
 
@@ -42,6 +43,15 @@ export default function TutorialStepModal({
       {currentStep === 'vote' && (
         <div data-tutorial="vote" className="absolute right-[9.688rem] top-[12.813rem] z-[99]">
           <TutorialVoteExample />
+        </div>
+      )}
+
+      {/* Mock Discussion Input - discussionInput 단계에서만 표시 */}
+      {currentStep === 'discussionInput' && (
+        <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 z-[6] px-4 pb-4">
+          <div data-tutorial="discussion-input" className="discussion-input-width">
+            <TutorialDiscussionInput />
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
@@ -1,11 +1,18 @@
 import type { TutorialStep } from '../../hooks/useTutorial';
 import { useSpotlight } from '../../hooks/useSpotlight';
+import type { SpotlightPosition } from '../../hooks/useSpotlight';
 import SpotlightOverlay from './SpotlightOverlay';
 import TutorialVoteExample from './TutorialVoteExample';
 import TutorialDiscussionInput from './TutorialDiscussionInput';
 import TutorialProgressBoard from './TutorialProgressBoard';
 import { TUTORIAL_STEPS, TOTAL_STEPS } from './const/tutorialSteps';
 import QuestionIcon from '@/assets/icon/question.svg?react';
+
+const MODAL_WIDTH = 448;
+const MODAL_GAP = 32;
+const MODAL_MIN_TOP = 80;
+const MODAL_ESTIMATED_HEIGHT = 400;
+const DISCUSSION_INPUT_MODAL_BOTTOM = '10rem';
 
 interface TutorialStepModalProps {
   isOpen: boolean;
@@ -15,6 +22,62 @@ interface TutorialStepModalProps {
   onSkip: () => void;
   onClose: () => void;
 }
+
+const getModalPosition = (spotlight: SpotlightPosition | null) => {
+  if (!spotlight) {
+    return { bottom: '5rem', left: '50%', transform: 'translateX(-50%)' };
+  }
+
+  const { top, left, width, height } = spotlight;
+  const rightSpace = window.innerWidth - (left + width);
+  const leftSpace = left;
+  const bottomSpace = window.innerHeight - (top + height);
+  const topSpace = top;
+
+  // 오른쪽에 충분한 공간이 있는 경우
+  if (rightSpace >= MODAL_WIDTH + MODAL_GAP * 2) {
+    return {
+      top: `${Math.max(MODAL_MIN_TOP, top)}px`,
+      left: `${left + width + MODAL_GAP}px`
+    };
+  }
+
+  // 왼쪽에 충분한 공간이 있는 경우
+  if (leftSpace >= MODAL_WIDTH + MODAL_GAP * 2) {
+    return {
+      top: `${Math.max(MODAL_MIN_TOP, top)}px`,
+      left: `${left - MODAL_WIDTH - MODAL_GAP}px`
+    };
+  }
+
+  // 하단에 충분한 공간이 있는 경우
+  if (bottomSpace >= MODAL_ESTIMATED_HEIGHT + MODAL_GAP * 2) {
+    return {
+      top: `${top + height + MODAL_GAP}px`,
+      left: '50%',
+      transform: 'translateX(-50%)'
+    };
+  }
+
+  // 상단에 충분한 공간이 있는 경우
+  if (topSpace >= MODAL_ESTIMATED_HEIGHT + MODAL_GAP) {
+    return {
+      bottom: `${window.innerHeight - top + MODAL_GAP}px`,
+      left: '50%',
+      transform: 'translateX(-50%)'
+    };
+  }
+
+  // 기본: 중앙 하단
+  return { bottom: '5rem', left: '50%', transform: 'translateX(-50%)' };
+};
+
+const getModalStyle = (currentStep: TutorialStep, spotlight: SpotlightPosition | null) => {
+  if (currentStep === 'discussionInput') {
+    return { bottom: DISCUSSION_INPUT_MODAL_BOTTOM, left: '50%', transform: 'translateX(-50%)' };
+  }
+  return getModalPosition(spotlight);
+};
 
 export default function TutorialStepModal({
   isOpen,
@@ -30,7 +93,6 @@ export default function TutorialStepModal({
     enabled: isOpen && currentStep !== 'welcome' && currentStep !== 'completed'
   });
 
-  // sidebarPanel 단계에서는 sidebar 전체 영역을 spotlight로
   const spotlight =
     currentStep === 'sidebarPanel' && defaultSpotlight
       ? { ...defaultSpotlight, top: 0, height: window.innerHeight }
@@ -42,25 +104,20 @@ export default function TutorialStepModal({
   const { title, description, stepNumber } = stepContent;
   const isLastStep = stepNumber === TOTAL_STEPS;
 
-  return (
-    <div className="fixed inset-0 z-[100]">
-      <SpotlightOverlay spotlight={spotlight} onBackdropClick={onSkip} />
-
-      {/* Mock Progress Board - progressBoard 단계에서만 표시 */}
+  const renderMockComponents = () => (
+    <>
       {currentStep === 'progressBoard' && (
         <div className="fixed top-0 left-0 right-0 z-[99] flex justify-center pointer-events-none">
           <TutorialProgressBoard />
         </div>
       )}
 
-      {/* Mock Vote UI - vote 단계에서만 표시 */}
       {currentStep === 'vote' && (
         <div data-tutorial="vote" className="absolute right-[9.688rem] top-[12.813rem] z-[99]">
           <TutorialVoteExample />
         </div>
       )}
 
-      {/* Mock Discussion Input - discussionInput 단계에서만 표시 */}
       {currentStep === 'discussionInput' && (
         <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 z-[6] px-4 pb-4">
           <div data-tutorial="discussion-input" className="discussion-input-width">
@@ -68,14 +125,18 @@ export default function TutorialStepModal({
           </div>
         </div>
       )}
+    </>
+  );
+
+  return (
+    <div className="fixed inset-0 z-[100]">
+      <SpotlightOverlay spotlight={spotlight} onBackdropClick={onSkip} />
+
+      {renderMockComponents()}
 
       <div
         className="absolute pointer-events-auto transition-all duration-300"
-        style={
-          spotlight && spotlight.top > 400
-            ? { top: '5rem', left: '50%', transform: 'translateX(-50%)' }
-            : { bottom: '5rem', left: '50%', transform: 'translateX(-50%)' }
-        }
+        style={getModalStyle(currentStep, spotlight)}
       >
         <div className="relative max-w-md rounded-2xl bg-[#1E2432] border-2 border-[#FF6900] shadow-2xl p-6">
           <button

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
@@ -3,6 +3,7 @@ import { useSpotlight } from '../../hooks/useSpotlight';
 import SpotlightOverlay from './SpotlightOverlay';
 import TutorialVoteExample from './TutorialVoteExample';
 import TutorialDiscussionInput from './TutorialDiscussionInput';
+import TutorialProgressBoard from './TutorialProgressBoard';
 import { TUTORIAL_STEPS, TOTAL_STEPS } from './const/tutorialSteps';
 import QuestionIcon from '@/assets/icon/question.svg?react';
 
@@ -38,6 +39,13 @@ export default function TutorialStepModal({
   return (
     <div className="fixed inset-0 z-[100]">
       <SpotlightOverlay spotlight={spotlight} onBackdropClick={onSkip} />
+
+      {/* Mock Progress Board - progressBoard 단계에서만 표시 */}
+      {currentStep === 'progressBoard' && (
+        <div className="fixed top-0 left-0 right-0 z-[99] flex justify-center pointer-events-none">
+          <TutorialProgressBoard />
+        </div>
+      )}
 
       {/* Mock Vote UI - vote 단계에서만 표시 */}
       {currentStep === 'vote' && (

--- a/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
+++ b/frontend/src/pages/battlePage/components/tutorial/TutorialStepModal.tsx
@@ -25,10 +25,16 @@ export default function TutorialStepModal({
   onClose
 }: TutorialStepModalProps) {
   const stepContent = TUTORIAL_STEPS[currentStep];
-  const spotlight = useSpotlight({
+  const defaultSpotlight = useSpotlight({
     selector: stepContent?.highlightElement,
     enabled: isOpen && currentStep !== 'welcome' && currentStep !== 'completed'
   });
+
+  // sidebarPanel 단계에서는 sidebar 전체 영역을 spotlight로
+  const spotlight =
+    currentStep === 'sidebarPanel' && defaultSpotlight
+      ? { ...defaultSpotlight, top: 0, height: window.innerHeight }
+      : defaultSpotlight;
 
   if (!isOpen || currentStep === 'welcome' || currentStep === 'completed') return null;
   if (!stepContent) return null;

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -167,7 +167,7 @@ export default function BattlePage() {
 
         {/* DiscussionInput - 화면 중앙 하단에 fixed */}
         <div
-          className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 z-[9999] px-4 pb-4 transition-all duration-500 ease-out ${
+          className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 z-[5] px-4 pb-4 transition-all duration-500 ease-out ${
             shouldShowInput ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0 pointer-events-none'
           }`}
         >

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -6,12 +6,7 @@ import { useTeamVoteResult } from './hooks/useTeamVoteResult';
 import { useTutorial } from './hooks/useTutorial';
 import useModal from '@/commons/hooks/useModal';
 import { soundManager } from '@/commons/utils/soundManager';
-import {
-  useBattleStore,
-  selectBattleProgress,
-  selectSelectedTeam,
-  selectProgressBoardCollapsed
-} from './stores/battleStore';
+import { useBattleStore, selectBattleProgress, selectSelectedTeam } from './stores/battleStore';
 import { isInputDisabled } from './utils/battlePhase';
 
 import BattleHeader from './components/header';
@@ -39,7 +34,6 @@ export default function BattlePage() {
   const sidebarOpenedForTutorial = useRef(false);
   const user = useAuthStore(selectUser);
   const leaveBattle = useBattleStore((s) => s.leaveBattle);
-  const progressBoardCollapsed = useBattleStore(selectProgressBoardCollapsed);
   const battleProgress = useBattleStore(selectBattleProgress);
 
   useEffect(() => {
@@ -65,12 +59,6 @@ export default function BattlePage() {
   // 사운드 초기화
   useEffect(() => {
     soundManager.preload('timerWarning', '/sounds/timerSound.wav');
-    soundManager.preload('notificationPing', '/sounds/notificationPing.mp3');
-    soundManager.preload('swoosh', '/sounds/swoosh.mp3');
-    soundManager.preload('swordSlash', '/sounds/swordSlash.mp3');
-    soundManager.preload('fanfare', '/sounds/fanfare.mp3');
-    soundManager.preload('click', '/sounds/click.mp3');
-    soundManager.preload('click2', '/sounds/click2.mp3');
   }, []);
 
   useEffect(() => {
@@ -144,10 +132,7 @@ export default function BattlePage() {
             battleProgress &&
             (battleProgress.phase as string) !== 'PENDING' &&
             battleProgress.expiredAt != null &&
-            battleProgress.startedAt &&
-            !progressBoardCollapsed
-              ? 'mt-24'
-              : 'mt-6'
+            battleProgress.startedAt
           }`}
         >
           <div className="flex items-center justify-between mt-10 mb-8">

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -34,7 +34,6 @@ interface BattleStore {
   chatInitialized: boolean;
   opponentNotice: BattleChat | null;
   opponentNoticePending: BattleChat | null;
-  progressBoardCollapsed: boolean;
 
   initializeBattle: (config: { userId: string; battleId: string }) => void;
   setSocket: (socket: Socket | null) => void;
@@ -57,7 +56,6 @@ interface BattleStore {
   setOpponentNoticePending: (notice: BattleChat | null) => void;
   commitOpponentNotice: () => void;
   leaveBattle: () => void;
-  setProgressBoardCollapsed: (collapsed: boolean) => void;
 }
 
 export const useBattleStore = create<BattleStore>((set, get) => ({
@@ -77,7 +75,6 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
   chatInitialized: false,
   opponentNotice: null,
   opponentNoticePending: null,
-  progressBoardCollapsed: false,
 
   initializeBattle: (config) => set({ userId: config.userId, battleId: config.battleId, chatInitialized: false }),
   setSocket: (socket) => set({ socket }),
@@ -185,8 +182,7 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
       opponentNotice: null,
       opponentNoticePending: null
     });
-  },
-  setProgressBoardCollapsed: (collapsed) => set({ progressBoardCollapsed: collapsed })
+  }
 }));
 
 export const selectUserId = (state: BattleStore) => state.userId;
@@ -203,4 +199,3 @@ export const selectAllChats = (state: BattleStore) => state.allChats;
 export const selectSelectedTeam = (state: BattleStore) => state.selectedTeam;
 export const selectChatInitialized = (state: BattleStore) => state.chatInitialized;
 export const selectOpponentNotice = (state: BattleStore) => state.opponentNotice;
-export const selectProgressBoardCollapsed = (state: BattleStore) => state.progressBoardCollapsed;


### PR DESCRIPTION
## 🔗 관련 이슈
Close #232

## ✅ 작업 내용

### 💡개선 사항

#### 1. 튜토리얼 모달이 이의제기 입력창에 가려지는 문제 해결
- 이의제기 입력창의 z-index를 하향 조정하여 튜토리얼 가이드가 항상 최상단에 표시되도록 수정 했습니다.

#### 2. 튜토리얼 단계별 UI 요소 표시 개선 (Mock 컴포넌트 띄우기)
- 게임 진행 상태에 따라 표시 되지  않는 UI들이 있는데, 이 컴포넌트들을 소개하기 위해  해당 소개 차례 때 Mock 컴포넌트를 임시적으로 띄우는 방식을 적용 해봤습니다. (기존 투표 소개할 때 처럼)
  - **이의제기 입력창 가이드**: 게임 진행 상태와 무관하게 튜토리얼 전용 입력창을 표시하여 사용법 설명
  - **사이드바 가이드**: 사이드바 설명 시 오버레이에 가려지지 않고 전체가 명확하게 보이도록 개선

#### 3. 튜토리얼 모달 위치 자동 조정
- 설명하는 UI 요소 근처에 가이드 모달이 자동으로 배치하는 로직을 적용했습니다. 기존에는 하이라이트 하며 소개하는 요소와 거리가 좀 있다고 생각이 들어서 이번에 함께 구현했습니다. 

#### 4. 배틀 현황판 상태 관리 개선
- 현황판 접기/펼치기 동작이 다른 게임 상태에 영향을 주지 않도록 독립적으로 관리 하도록 했습니다. (굳이 해당 상태는 해당 컴포넌트 내에서만 사용되기에 store를 쓸 필요가 없더라구요)

#### 5. 사이드바 소개 할 때 제대로 포커싱 하지 못하는 버그 수정 
- 사이드바 소개 할 때 제대로 포커싱 하지 못하는 버그 수정 했습니다. 

<br />

## 📸 구현 내용
### 대기 라운드에서 가짜 이의제기 input을 띄워 하이라이트 하는 부분
<img width="1186" height="836" alt="image" src="https://github.com/user-attachments/assets/7983fd44-abe9-40b5-9a64-52f1cd878f42" />

### 대기 라운드에서 가짜 상황 진행판을 띄워 하이라이트 하는 부분
<img width="1307" height="546" alt="image" src="https://github.com/user-attachments/assets/fefd989a-d66c-4986-a169-a557351d0ef5" />

<br />

## 💬 질문사항 (고민했던 부분)

1. **이의제기 입력창 설명 시 모달 위치**
   - 입력창과 겹치지 않도록 상단에 고정 배치했는데, 반응형 대응 필요 여부 검토 부탁드립니다

2. **튜토리얼 컴포넌트 구조**
   - 각 단계별로 독립적인 Mock 컴포넌트를 만들었는데 이러면 유지보수 관점에서 참 안좋을거 같은데... 기존 컴포넌트에 튜토리얼 전용 prop과 로직을 넣고 싶진 않고... 참... 