### PR TITLE
[Fix] mvp 선정 시 마지막 팀 변경 반영 안됨

### DIFF
--- a/backend/src/battles/service/battles.service.spec.ts
+++ b/backend/src/battles/service/battles.service.spec.ts
@@ -1129,18 +1129,17 @@ describe('BattlesService', () => {
       const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
       seedBattles([battle])
 
-      const state = await getState('battle-1')
-
       // 참가자 등록 (joinedAt 시간 순서대로)
       await service.registerGuest('battle-1', { id: 'user-1', nickname: 'User1', createdAt: 1000 })
       await service.registerGuest('battle-1', { id: 'user-2', nickname: 'User2', createdAt: 2000 })
       await service.registerGuest('battle-1', { id: 'user-3', nickname: 'User3', createdAt: 3000 })
 
-      state.participants.set('user-1', BATTLE_TEAM.A)
-      state.participants.set('user-2', BATTLE_TEAM.B)
-      state.participants.set('user-3', BATTLE_TEAM.A)
-
-      service['rebuildTeamUsers'](state)
+      await updateState('battle-1', state => {
+        state.participants.set('user-1', BATTLE_TEAM.A)
+        state.participants.set('user-2', BATTLE_TEAM.B)
+        state.participants.set('user-3', BATTLE_TEAM.A)
+        service['rebuildTeamUsers'](state)
+      })
     })
 
     it('case', async () => {
@@ -1492,15 +1491,14 @@ describe('BattlesService', () => {
       const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
       seedBattles([battle])
 
-      const state = await getState('battle-1')
-
       await service.registerGuest('battle-1', { id: 'user-a', nickname: 'UserA', createdAt: 1000 })
       await service.registerGuest('battle-1', { id: 'user-b', nickname: 'UserB', createdAt: 2000 })
 
-      state.participants.set('user-a', BATTLE_TEAM.A)
-      state.participants.set('user-b', BATTLE_TEAM.B)
-
-      service['rebuildTeamUsers'](state)
+      await updateState('battle-1', state => {
+        state.participants.set('user-a', BATTLE_TEAM.A)
+        state.participants.set('user-b', BATTLE_TEAM.B)
+        service['rebuildTeamUsers'](state)
+      })
     })
 
     it('case', async () => {
@@ -1621,13 +1619,14 @@ describe('BattlesService', () => {
     })
 
     it('case', async () => {
-      const state = await getState('battle-1')
-      state.phase = BATTLE_PHASE.ATTACK.name
-
       // 같은 팀, 같은 점수 비율
       await service.registerGuest('battle-1', { id: 'user-a2', nickname: 'UserA2', createdAt: 3000 })
-      state.participants.set('user-a2', BATTLE_TEAM.A)
-      service['rebuildTeamUsers'](state)
+      const state = await updateState('battle-1', state => {
+        state.participants.set('user-a2', BATTLE_TEAM.A)
+        service['rebuildTeamUsers'](state)
+      })
+
+      state.phase = BATTLE_PHASE.ATTACK.name
 
       // user-a: 50표 / 100명 = 0.5점 → 1.5배 → 0.75점, totalVotes = 50
       state.opinionHistory.push({
@@ -1762,15 +1761,14 @@ describe('BattlesService', () => {
       const battle = createBattle({ id: 'battle-1', status: BATTLE_STATUS.OPEN })
       seedBattles([battle])
 
-      const state = await getState('battle-1')
-
       await service.registerGuest('battle-1', { id: 'user-1', nickname: 'User1', createdAt: 1000 })
       await service.registerGuest('battle-1', { id: 'user-2', nickname: 'User2', createdAt: 2000 })
 
-      state.participants.set('user-1', BATTLE_TEAM.A)
-      state.participants.set('user-2', BATTLE_TEAM.B)
-
-      service['rebuildTeamUsers'](state)
+      await updateState('battle-1', state => {
+        state.participants.set('user-1', BATTLE_TEAM.A)
+        state.participants.set('user-2', BATTLE_TEAM.B)
+        service['rebuildTeamUsers'](state)
+      })
     })
 
     it('case', async () => {

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -641,8 +641,8 @@ export class BattlesService extends EventEmitter {
     })
 
     // 최종 팀 기준으로 MVP 팀 설정 (팀 변경 반영)
-    candidateMap.forEach((candidate, oderId) => {
-      const finalTeam = state.participants.get(oderId)
+    candidateMap.forEach((candidate, userId) => {
+      const finalTeam = state.participants.get(userId)
       candidate.team = finalTeam === BATTLE_TEAM.A ? 'A' : finalTeam === BATTLE_TEAM.B ? 'B' : 'NONE'
     })
 
@@ -660,9 +660,9 @@ export class BattlesService extends EventEmitter {
     return candidates.slice(0, MVP_DISPLAY_COUNT)
   }
 
-  private getParticipantJoinedAt(state: ActiveBattleState, oderId: string): number {
+  private getParticipantJoinedAt(state: ActiveBattleState, userId: string): number {
     // participants Map의 삽입 순서를 기반으로 참가 순서 반환
-    const participantOrder = [...state.participants.keys()].indexOf(oderId)
+    const participantOrder = [...state.participants.keys()].indexOf(userId)
     return participantOrder >= 0 ? participantOrder : 0
   }
 

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -237,7 +237,7 @@ export class BattlesService extends EventEmitter {
       .filter(item => item && typeof item === 'object')
       .map(item => {
         const mvp = item as Partial<Mvp>
-        const team: 'A' | 'B' = mvp.team === 'B' ? 'B' : 'A'
+        const team: 'A' | 'B' | 'NONE' = mvp.team === 'A' ? 'A' : mvp.team === 'B' ? 'B' : 'NONE'
         const parsed: Mvp = {
           userId: typeof mvp.userId === 'string' ? mvp.userId : '',
           nickname: typeof mvp.nickname === 'string' ? mvp.nickname : '',

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -603,10 +603,12 @@ export class BattlesService extends EventEmitter {
 
     allOpinions.forEach(opinion => {
       const { authorId, nickname } = opinion.author
-      const team = opinion.team
 
-      // 중립 팀 및 빈 userId(placeholder) 제외
-      if (team === BATTLE_TEAM.NONE || !authorId) return
+      // 빈 userId(placeholder) 제외
+      if (!authorId) return
+
+      // 의견 제출 시점에 중립 팀이면 점수 집계 제외 (중립은 의견 제출 불가)
+      if (opinion.team === BATTLE_TEAM.NONE) return
 
       // 페이즈별로 기록된 투표 참가자 수 사용 (없으면 0으로 처리)
       const voterCount = opinion.voterCountAtPhase ?? 0
@@ -627,7 +629,7 @@ export class BattlesService extends EventEmitter {
           createMvpCandidate({
             userId: authorId,
             nickname,
-            team: team === BATTLE_TEAM.A ? 'A' : 'B',
+            team: 'A', // 임시값, 최종 팀으로 나중에 덮어씀
             score: opinionScore,
             totalVotes: opinion.upvotes,
             opinionCount: 1,
@@ -636,6 +638,12 @@ export class BattlesService extends EventEmitter {
           }),
         )
       }
+    })
+
+    // 최종 팀 기준으로 MVP 팀 설정 (팀 변경 반영)
+    candidateMap.forEach((candidate, oderId) => {
+      const finalTeam = state.participants.get(oderId)
+      candidate.team = finalTeam === BATTLE_TEAM.A ? 'A' : finalTeam === BATTLE_TEAM.B ? 'B' : 'NONE'
     })
 
     if (candidateMap.size === 0) return []

--- a/backend/src/battles/service/utils/mvp.util.spec.ts
+++ b/backend/src/battles/service/utils/mvp.util.spec.ts
@@ -202,5 +202,14 @@ describe('MVP Utils', () => {
       const score = applyWinnerBonus(0.7, 'A', 'A')
       expect(score).toBeCloseTo(1.05)
     })
+
+    it('중립(NONE) 팀에는 보너스를 적용하지 않는다', () => {
+      const scoreWhenAWins = applyWinnerBonus(1.0, 'NONE', 'A')
+      const scoreWhenBWins = applyWinnerBonus(1.0, 'NONE', 'B')
+      const scoreWhenDraw = applyWinnerBonus(1.0, 'NONE', 'DRAW')
+      expect(scoreWhenAWins).toBe(1.0)
+      expect(scoreWhenBWins).toBe(1.0)
+      expect(scoreWhenDraw).toBe(1.0)
+    })
   })
 })

--- a/backend/src/battles/service/utils/mvp.util.ts
+++ b/backend/src/battles/service/utils/mvp.util.ts
@@ -16,10 +16,11 @@ export function calculateOpinionScore(upvotes: number, voterCount: number): numb
 /**
  * 승리 팀 보너스를 적용한 최종 점수를 계산한다
  * 승리 팀에 속한 후보자는 누적 점수에 1.5배 보너스를 받는다
- * 무승부인 경우 보너스 없음
+ * 무승부 또는 중립(NONE) 팀인 경우 보너스 없음
  */
-export function applyWinnerBonus(score: number, team: 'A' | 'B', winner: 'A' | 'B' | 'DRAW'): number {
+export function applyWinnerBonus(score: number, team: 'A' | 'B' | 'NONE', winner: 'A' | 'B' | 'DRAW'): number {
   if (winner === 'DRAW') return score
+  if (team === 'NONE') return score
   if (team === winner) {
     return score * WINNER_TEAM_BONUS_MULTIPLIER
   }

--- a/backend/src/battles/service/utils/mvp.util.ts
+++ b/backend/src/battles/service/utils/mvp.util.ts
@@ -19,12 +19,7 @@ export function calculateOpinionScore(upvotes: number, voterCount: number): numb
  * 무승부 또는 중립(NONE) 팀인 경우 보너스 없음
  */
 export function applyWinnerBonus(score: number, team: 'A' | 'B' | 'NONE', winner: 'A' | 'B' | 'DRAW'): number {
-  if (winner === 'DRAW') return score
-  if (team === 'NONE') return score
-  if (team === winner) {
-    return score * WINNER_TEAM_BONUS_MULTIPLIER
-  }
-  return score
+  return team === winner ? score * WINNER_TEAM_BONUS_MULTIPLIER : score
 }
 
 /** MVP 비교 함수 타입 */

--- a/backend/src/battles/types/battleResult.types.ts
+++ b/backend/src/battles/types/battleResult.types.ts
@@ -44,7 +44,7 @@ export interface TimelineItem {
 export interface Mvp {
   userId: string
   nickname: string
-  team: 'A' | 'B'
+  team: 'A' | 'B' | 'NONE'
   score: number
   totalVotes: number
   opinionCount: number

--- a/frontend/src/pages/battleResultPage/components/MvpCard.tsx
+++ b/frontend/src/pages/battleResultPage/components/MvpCard.tsx
@@ -51,10 +51,12 @@ export default function MvpCard({ mvpList, bestOpinion }: MvpCardProps) {
                 className={`px-2 py-0.5 rounded-full text-xs font-bold ${
                   mvp.team === 'A'
                     ? 'bg-blue-500/30 text-blue-200 border border-blue-400/50'
-                    : 'bg-red-500/30 text-red-200 border border-red-400/50'
+                    : mvp.team === 'B'
+                      ? 'bg-red-500/30 text-red-200 border border-red-400/50'
+                      : 'bg-gray-500/30 text-gray-200 border border-gray-400/50'
                 }`}
               >
-                {mvp.team === 'A' ? '코드 A' : '코드 B'}팀
+                {mvp.team === 'A' ? '코드 A' : mvp.team === 'B' ? '코드 B' : '중립'}팀
               </div>
             </div>
 

--- a/frontend/src/pages/battleResultPage/types/index.ts
+++ b/frontend/src/pages/battleResultPage/types/index.ts
@@ -47,7 +47,7 @@ export interface TimelineItem {
 export interface Mvp {
   userId: string;
   nickname: string;
-  team: Exclude<Team, 'NONE'>;
+  team: Team;
   score: number;
   totalVotes: number;
   opinionCount: number;


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #262

## ✅ 작업 내용

### 💡개선 사항
- MVP 선정 시 의견 제출 시점 팀이 아닌 **최종 선택 팀** 기준으로 표기되도록 수정
- 최종 팀이 중립(NONE)인 경우에도 MVP 후보에 포함되며, 팀이 NONE으로 표시됨
- 1.5배 승리 팀 보너스가 **최종 팀 기준**으로 적용됨 (중립은 보너스 미적용)

<br />

## 📸 참고 사항
- 변경 파일:
  - `backend/src/battles/types/battleResult.types.ts` - Mvp 타입에 `'NONE'` 추가
  - `backend/src/battles/service/utils/mvp.util.ts` - NONE 팀 보너스 미적용 처리
  - `backend/src/battles/service/battles.service.ts` - `state.participants`에서 최종 팀 조회
  - `backend/src/battles/service/utils/mvp.util.spec.ts` - NONE 팀 테스트 추가

- 핵심 로직 변경 (`calculateMVPs`):
  - 기존: `opinion.team` (의견 제출 시점 팀)
  - 변경: `state.participants.get(authorId)` (최종 선택 팀)

<br />

## 💬 질문사항 (고민했던 부분)