### PR TITLE
Hotfix: 배틀 결과 페이지 진입 에러 수정

### DIFF
--- a/backend/src/battles/const/battles.const.ts
+++ b/backend/src/battles/const/battles.const.ts
@@ -67,3 +67,5 @@ export const BATTLE_CHAT_SCOPE = {
   ALL: 'ALL',
   TEAM: 'TEAM',
 } as const
+
+export const MVP_DISPLAY_COUNT = 3

--- a/backend/src/battles/const/battles.const.ts
+++ b/backend/src/battles/const/battles.const.ts
@@ -67,5 +67,3 @@ export const BATTLE_CHAT_SCOPE = {
   ALL: 'ALL',
   TEAM: 'TEAM',
 } as const
-
-export const MVP_DISPLAY_COUNT = 3

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -1,4 +1,4 @@
-import { Logger, OnModuleInit, UnauthorizedException } from '@nestjs/common'
+import { Logger, OnModuleInit, UnauthorizedException, NotFoundException } from '@nestjs/common'
 import { Server } from 'socket.io'
 import type { SocketWithUserId } from '../types/socket.types'
 import {
@@ -80,10 +80,17 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     const userId = client.data.userId
     const battleId = client.data.battleId
     if (userId && battleId) {
-      const result = this.battlesService.leaveBattle(userId, battleId)
-      const battleRoomId = this.battlesService.getBattleRoomId(battleId)
-      this.server.to(battleRoomId).emit('battle:leaved', result)
-      client.data.battleId = undefined
+      try {
+        const result = this.battlesService.leaveBattle(userId, battleId)
+        const battleRoomId = this.battlesService.getBattleRoomId(battleId)
+        this.server.to(battleRoomId).emit('battle:leaved', result)
+      } catch (error) {
+        if (!(error instanceof NotFoundException)) {
+          this.logger.error(`[소켓 연결 해제 처리 실패] userId: ${userId}, battleId: ${battleId}`, error as Error)
+        }
+      } finally {
+        client.data.battleId = undefined
+      }
     }
     if (userId) {
       this.userIdToSocketMap.delete(userId)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -69,7 +69,7 @@ const router = createBrowserRouter([
     errorElement: <ErrorPage />
   },
   {
-    path: '/battle/:id/result',
+    path: '/battles/:id/result',
     element: <BattleResultPage />,
     errorElement: <ErrorPage />
   }

--- a/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
@@ -47,7 +47,7 @@ export function useBattleProgress() {
 
     // 배틀 종료 이벤트 구독
     const handleBattleClosed = (data: { battleId: string }) => {
-      navigate(`/battle/${data.battleId}/result`);
+      navigate(`/battles/${data.battleId}/result`);
     };
     socket.on('battle:closed', handleBattleClosed);
 


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

배틀 종료 후 disconnect에서 leveBattle 시 404 발생하는 문제가 발생하여 NotFoundException은 무시하도록 처리했습니다.
결과 페이지 라우트 : /battle/:id/result 와 /battles/:id/result로 섞여있어서 /battles/:id/result로 일치

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
