### PR TITLE
[Fix] 타임라인 버튼을 누르면 문제 설명 사이드바가 열리는 버그를 수정한다.

### DIFF
--- a/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
@@ -2,7 +2,7 @@ import ClockIcon from '@/assets/icon/clock.svg?react';
 import MessageIcon from '@/assets/icon/message.svg?react';
 
 interface BookmarkButtonProps {
-  onOpen: () => void;
+  onOpen: (tab: 'info' | 'timeline') => void;
   isOpen: boolean;
   highlight?: boolean;
 }
@@ -17,7 +17,7 @@ export default function BookmarkButton({ onOpen, isOpen, highlight = false }: Bo
     >
       {/* 문제 설명 */}
       <button
-        onClick={onOpen}
+        onClick={() => onOpen('info')}
         className="group relative bg-linear-to-r from-[#FF6900] to-[#FF8533] px-3 py-2 rounded-r-md shadow-md hover:shadow-lg transition-all duration-200 hover:translate-x-1 flex items-center gap-1"
         aria-label="문제 설명 보기"
       >
@@ -27,7 +27,7 @@ export default function BookmarkButton({ onOpen, isOpen, highlight = false }: Bo
 
       {/* 타임라인 */}
       <button
-        onClick={onOpen}
+        onClick={() => onOpen('timeline')}
         className="group relative bg-linear-to-r from-[#AD46FF] to-[#6BA3FF] px-3 py-2 rounded-r-md shadow-md hover:shadow-lg transition-all duration-200 hover:translate-x-1 flex items-center gap-1"
         aria-label="타임라인 보기"
       >

--- a/frontend/src/pages/battlePage/components/sidebar/index.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/index.tsx
@@ -13,6 +13,8 @@ interface BattleSidebarProps {
   category: string;
   topics: string[];
   raiseZIndex?: boolean;
+  activeTab: Tab;
+  onActiveTabChange: (tab: Tab) => void;
 }
 
 type Tab = 'info' | 'timeline';
@@ -25,9 +27,10 @@ export default function BattleSidebar({
   language,
   category,
   topics,
-  raiseZIndex = false
+  raiseZIndex = false,
+  activeTab = 'info',
+  onActiveTabChange
 }: BattleSidebarProps) {
-  const [activeTab, setActiveTab] = useState<Tab>('info');
   const { width, isResizing, setIsResizing } = useResize({
     initialWidth: 400
   });
@@ -56,7 +59,7 @@ export default function BattleSidebar({
         raiseZIndex ? 'z-[101]' : 'z-100'
       } ${isOpen ? 'translate-x-0' : '-translate-x-full'} ${isResizing ? 'select-none' : ''}`}
     >
-      <SidebarHeader activeTab={activeTab} onTabChange={setActiveTab} onClose={onClose} />
+      <SidebarHeader activeTab={activeTab} onTabChange={onActiveTabChange} onClose={onClose} />
       <div className="flex justify-between">
         <div className="flex-1 h-[calc(100vh-65px)] overflow-y-auto overflow-x-hidden">
           {activeTab === 'info' ? (

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -25,12 +25,15 @@ import TeamVoteResultModal from './components/effects/TeamVoteResultModal';
 import RoundUpdateModal from './components/effects/RoundUpdateModal';
 import { selectUser, useAuthStore } from '@/commons/stores/authStore';
 
+type Tab = 'info' | 'timeline';
+
 export default function BattlePage() {
   const { id: battleId } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const battleInfo = useLoaderData<BattleInfo>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
+  const [activeSidebarTab, setActiveSidebarTab] = useState<Tab>('info');
   const sidebarOpenedForTutorial = useRef(false);
   const user = useAuthStore(selectUser);
   const leaveBattle = useBattleStore((s) => s.leaveBattle);
@@ -139,7 +142,10 @@ export default function BattlePage() {
     <div className="text-white relative">
       {/* 책갈피 버튼 */}
       <BookmarkButton
-        onOpen={handleOpenSidebar}
+        onOpen={(tab) => {
+          setActiveSidebarTab(tab);
+          handleOpenSidebar();
+        }}
         isOpen={isSidebarOpen}
         highlight={isTutorialOpen && currentStep === 'sidebar'}
       />
@@ -154,6 +160,8 @@ export default function BattlePage() {
         category={battleInfo.category}
         topics={battleInfo.topics}
         raiseZIndex={isTutorialOpen && currentStep === 'sidebarPanel'}
+        activeTab={activeSidebarTab}
+        onActiveTabChange={setActiveSidebarTab}
       />
 
       {/* 메인 콘텐츠 */}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -100,6 +100,7 @@ export default function BattlePage() {
     const shouldOpenSidebar = isTutorialOpen && currentStep === 'sidebarPanel';
 
     if (shouldOpenSidebar && !isSidebarOpen) {
+      setActiveSidebarTab('info');
       handleOpenSidebar();
       sidebarOpenedForTutorial.current = true;
       return;


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #265

## ✅ 작업 내용

###  사이드바 북마크 버튼(문제 설명/타임라인)을 클릭해도 항상 기본 탭('문제 설명')만 열리는 버그 수정
버그 원인으로는 사이드바 컴포넌트와 북마크 버튼이 각각 독립적인 상태를 관리하여 동기화되지 않는 문제로 모(`BattlePage`)에서 탭 상태를 관리하는 제어 컴포넌트 패턴으로 리팩토링하여 수정 했습니다. 

<br />

### 기존 문제 상황 

https://github.com/user-attachments/assets/67288ec6-5012-4869-88a3-4698205165e8

<br/>

### 버그 수 완료 영상


## 📸 참고 사항

###  주요 변경 파일
1. **`BookmarkButton.tsx`**
   - `onOpen` 콜백 시그니처 변경: `() => void` → `(tab: 'info' | 'timeline') => void`

2. **`BattleSidebar/index.tsx`**
   - 내부 `activeTab` state 제거 → prop으로 변경
   - `onActiveTabChange` 콜백 추가
   - Uncontrolled → **Controlled Component**로 전환

3. **`BattlePage/index.tsx`**
   - `activeSidebarTab` state 추가 
   - 북마크 버튼 클릭 핸들러: 탭 설정 후 사이드바 열기
   - 튜토리얼 useEffect: `setActiveSidebarTab('info')` 추가


<br />
