### PR TITLE
[HotFix] : SoundManager에 누락된 사운드 Preload 하는 로직 복구

### DIFF
--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -59,6 +59,12 @@ export default function BattlePage() {
   // 사운드 초기화
   useEffect(() => {
     soundManager.preload('timerWarning', '/sounds/timerSound.wav');
+    soundManager.preload('notificationPing', '/sounds/notificationPing.mp3');
+    soundManager.preload('swoosh', '/sounds/swoosh.mp3');
+    soundManager.preload('swordSlash', '/sounds/swordSlash.mp3');
+    soundManager.preload('fanfare', '/sounds/fanfare.mp3');
+    soundManager.preload('click', '/sounds/click.mp3');
+    soundManager.preload('click2', '/sounds/click2.mp3');
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## 🔗 관련 이슈
#204 

## ✅ 작업 내용

### 💡개선 사항
####  SoundManager에 누락된 사운드 Preload 하는 로직 복구
```typescript
    soundManager.preload('notificationPing', '/sounds/notificationPing.mp3');
    soundManager.preload('swoosh', '/sounds/swoosh.mp3');
    soundManager.preload('swordSlash', '/sounds/swordSlash.mp3');
    soundManager.preload('fanfare', '/sounds/fanfare.mp3');
    soundManager.preload('click', '/sounds/click.mp3');
    soundManager.preload('click2', '/sounds/click2.mp3');
```
해당 #204 이후 pr에서 병합 과정간에 누락 된 것으로 추정

<br />
