### PR TITLE
[Devops] 버전 태그 및 릴리즈 관리 체계 구축

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -2,9 +2,14 @@ name: deploy-prod
 
 on:
   push:
-    branches:
-      - release
+    tags:
+      - "v*"
   workflow_dispatch:
+    inputs:
+      version_tag:
+        description: "시멘틱 버전 태그를 입력하세요. 비워두면 최신 시멘틱 버전 태그를 사용합니다."
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -18,8 +23,39 @@ env:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    outputs:
+      version_tag: ${{ steps.set_version.outputs.version_tag }}
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set version tag
+        id: set_version
+        run: |
+          # tag push면 그 태그가 곧 버전
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "version_tag=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+            echo "Deploying tag from push event: ${GITHUB_REF_NAME}"
+            exit 0
+          fi
+
+          # workflow_dispatch면 입력 우선, 없으면 최신 semver tag
+          input_tag="${{ github.event.inputs.version_tag }}"
+          if [ -n "$input_tag" ]; then
+            echo "version_tag=$input_tag" >> $GITHUB_OUTPUT
+            echo "Deploying input tag: $input_tag"
+            exit 0
+          fi
+
+          latest_tag=$(git tag --list "v*" --sort=-v:refname | head -n 1)
+          if [ -z "$latest_tag" ]; then
+            latest_tag="latest"
+          fi
+          echo "version_tag=$latest_tag" >> $GITHUB_OUTPUT
+          echo "Deploying latest tag: $latest_tag"
 
       - name: Set lowercase image names
         id: image_names
@@ -43,7 +79,7 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ steps.image_names.outputs.backend_image }}:latest
-            ${{ env.REGISTRY }}/${{ steps.image_names.outputs.backend_image }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ steps.image_names.outputs.backend_image }}:${{ steps.set_version.outputs.version_tag }}
 
       - name: Build and push frontend
         uses: docker/build-push-action@v6
@@ -55,7 +91,7 @@ jobs:
             VITE_API_URL=${{ secrets.VITE_API_URL }}
           tags: |
             ${{ env.REGISTRY }}/${{ steps.image_names.outputs.frontend_image }}:latest
-            ${{ env.REGISTRY }}/${{ steps.image_names.outputs.frontend_image }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ steps.image_names.outputs.frontend_image }}:${{ steps.set_version.outputs.version_tag }}
 
   cd:
     needs: ci
@@ -80,12 +116,18 @@ jobs:
           password: ${{ secrets.NCP_PASSWORD_PROD }}
           script: |
             set -e
+
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
             cd "${{ secrets.NCP_DEPLOY_PATH }}"
 
+            VERSION_TAG="${{ needs.ci.outputs.version_tag }}"
+            export VERSION_TAG
+
+            echo "Deploying version: ${VERSION_TAG}"
+
             # === 기존 컨테이너 종료 ===
             docker compose -f docker-compose.yml down || true
-
+            
             # === 이미지 pull ===
             docker compose -f docker-compose.yml pull
 

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -126,3 +126,25 @@ jobs:
 
           git tag "$tag"
           git push origin "$tag"
+
+      # === GitHub Release 생성 ===
+      - name: Create GitHub Release
+        if: steps.pr_labels.outputs.should_skip != 'true'
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.semver.outputs.version_tag }}
+          release_name: Release ${{ steps.semver.outputs.version_tag }}
+          body: |
+            ## Release ${{ steps.semver.outputs.version_tag }}
+            
+            ### Changes
+            - Merged PR: #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}
+            
+            ### Version Bump
+            - Type: ${{ steps.pr_labels.outputs.bump_type }}
+            - Previous version: ${{ steps.get_latest_tag.outputs.latest_tag }}
+            - New version: ${{ steps.semver.outputs.version_tag }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -42,10 +42,9 @@ jobs:
             exit 0
           fi
 
-        
-          if echo "$labels" | grep -q "release:major"; then
+          if echo "$labels" | grep -q "major"; then
             bump_type=major
-          elif echo "$labels" | grep -q "release:minor"; then
+          elif echo "$labels" | grep -q "minor"; then
             bump_type=minor
           else
             bump_type=patch

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -1,0 +1,129 @@
+name: Version Tag
+
+on:
+  pull_request:
+    types: [closed]  # PR이 닫힐 때
+    branches:
+      - release 
+
+permissions:
+  contents: write
+
+jobs:
+  version-tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.semver.outputs.new_version }}
+      version_tag: ${{ steps.semver.outputs.version_tag }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 
+
+      # === jq 설치 (JSON 파싱 도구) ===
+      - name: Install jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      # === PR 라벨 확인 및 버전 증가 타입 결정 ===
+      - name: Get PR labels
+        id: pr_labels
+        run: |
+          labels=$(echo '${{ toJSON(github.event.pull_request.labels) }}' | jq -r '.[].name' | grep -E '^(major|minor|patch)$' || true)
+
+          # 라벨이 없으면 버전 태깅 스킵
+          if [ -z "$labels" ]; then
+            echo "No release label found. Skipping version tagging."
+            echo "should_skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+        
+          if echo "$labels" | grep -q "release:major"; then
+            bump_type=major
+          elif echo "$labels" | grep -q "release:minor"; then
+            bump_type=minor
+          else
+            bump_type=patch
+          fi
+
+          echo "bump_type=${bump_type}" >> $GITHUB_OUTPUT
+          echo "Found bump type: ${bump_type}"
+
+      # === 최신 시멘틱 버전 태그 조회 ===
+      - name: Get latest tag (semver)
+        id: get_latest_tag
+        if: steps.pr_labels.outputs.should_skip != 'true'
+        run: |
+          # v로 시작하는 태그 중 시멘틱 버전 순으로 정렬하여 최신 태그 조회
+          latest_tag=$(git tag --list "v*" --sort=-v:refname | head -n 1)
+          
+          # 태그가 없으면 v0.0.0부터 시작
+          if [ -z "$latest_tag" ]; then
+            latest_tag="v0.0.0"
+          fi
+          
+          echo "latest_tag=${latest_tag}" >> $GITHUB_OUTPUT
+          echo "Latest tag: ${latest_tag}"
+
+      # === 새 버전 계산 ===
+      - name: Determine version bump
+        id: semver
+        if: steps.pr_labels.outputs.should_skip != 'true'
+        run: |
+          bump_type="${{ steps.pr_labels.outputs.bump_type }}"
+          latest_tag="${{ steps.get_latest_tag.outputs.latest_tag }}"
+
+          current_version=${latest_tag#v}
+       
+          IFS='.' read -r major minor patch <<< "$current_version"
+
+          if [ -z "$major" ] || [ -z "$minor" ] || [ -z "$patch" ]; then
+            major=0; minor=0; patch=0
+          fi
+
+          # 버전 증가 타입에 따라 새 버전 계산
+          case "$bump_type" in
+            major)
+              # major 증가: 1.0.0 → 2.0.0
+              new_version="$((major + 1)).0.0"
+              ;;
+            minor)
+              # minor 증가: 1.0.0 → 1.1.0
+              new_version="${major}.$((minor + 1)).0"
+              ;;
+            patch)
+              # patch 증가: 1.0.0 → 1.0.1
+              new_version="${major}.${minor}.$((patch + 1))"
+              ;;
+            *)
+              echo "Unknown bump type: ${bump_type}"
+              exit 1
+              ;;
+          esac
+
+          version_tag="v${new_version}"
+          echo "new_version=${new_version}" >> $GITHUB_OUTPUT
+          echo "version_tag=${version_tag}" >> $GITHUB_OUTPUT
+          echo "New version will be: ${version_tag}"
+
+      # === Git 태그 생성 및 푸시 ===
+      - name: Create Git tag
+        if: steps.pr_labels.outputs.should_skip != 'true'
+        run: |
+          tag="${{ steps.semver.outputs.version_tag }}"
+
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists. Skipping."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git tag "$tag"
+          git push origin "$tag"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   migrate:
-    image: ghcr.io/boostcampwm2025/web02-cmc-backend-prod:latest
+    image: ghcr.io/boostcampwm2025/web02-cmc-backend-prod:${VERSION_TAG:-latest}
     profiles:
       - tools
     working_dir: /app/backend
@@ -11,7 +11,7 @@ services:
       - ./.env
 
   backend:
-    image: ghcr.io/boostcampwm2025/web02-cmc-backend-prod:latest
+    image: ghcr.io/boostcampwm2025/web02-cmc-backend-prod:${VERSION_TAG:-latest}
     environment:
       PORT: 3000
     env_file:
@@ -57,7 +57,7 @@ services:
     restart: unless-stopped
 
   frontend:
-    image: ghcr.io/boostcampwm2025/web02-cmc-frontend-prod:latest
+    image: ghcr.io/boostcampwm2025/web02-cmc-frontend-prod:${VERSION_TAG:-latest}
     ports:
       - "80:80"
     depends_on:


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

resolve #225 

## ✅ 작업 내용

### 💡개선 사항
- 자동 버전 태깅 시스템 구현
  - `release` 브랜치 PR merge 시 라벨(major/minor/patch)에 따라 자동 버전 증가
  - GitHub Release 자동 생성
  - 새 버전 Git tag 생성
- Prod 배포에 시멘틱 버전 태깅 적용
  - 태그 푸시 또는 workflow_dispatch로 버전 지정 배포 가능
- Dev 배포는 latest 태그 유지 (기존 동작 유지)

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->
팀 위키에 진행 과정 작성해놓았습니다.!
> [Docker 이미지 태깅](https://lovely-sunstone-c80.notion.site/Docker-2f0d7ffb4ba480a8a4e3d1d7c07e8922?source=copy_link)
> <img width="2048" height="549" alt="image" src="https://github.com/user-attachments/assets/e6d14eee-a808-499d-b119-59898ccf4d59" />

- release에 배포할 때 major/minor/patch 중 하나 이상의 라벨을 필수로 붙여야합니다!!
- 서버의 docker-compose.yml 파일도 수정해놨습니다

| 오토 태깅 | 깃 태그/release 파일 |
|--|--|
|  <img width="882" height="542" alt="image" src="https://github.com/user-attachments/assets/558a5b11-3695-4c92-ae6b-e7ce11ff0ff8" /> |  <img width="1442" height="823" alt="image" src="https://github.com/user-attachments/assets/954eec05-4fec-4519-b94f-9c5872cfd4c2" />  |
<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
대니 브랜치에서 분기해서 작업했고, 추후 rebase 하겠습니당