### PR TITLE
[Feature] Private 배틀 초대 링크를 통한 배틀 진입 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import BattleCreatePage from './pages/battleCreatePage';
 import MainPage from './pages/mainPage';
 import BattlePage from './pages/battlePage';
 import TeamSelectPage from './pages/teamSelectPage';
+import InvitePage from './pages/invitePage';
 import fetchBattleInfo from './commons/apis/getBattleInfo';
 import './App.css';
 import BattleResultPage from './pages/battleResultPage';
@@ -66,6 +67,11 @@ const router = createBrowserRouter([
   {
     path: '/battle/create',
     element: <BattleCreatePage />,
+    errorElement: <ErrorPage />
+  },
+  {
+    path: '/battles/:inviteCode',
+    element: <InvitePage />,
     errorElement: <ErrorPage />
   },
   {

--- a/frontend/src/assets/icon/check.svg
+++ b/frontend/src/assets/icon/check.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16.6667 5L7.50004 14.1667L3.33337 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/assets/icon/copy.svg
+++ b/frontend/src/assets/icon/copy.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="6.66663" y="6.66667" width="10" height="10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.3334 6.66667V4.16667C13.3334 3.72464 13.1578 3.30072 12.8452 2.98816C12.5327 2.67559 12.1087 2.5 11.6667 2.5H4.16671C3.72469 2.5 3.30076 2.67559 2.9882 2.98816C2.67564 3.30072 2.50004 3.72464 2.50004 4.16667V11.6667C2.50004 12.1087 2.67564 12.5326 2.9882 12.8452C3.30076 13.1577 3.72469 13.3333 4.16671 13.3333H6.66671" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/commons/apis/getBattleInfo.ts
+++ b/frontend/src/commons/apis/getBattleInfo.ts
@@ -24,7 +24,8 @@ function isBattleInfo(data: unknown): data is BattleInfo {
     typeof timelines === 'object' &&
     timelines !== null &&
     Array.isArray(timelines.attacks) &&
-    Array.isArray(timelines.defenses)
+    Array.isArray(timelines.defenses) &&
+    (obj.inviteCode === undefined || typeof obj.inviteCode === 'string')
   );
 }
 
@@ -34,10 +35,17 @@ const fetchBattleInfo = async (id: string) => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
-      }
+      },
+      credentials: 'include' // 쿠키 포함
     });
 
     if (!response.ok) {
+      if (response.status === 403) {
+        // 비공개 배틀 접근 거부 - 초대 코드 필요
+        alert('비공개 배틀에 접근하려면 초대 코드가 필요합니다.');
+        window.location.href = '/';
+        throw new Error('비공개 배틀에 접근하려면 초대 코드가 필요합니다.');
+      }
       throw new Error('배틀 데이터를 불러오는데 실패했습니다.');
     }
 

--- a/frontend/src/commons/apis/getBattleInfo.ts
+++ b/frontend/src/commons/apis/getBattleInfo.ts
@@ -41,7 +41,6 @@ const fetchBattleInfo = async (id: string) => {
 
     if (!response.ok) {
       if (response.status === 403) {
-        // 비공개 배틀 접근 거부 - 초대 코드 필요
         alert('비공개 배틀에 접근하려면 초대 코드가 필요합니다.');
         window.location.href = '/';
         throw new Error('비공개 배틀에 접근하려면 초대 코드가 필요합니다.');

--- a/frontend/src/commons/apis/postCreateBattle.ts
+++ b/frontend/src/commons/apis/postCreateBattle.ts
@@ -1,0 +1,58 @@
+import type { BattleLanguage, BattleType } from '@/pages/battleCreatePage/index';
+import type { BattleCategory } from '@/pages/mainPage/types/battle';
+
+type BattlePlayTimeName = 'FIFTEEN_MIN' | 'THIRTY_MIN';
+
+export interface CreateBattleRequest {
+  authorId: string;
+  title: string;
+  description: string;
+  aCode: string;
+  bCode: string;
+  language: BattleLanguage;
+  type: BattleType;
+  category: BattleCategory;
+  playTime: BattlePlayTimeName;
+  topics: string[];
+}
+
+export interface CreateBattleResponse {
+  battleId: string;
+  inviteCode?: string;
+}
+
+function isCreateBattleResponse(data: unknown): data is CreateBattleResponse {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+
+  const obj = data as CreateBattleResponse;
+
+  return typeof obj.battleId === 'string' && (obj.inviteCode === undefined || typeof obj.inviteCode === 'string');
+}
+
+const postCreateBattle = async (payload: CreateBattleRequest): Promise<CreateBattleResponse> => {
+  try {
+    const response = await fetch(`/api/battles`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => null)) as { message?: string } | null;
+      throw new Error(errorData?.message ?? '배틀 생성에 실패했습니다.');
+    }
+
+    const data = await response.json();
+    if (isCreateBattleResponse(data)) {
+      return data;
+    }
+    throw new Error('잘못된 응답 형식입니다.');
+  } catch (error) {
+    console.error('배틀 생성 중 오류 발생:', error);
+    throw error;
+  }
+};
+
+export default postCreateBattle;

--- a/frontend/src/commons/apis/postCreateBattle.ts
+++ b/frontend/src/commons/apis/postCreateBattle.ts
@@ -36,6 +36,7 @@ const postCreateBattle = async (payload: CreateBattleRequest): Promise<CreateBat
     const response = await fetch(`/api/battles`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include', // 쿠키 수신을 위해 필요
       body: JSON.stringify(payload)
     });
 

--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -28,6 +28,7 @@ export interface BattleInfo {
     defenses: BattleDefense[];
   };
   referenceData?: BattleReferenceData | null;
+  inviteCode?: string;
 }
 
 // 공통 타입들

--- a/frontend/src/pages/battleCreatePage/components/InviteLinkButton.tsx
+++ b/frontend/src/pages/battleCreatePage/components/InviteLinkButton.tsx
@@ -22,34 +22,22 @@ export default function InviteLinkButton({ inviteCode }: InviteLinkProps) {
   };
 
   return (
-    <div className="flex items-center gap-2">
-      <div className="flex-1 bg-[#1A1A2E] border border-[#2D2D3F] rounded-lg px-4 py-2 flex items-center gap-2">
-        <input
-          type="text"
-          value={inviteLink}
-          readOnly
-          className="flex-1 bg-transparent text-white text-sm focus:outline-none"
-          onClick={(e) => e.currentTarget.select()}
-        />
-      </div>
-
-      <button
-        onClick={handleCopy}
-        className="px-4 py-2 bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white rounded-lg transition-colors flex items-center justify-center min-w-[60px] sm:min-w-[100px]"
-        title="링크 복사"
-      >
-        {copied ? (
-          <div className="flex items-center gap-2">
-            <CheckIcon className="w-4 h-4 shrink-0" />
-            <span className="text-sm hidden sm:inline">복사됨</span>
-          </div>
-        ) : (
-          <div className="flex items-center gap-2">
-            <CopyIcon className="w-4 h-4 shrink-0" />
-            <span className="text-sm hidden sm:inline">복사</span>
-          </div>
-        )}
-      </button>
-    </div>
+    <button
+      onClick={handleCopy}
+      className="px-4 py-2 bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white rounded-lg transition-colors flex items-center justify-center gap-2"
+      title="링크 복사"
+    >
+      {copied ? (
+        <>
+          <CheckIcon className="w-4 h-4 shrink-0" />
+          <span className="text-sm">복사됨</span>
+        </>
+      ) : (
+        <>
+          <CopyIcon className="w-4 h-4 shrink-0" />
+          <span className="text-sm">친구 초대</span>
+        </>
+      )}
+    </button>
   );
 }

--- a/frontend/src/pages/battleCreatePage/components/InviteLinkButton.tsx
+++ b/frontend/src/pages/battleCreatePage/components/InviteLinkButton.tsx
@@ -24,18 +24,18 @@ export default function InviteLinkButton({ inviteCode }: InviteLinkProps) {
   return (
     <button
       onClick={handleCopy}
-      className="px-4 py-2 bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white rounded-lg transition-colors flex items-center justify-center gap-2"
+      className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors flex items-center justify-center gap-2 text-sm w-[100px] sm:w-auto sm:min-w-[100px]"
       title="링크 복사"
     >
       {copied ? (
         <>
           <CheckIcon className="w-4 h-4 shrink-0" />
-          <span className="text-sm">복사됨</span>
+          <span className="text-sm hidden sm:inline">복사됨</span>
         </>
       ) : (
         <>
           <CopyIcon className="w-4 h-4 shrink-0" />
-          <span className="text-sm">친구 초대</span>
+          <span className="text-sm hidden sm:inline">친구 초대</span>
         </>
       )}
     </button>

--- a/frontend/src/pages/battleCreatePage/components/InviteLinkButton.tsx
+++ b/frontend/src/pages/battleCreatePage/components/InviteLinkButton.tsx
@@ -2,11 +2,11 @@ import { useState } from 'react';
 import CheckIcon from '@/assets/icon/check.svg?react';
 import CopyIcon from '@/assets/icon/copy.svg?react';
 
-interface InviteLinkButtonProps {
+interface InviteLinkProps {
   inviteCode: string;
 }
 
-export default function InviteLinkButton({ inviteCode }: InviteLinkButtonProps) {
+export default function InviteLinkButton({ inviteCode }: InviteLinkProps) {
   const [copied, setCopied] = useState(false);
 
   const inviteLink = `${window.location.origin}/battles/${inviteCode}`;

--- a/frontend/src/pages/battleCreatePage/components/test/InviteLinkButton.test.tsx
+++ b/frontend/src/pages/battleCreatePage/components/test/InviteLinkButton.test.tsx
@@ -16,25 +16,18 @@ describe('InviteLinkButton', () => {
 
   const mockInviteCode = 'testInviteCode123';
 
-  it('초대 링크가 올바르게 렌더링된다', () => {
+  it('친구 초대 버튼이 렌더링된다', () => {
     render(<InviteLinkButton inviteCode={mockInviteCode} />);
 
-    const input = screen.getByRole('textbox') as HTMLInputElement;
-    expect(input.value).toBe(`${window.location.origin}/battles/${mockInviteCode}`);
+    const button = screen.getByTitle('링크 복사');
+    expect(button).toBeInTheDocument();
   });
 
-  it('복사 버튼이 렌더링된다', () => {
+  it('버튼 클릭 시 클립보드에 링크가 복사된다', async () => {
     render(<InviteLinkButton inviteCode={mockInviteCode} />);
 
-    const copyButton = screen.getByRole('button', { name: /복사/i });
-    expect(copyButton).toBeInTheDocument();
-  });
-
-  it('복사 버튼 클릭 시 클립보드에 링크가 복사된다', async () => {
-    render(<InviteLinkButton inviteCode={mockInviteCode} />);
-
-    const copyButton = screen.getByRole('button', { name: /복사/i });
-    fireEvent.click(copyButton);
+    const button = screen.getByTitle('링크 복사');
+    fireEvent.click(button);
 
     await waitFor(() => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(`${window.location.origin}/battles/${mockInviteCode}`);
@@ -44,11 +37,12 @@ describe('InviteLinkButton', () => {
   it('복사 성공 시 "복사됨" 텍스트가 표시된다', async () => {
     render(<InviteLinkButton inviteCode={mockInviteCode} />);
 
-    const copyButton = screen.getByRole('button', { name: /복사/i });
-    fireEvent.click(copyButton);
+    const button = screen.getByTitle('링크 복사');
+    fireEvent.click(button);
 
     await waitFor(() => {
-      expect(screen.getByText('복사됨')).toBeInTheDocument();
+      const copiedText = screen.queryByText('복사됨');
+      expect(copiedText).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/battleCreatePage/components/test/InviteLinkButton.test.tsx
+++ b/frontend/src/pages/battleCreatePage/components/test/InviteLinkButton.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import InviteLinkButton from '../InviteLinkButton';
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: vi.fn().mockResolvedValue(undefined)
+  }
+});
+
+describe('InviteLinkButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockInviteCode = 'testInviteCode123';
+
+  it('초대 링크가 올바르게 렌더링된다', () => {
+    render(<InviteLinkButton inviteCode={mockInviteCode} />);
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toBe(`${window.location.origin}/battles/${mockInviteCode}`);
+  });
+
+  it('복사 버튼이 렌더링된다', () => {
+    render(<InviteLinkButton inviteCode={mockInviteCode} />);
+
+    const copyButton = screen.getByRole('button', { name: /복사/i });
+    expect(copyButton).toBeInTheDocument();
+  });
+
+  it('복사 버튼 클릭 시 클립보드에 링크가 복사된다', async () => {
+    render(<InviteLinkButton inviteCode={mockInviteCode} />);
+
+    const copyButton = screen.getByRole('button', { name: /복사/i });
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(`${window.location.origin}/battles/${mockInviteCode}`);
+    });
+  });
+
+  it('복사 성공 시 "복사됨" 텍스트가 표시된다', async () => {
+    render(<InviteLinkButton inviteCode={mockInviteCode} />);
+
+    const copyButton = screen.getByRole('button', { name: /복사/i });
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('복사됨')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/battleCreatePage/index.test.tsx
+++ b/frontend/src/pages/battleCreatePage/index.test.tsx
@@ -23,11 +23,12 @@ vi.mock('@/commons/stores/authStore', () => ({
   }),
   selectUser: vi.fn((state: any) => state.user)
 }));
+const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
   return {
     ...actual,
-    useNavigate: () => vi.fn()
+    useNavigate: () => mockNavigate
   };
 });
 
@@ -38,6 +39,7 @@ const renderWithRouter = (component: React.ReactElement) => {
 describe('BattleCreatePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockNavigate.mockClear();
     vi.mocked(formatCodeUtil.formatCode).mockResolvedValue({ code: 'formatted code', formatted: true });
   });
 
@@ -49,7 +51,7 @@ describe('BattleCreatePage', () => {
     expect(screen.getByPlaceholderText(/어떤 코드를 비교하고 싶으신가요?/i)).toBeInTheDocument();
   });
 
-  it('배틀 생성 성공 시 초대 링크 UI가 표시된다', async () => {
+  it('비공개 배틀 생성 성공 시 inviteCode로 리다이렉트된다', async () => {
     const user = userEvent.setup({ delay: null });
     vi.mocked(postCreateBattleApi.default).mockResolvedValue({
       battleId: 'test-battle-id',
@@ -69,16 +71,14 @@ describe('BattleCreatePage', () => {
     await user.click(screen.getByRole('button', { name: /배틀 시작/i }));
 
     await waitFor(() => {
-      expect(screen.getByText('친구 초대')).toBeInTheDocument();
-      expect(screen.getByText(/초대 링크를 복사하여 친구들에게 공유해봐요!/i)).toBeInTheDocument();
+      expect(mockNavigate).toHaveBeenCalledWith('/battles/test-invite-code');
     });
   });
 
-  it('초대 링크가 표시되면 "배틀 참여하기" 버튼이 나타난다', async () => {
+  it('공개 배틀 생성 성공 시 team-select로 리다이렉트된다', async () => {
     const user = userEvent.setup({ delay: null });
     vi.mocked(postCreateBattleApi.default).mockResolvedValue({
-      battleId: 'test-battle-id',
-      inviteCode: 'test-invite-code'
+      battleId: 'test-battle-id'
     });
 
     renderWithRouter(<BattleCreatePage />);
@@ -94,7 +94,7 @@ describe('BattleCreatePage', () => {
     await user.click(screen.getByRole('button', { name: /배틀 시작/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /배틀 참여하기/i })).toBeInTheDocument();
+      expect(mockNavigate).toHaveBeenCalledWith('/battle/test-battle-id/team-select/');
     });
   });
 

--- a/frontend/src/pages/battleCreatePage/index.test.tsx
+++ b/frontend/src/pages/battleCreatePage/index.test.tsx
@@ -51,34 +51,11 @@ describe('BattleCreatePage', () => {
     expect(screen.getByPlaceholderText(/어떤 코드를 비교하고 싶으신가요?/i)).toBeInTheDocument();
   });
 
-  it('비공개 배틀 생성 성공 시 inviteCode로 리다이렉트된다', async () => {
+  it('배틀 생성 성공 시 team-select로 리다이렉트된다', async () => {
     const user = userEvent.setup({ delay: null });
     vi.mocked(postCreateBattleApi.default).mockResolvedValue({
       battleId: 'test-battle-id',
       inviteCode: 'test-invite-code'
-    });
-
-    renderWithRouter(<BattleCreatePage />);
-
-    await user.type(screen.getByPlaceholderText(/예: 배열에서 중복 제거하기/i), 'Test Battle');
-    await user.type(screen.getByPlaceholderText(/어떤 코드를 비교하고 싶으신가요?/i), 'Test Description');
-    await user.type(screen.getByPlaceholderText(/첫 번째 코드/i), 'code A');
-    await user.type(screen.getByPlaceholderText(/두 번째 코드/i), 'code B');
-
-    const topicCheckbox = screen.getByLabelText(/효율성/i);
-    await user.click(topicCheckbox);
-
-    await user.click(screen.getByRole('button', { name: /배틀 시작/i }));
-
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/battles/test-invite-code');
-    });
-  });
-
-  it('공개 배틀 생성 성공 시 team-select로 리다이렉트된다', async () => {
-    const user = userEvent.setup({ delay: null });
-    vi.mocked(postCreateBattleApi.default).mockResolvedValue({
-      battleId: 'test-battle-id'
     });
 
     renderWithRouter(<BattleCreatePage />);

--- a/frontend/src/pages/battleCreatePage/index.test.tsx
+++ b/frontend/src/pages/battleCreatePage/index.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
+import BattleCreatePage from './index';
+import * as postCreateBattleApi from '@/commons/apis/postCreateBattle';
+import * as formatCodeUtil from '@/commons/utils/codeFormatter';
+
+vi.mock('@/commons/apis/postCreateBattle');
+vi.mock('@/commons/utils/codeFormatter');
+vi.mock('@/commons/stores/authStore', () => ({
+  useAuthStore: vi.fn((selector: any) => {
+    const mockUser = {
+      id: 'test-user-id',
+      nickname: 'testuser',
+      avatarUrl: null,
+      type: 'oauth' as const
+    };
+    if (selector) {
+      return selector({ user: mockUser });
+    }
+    return mockUser;
+  }),
+  selectUser: vi.fn((state: any) => state.user)
+}));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn()
+  };
+});
+
+const renderWithRouter = (component: React.ReactElement) => {
+  return render(<BrowserRouter>{component}</BrowserRouter>);
+};
+
+describe('BattleCreatePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(formatCodeUtil.formatCode).mockResolvedValue({ code: 'formatted code', formatted: true });
+  });
+
+  it('배틀 생성 페이지가 올바르게 렌더링된다', () => {
+    renderWithRouter(<BattleCreatePage />);
+
+    expect(screen.getByText('새 배틀 생성')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/예: 배열에서 중복 제거하기/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/어떤 코드를 비교하고 싶으신가요?/i)).toBeInTheDocument();
+  });
+
+  it('배틀 생성 성공 시 초대 링크 UI가 표시된다', async () => {
+    const user = userEvent.setup({ delay: null });
+    vi.mocked(postCreateBattleApi.default).mockResolvedValue({
+      battleId: 'test-battle-id',
+      inviteCode: 'test-invite-code'
+    });
+
+    renderWithRouter(<BattleCreatePage />);
+
+    await user.type(screen.getByPlaceholderText(/예: 배열에서 중복 제거하기/i), 'Test Battle');
+    await user.type(screen.getByPlaceholderText(/어떤 코드를 비교하고 싶으신가요?/i), 'Test Description');
+    await user.type(screen.getByPlaceholderText(/첫 번째 코드/i), 'code A');
+    await user.type(screen.getByPlaceholderText(/두 번째 코드/i), 'code B');
+
+    const topicCheckbox = screen.getByLabelText(/효율성/i);
+    await user.click(topicCheckbox);
+
+    await user.click(screen.getByRole('button', { name: /배틀 시작/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('친구 초대')).toBeInTheDocument();
+      expect(screen.getByText(/초대 링크를 복사하여 친구들에게 공유해봐요!/i)).toBeInTheDocument();
+    });
+  });
+
+  it('초대 링크가 표시되면 "배틀 참여하기" 버튼이 나타난다', async () => {
+    const user = userEvent.setup({ delay: null });
+    vi.mocked(postCreateBattleApi.default).mockResolvedValue({
+      battleId: 'test-battle-id',
+      inviteCode: 'test-invite-code'
+    });
+
+    renderWithRouter(<BattleCreatePage />);
+
+    await user.type(screen.getByPlaceholderText(/예: 배열에서 중복 제거하기/i), 'Test Battle');
+    await user.type(screen.getByPlaceholderText(/어떤 코드를 비교하고 싶으신가요?/i), 'Test Description');
+    await user.type(screen.getByPlaceholderText(/첫 번째 코드/i), 'code A');
+    await user.type(screen.getByPlaceholderText(/두 번째 코드/i), 'code B');
+
+    const topicCheckbox = screen.getByLabelText(/효율성/i);
+    await user.click(topicCheckbox);
+
+    await user.click(screen.getByRole('button', { name: /배틀 시작/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /배틀 참여하기/i })).toBeInTheDocument();
+    });
+  });
+
+  it('배틀 생성 실패 시 에러 메시지가 표시된다', async () => {
+    const user = userEvent.setup({ delay: null });
+    const errorMessage = '배틀 생성에 실패했습니다.';
+    vi.mocked(postCreateBattleApi.default).mockRejectedValue(new Error(errorMessage));
+
+    renderWithRouter(<BattleCreatePage />);
+
+    await user.type(screen.getByPlaceholderText(/예: 배열에서 중복 제거하기/i), 'Test Battle');
+    await user.type(screen.getByPlaceholderText(/어떤 코드를 비교하고 싶으신가요?/i), 'Test Description');
+    await user.type(screen.getByPlaceholderText(/첫 번째 코드/i), 'code A');
+    await user.type(screen.getByPlaceholderText(/두 번째 코드/i), 'code B');
+
+    const topicCheckbox = screen.getByLabelText(/효율성/i);
+    await user.click(topicCheckbox);
+
+    await user.click(screen.getByRole('button', { name: /배틀 시작/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -5,18 +5,11 @@ import { BATTLE_CATEGORY_CONFIG } from '../mainPage/types/battle';
 import BattleTopicInput from './components/BattleTopicInput';
 import { formatCode } from '@/commons/utils/codeFormatter';
 import { selectUser, useAuthStore } from '@/commons/stores/authStore';
-import InviteLinkButton from './components/InviteLinkButton';
-import PeopleIcon from '@/assets/icon/peoples.svg?react';
 import postCreateBattle from '@/commons/apis/postCreateBattle';
 
 export type BattleType = 'PUBLIC' | 'PRIVATE';
 export type BattleLanguage = 'javascript' | 'typescript' | 'python';
 export type BattlePlayTime = 'FIFTEEN_MIN' | 'THIRTY_MIN';
-
-interface InviteLinkData {
-  battleId: string;
-  inviteCode: string;
-}
 
 const LANGUAGE_OPTIONS: Array<{ label: string; value: BattleLanguage }> = [
   { label: 'JavaScript', value: 'javascript' },
@@ -60,7 +53,6 @@ export default function BattleCreatePage() {
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [inviteLinkData, setInviteLinkData] = useState<InviteLinkData | null>(null);
 
   const rounds = PLAYTIME_OPTIONS.find(({ value }) => value === playTime)?.rounds ?? 0;
 
@@ -100,10 +92,11 @@ export default function BattleCreatePage() {
         topics
       });
 
+      // 비공개 배틀 생성 시 inviteCode로 리다이렉트
       if (data.inviteCode) {
-        setInviteLinkData({ battleId: data.battleId, inviteCode: data.inviteCode });
+        navigate(`/battles/${data.inviteCode}`);
       } else {
-        // 초대 코드가 없으면 바로 이동
+        // 공개 배틀은 바로 이동 가능
         navigate(`/battle/${data.battleId}/team-select/`);
       }
     } catch (e) {
@@ -258,68 +251,24 @@ export default function BattleCreatePage() {
                 </div>
               )}
 
-              {inviteLinkData && (
-                <div className="rounded-xl border border-orange-500/50 bg-orange-500/20 px-6 py-6 space-y-4 shadow-lg">
-                  <div className="text-center">
-                    <div className="flex items-center justify-center gap-2 mb-2">
-                      <PeopleIcon className="w-6 h-6 " />
-                      <h3 className="text-lg font-bold text-white">친구 초대</h3>
-                    </div>
-                    <p className="text-sm text-gray-300 mb-4">초대 링크를 복사하여 친구들에게 공유해봐요!</p>
-                  </div>
-
-                  <InviteLinkButton inviteCode={inviteLinkData.inviteCode} />
-                </div>
-              )}
-
               <div className="flex items-center justify-end gap-3 pt-2">
-                {inviteLinkData ? (
-                  <div className="flex items-center gap-3">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setInviteLinkData(null);
-                        setTitle('');
-                        setDescription('');
-                        setACode('');
-                        setBCode('');
-                        setTopics([]);
-                      }}
-                      className="rounded-xl border border-[#2b2b3e] bg-transparent px-5 py-3 text-gray-200 hover:bg-[#1a1a2e] transition-colors"
-                    >
-                      취소
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        navigate(`/battle/${inviteLinkData.battleId}/team-select/`);
-                      }}
-                      className="inline-flex items-center gap-2 rounded-xl bg-orange-500 px-5 py-3 font-semibold text-white shadow-[0_12px_24px_rgba(255,105,0,0.25)] hover:bg-orange-400 transition-colors"
-                    >
-                      배틀 참여하기
-                    </button>
-                  </div>
-                ) : (
-                  <div className="flex items-center gap-3">
-                    <button
-                      type="button"
-                      onClick={() => navigate('/')}
-                      className="rounded-xl border border-[#2b2b3e] bg-transparent px-5 py-3 text-gray-200 hover:bg-[#1a1a2e] transition-colors"
-                    >
-                      취소
-                    </button>
+                <button
+                  type="button"
+                  onClick={() => navigate('/')}
+                  className="rounded-xl border border-[#2b2b3e] bg-transparent px-5 py-3 text-gray-200 hover:bg-[#1a1a2e] transition-colors"
+                >
+                  취소
+                </button>
 
-                    <button
-                      type="button"
-                      disabled={!canSubmit || isSubmitting}
-                      onClick={handleSubmit}
-                      className="inline-flex items-center gap-2 rounded-xl bg-orange-500 px-5 py-3 font-semibold text-white shadow-[0_12px_24px_rgba(255,105,0,0.25)] hover:bg-orange-400 disabled:cursor-not-allowed disabled:bg-orange-500/50 transition-colors"
-                    >
-                      <PlusIcon className="h-4 w-4" />
-                      {isSubmitting ? '생성 중...' : '배틀 시작'}
-                    </button>
-                  </div>
-                )}
+                <button
+                  type="button"
+                  disabled={!canSubmit || isSubmitting}
+                  onClick={handleSubmit}
+                  className="inline-flex items-center gap-2 rounded-xl bg-orange-500 px-5 py-3 font-semibold text-white shadow-[0_12px_24px_rgba(255,105,0,0.25)] hover:bg-orange-400 disabled:cursor-not-allowed disabled:bg-orange-500/50 transition-colors"
+                >
+                  <PlusIcon className="h-4 w-4" />
+                  {isSubmitting ? '생성 중...' : '배틀 시작'}
+                </button>
               </div>
             </div>
           </div>

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -22,10 +22,10 @@ const PLAYTIME_OPTIONS: Array<{ label: string; value: BattlePlayTime; rounds: nu
   { label: '30분', value: 'THIRTY_MIN', rounds: 2 }
 ];
 
-const VISIBILITY_OPTIONS: Array<{ label: string; value: BattleType }> = [
-  { label: '공개', value: 'PUBLIC' },
-  { label: '비공개', value: 'PRIVATE' }
-];
+// const VISIBILITY_OPTIONS: Array<{ label: string; value: BattleType }> = [
+//   { label: '공개', value: 'PUBLIC' },
+//   { label: '비공개', value: 'PRIVATE' }
+// ];
 
 export default function BattleCreatePage() {
   const navigate = useNavigate();
@@ -49,7 +49,7 @@ export default function BattleCreatePage() {
   const [category, setCategory] = useState(categoryOptions[0]?.value ?? 'ALGORITHM');
   const [playTime, setPlayTime] = useState<BattlePlayTime>('FIFTEEN_MIN');
   const [topics, setTopics] = useState<string[]>([]);
-  const [type, setType] = useState<BattleType>('PUBLIC');
+  const [type] = useState<BattleType>('PRIVATE'); // 현재는 비공개만
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -220,7 +220,7 @@ export default function BattleCreatePage() {
                 </div>
               </div>
 
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              {/* <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                 <div className="space-y-2">
                   <label className="text-sm text-gray-300">배틀 공개 여부</label>
                   <select
@@ -235,7 +235,7 @@ export default function BattleCreatePage() {
                     ))}
                   </select>
                 </div>
-              </div>
+              </div> */}
 
               <BattleTopicInput rounds={rounds} selectedTopics={topics} onTopicsChange={setTopics} />
 

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -92,13 +92,7 @@ export default function BattleCreatePage() {
         topics
       });
 
-      // 비공개 배틀 생성 시 inviteCode로 리다이렉트
-      if (data.inviteCode) {
-        navigate(`/battles/${data.inviteCode}`);
-      } else {
-        // 공개 배틀은 바로 이동 가능
-        navigate(`/battle/${data.battleId}/team-select/`);
-      }
+      navigate(`/battle/${data.battleId}/team-select/`);
     } catch (e) {
       setErrorMessage(e instanceof Error ? e.message : '알 수 없는 오류가 발생했습니다.');
     } finally {

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -5,10 +5,18 @@ import { BATTLE_CATEGORY_CONFIG } from '../mainPage/types/battle';
 import BattleTopicInput from './components/BattleTopicInput';
 import { formatCode } from '@/commons/utils/codeFormatter';
 import { selectUser, useAuthStore } from '@/commons/stores/authStore';
+import InviteLinkButton from './components/InviteLinkButton';
+import PeopleIcon from '@/assets/icon/peoples.svg?react';
+import postCreateBattle from '@/commons/apis/postCreateBattle';
 
-type BattleType = 'PUBLIC' | 'PRIVATE';
-type BattleLanguage = 'javascript' | 'typescript' | 'python';
-type BattlePlayTime = 'FIFTEEN_MIN' | 'THIRTY_MIN';
+export type BattleType = 'PUBLIC' | 'PRIVATE';
+export type BattleLanguage = 'javascript' | 'typescript' | 'python';
+export type BattlePlayTime = 'FIFTEEN_MIN' | 'THIRTY_MIN';
+
+interface InviteLinkData {
+  battleId: string;
+  inviteCode: string;
+}
 
 const LANGUAGE_OPTIONS: Array<{ label: string; value: BattleLanguage }> = [
   { label: 'JavaScript', value: 'javascript' },
@@ -49,10 +57,10 @@ export default function BattleCreatePage() {
   const [playTime, setPlayTime] = useState<BattlePlayTime>('FIFTEEN_MIN');
   const [topics, setTopics] = useState<string[]>([]);
   const [type, setType] = useState<BattleType>('PUBLIC');
-  const [password, setPassword] = useState('');
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [inviteLinkData, setInviteLinkData] = useState<InviteLinkData | null>(null);
 
   const rounds = PLAYTIME_OPTIONS.find(({ value }) => value === playTime)?.rounds ?? 0;
 
@@ -62,7 +70,6 @@ export default function BattleCreatePage() {
     if (!description.trim()) return false;
     if (!aCode.trim()) return false;
     if (!bCode.trim()) return false;
-    if (type === 'PRIVATE' && !password.trim()) return false;
     if (topics.length !== rounds) return false;
 
     return true;
@@ -79,31 +86,26 @@ export default function BattleCreatePage() {
       if (!authorId) {
         throw new Error('로그인이 필요합니다.');
       }
-      const res = await fetch(`/api/battles`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          authorId,
-          title: title.trim(),
-          description: description.trim(),
-          aCode: formattedA.code,
-          bCode: formattedB.code,
-          language,
-          type,
-          password: type === 'PRIVATE' ? password : undefined,
-          category,
-          playTime,
-          topics
-        })
+
+      const data = await postCreateBattle({
+        authorId,
+        title: title.trim(),
+        description: description.trim(),
+        aCode: formattedA.code,
+        bCode: formattedB.code,
+        language,
+        type,
+        category,
+        playTime,
+        topics
       });
 
-      if (!res.ok) {
-        const payload = (await res.json().catch(() => null)) as { message?: string } | null;
-        throw new Error(payload?.message ?? '배틀 생성에 실패했습니다.');
+      if (data.inviteCode) {
+        setInviteLinkData({ battleId: data.battleId, inviteCode: data.inviteCode });
+      } else {
+        // 초대 코드가 없으면 바로 이동
+        navigate(`/battle/${data.battleId}/team-select/`);
       }
-
-      const data = (await res.json()) as { battleId: string };
-      navigate(`/battle/${data.battleId}/team-select/`);
     } catch (e) {
       setErrorMessage(e instanceof Error ? e.message : '알 수 없는 오류가 발생했습니다.');
     } finally {
@@ -246,18 +248,6 @@ export default function BattleCreatePage() {
                     ))}
                   </select>
                 </div>
-
-                {type === 'PRIVATE' && (
-                  <div className="space-y-2 md:col-span-2">
-                    <label className="text-sm text-gray-300">비공개 배틀 비밀번호</label>
-                    <input
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      placeholder="비밀번호를 입력하세요"
-                      className="w-full rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/60"
-                    />
-                  </div>
-                )}
               </div>
 
               <BattleTopicInput rounds={rounds} selectedTopics={topics} onTopicsChange={setTopics} />
@@ -268,24 +258,68 @@ export default function BattleCreatePage() {
                 </div>
               )}
 
-              <div className="flex items-center justify-end gap-3 pt-2">
-                <button
-                  type="button"
-                  onClick={() => navigate('/')}
-                  className="rounded-xl border border-[#2b2b3e] bg-transparent px-5 py-3 text-gray-200 hover:bg-[#1a1a2e] transition-colors"
-                >
-                  취소
-                </button>
+              {inviteLinkData && (
+                <div className="rounded-xl border border-orange-500/50 bg-orange-500/20 px-6 py-6 space-y-4 shadow-lg">
+                  <div className="text-center">
+                    <div className="flex items-center justify-center gap-2 mb-2">
+                      <PeopleIcon className="w-6 h-6 " />
+                      <h3 className="text-lg font-bold text-white">친구 초대</h3>
+                    </div>
+                    <p className="text-sm text-gray-300 mb-4">초대 링크를 복사하여 친구들에게 공유해봐요!</p>
+                  </div>
 
-                <button
-                  type="button"
-                  disabled={!canSubmit || isSubmitting}
-                  onClick={handleSubmit}
-                  className="inline-flex items-center gap-2 rounded-xl bg-orange-500 px-5 py-3 font-semibold text-white shadow-[0_12px_24px_rgba(255,105,0,0.25)] hover:bg-orange-400 disabled:cursor-not-allowed disabled:bg-orange-500/50 transition-colors"
-                >
-                  <PlusIcon className="h-4 w-4" />
-                  {isSubmitting ? '생성 중...' : '배틀 시작'}
-                </button>
+                  <InviteLinkButton inviteCode={inviteLinkData.inviteCode} />
+                </div>
+              )}
+
+              <div className="flex items-center justify-end gap-3 pt-2">
+                {inviteLinkData ? (
+                  <div className="flex items-center gap-3">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setInviteLinkData(null);
+                        setTitle('');
+                        setDescription('');
+                        setACode('');
+                        setBCode('');
+                        setTopics([]);
+                      }}
+                      className="rounded-xl border border-[#2b2b3e] bg-transparent px-5 py-3 text-gray-200 hover:bg-[#1a1a2e] transition-colors"
+                    >
+                      취소
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        navigate(`/battle/${inviteLinkData.battleId}/team-select/`);
+                      }}
+                      className="inline-flex items-center gap-2 rounded-xl bg-orange-500 px-5 py-3 font-semibold text-white shadow-[0_12px_24px_rgba(255,105,0,0.25)] hover:bg-orange-400 transition-colors"
+                    >
+                      배틀 참여하기
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-3">
+                    <button
+                      type="button"
+                      onClick={() => navigate('/')}
+                      className="rounded-xl border border-[#2b2b3e] bg-transparent px-5 py-3 text-gray-200 hover:bg-[#1a1a2e] transition-colors"
+                    >
+                      취소
+                    </button>
+
+                    <button
+                      type="button"
+                      disabled={!canSubmit || isSubmitting}
+                      onClick={handleSubmit}
+                      className="inline-flex items-center gap-2 rounded-xl bg-orange-500 px-5 py-3 font-semibold text-white shadow-[0_12px_24px_rgba(255,105,0,0.25)] hover:bg-orange-400 disabled:cursor-not-allowed disabled:bg-orange-500/50 transition-colors"
+                    >
+                      <PlusIcon className="h-4 w-4" />
+                      {isSubmitting ? '생성 중...' : '배틀 시작'}
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/pages/battlePage/components/header/index.tsx
+++ b/frontend/src/pages/battlePage/components/header/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/pages/battlePage/stores/battleStore';
 import type { BattlePhase } from '@/commons/types/battle';
 import PhaseSkip from './PhaseSkip';
+import InviteLinkButton from '@/pages/battleCreatePage/components/InviteLinkButton';
 
 const PHASE_INSTRUCTIONS: Record<BattlePhase, string> = {
   PENDING: '',
@@ -19,13 +20,15 @@ const PHASE_INSTRUCTIONS: Record<BattlePhase, string> = {
   DEFENSE: '상대의 공격에 대한 반박 논리를 작성해주세요',
   TEAM_SWITCH: '원하시는 팀으로 변경하실 수 있습니다'
 };
+
 interface BattleHeaderProps {
   isSkipEnabled: boolean;
   toggleSkip: () => void;
   totalSkips: number;
+  inviteCode?: string;
 }
 
-export default function BattleHeader({ isSkipEnabled, toggleSkip, totalSkips }: BattleHeaderProps) {
+export default function BattleHeader({ isSkipEnabled, toggleSkip, totalSkips, inviteCode }: BattleHeaderProps) {
   const battleProgress = useBattleStore(selectBattleProgress);
   const team = useBattleStore(selectSelectedTeam);
   const battleId = useBattleStore(selectBattleId);

--- a/frontend/src/pages/battlePage/components/header/index.tsx
+++ b/frontend/src/pages/battlePage/components/header/index.tsx
@@ -11,7 +11,6 @@ import {
 } from '@/pages/battlePage/stores/battleStore';
 import type { BattlePhase } from '@/commons/types/battle';
 import PhaseSkip from './PhaseSkip';
-import InviteLinkButton from '@/pages/battleCreatePage/components/InviteLinkButton';
 
 const PHASE_INSTRUCTIONS: Record<BattlePhase, string> = {
   PENDING: '',
@@ -25,10 +24,9 @@ interface BattleHeaderProps {
   isSkipEnabled: boolean;
   toggleSkip: () => void;
   totalSkips: number;
-  inviteCode?: string;
 }
 
-export default function BattleHeader({ isSkipEnabled, toggleSkip, totalSkips, inviteCode }: BattleHeaderProps) {
+export default function BattleHeader({ isSkipEnabled, toggleSkip, totalSkips }: BattleHeaderProps) {
   const battleProgress = useBattleStore(selectBattleProgress);
   const team = useBattleStore(selectSelectedTeam);
   const battleId = useBattleStore(selectBattleId);

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -27,6 +27,7 @@ import SoundSettingsButton from './components/header/SoundSettingsButton';
 import SkipModal from './components/effects/SkipModal';
 import { selectUser, useAuthStore } from '@/commons/stores/authStore';
 import { usePhaseSkip } from './hooks/usePhaseSkip';
+import InviteLinkButton from '@/pages/battleCreatePage/components/InviteLinkButton';
 
 type Tab = 'info' | 'timeline' | 'reference';
 
@@ -212,13 +213,16 @@ export default function BattlePage() {
             battleProgress.startedAt
           }`}
         >
-          <div className="flex items-center justify-between mt-10 mb-8">
+          <div className="flex items-center justify-between gap-4 mt-10 mb-8">
             <button
               onClick={handleLeaveBattle}
-              className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors"
+              className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors shrink-0 text-sm w-[100px] sm:w-auto sm:min-w-[100px]"
             >
               ← 돌아가기
             </button>
+            <div className="shrink-0">
+              {battleInfo.inviteCode && <InviteLinkButton inviteCode={battleInfo.inviteCode} />}
+            </div>
           </div>
           <div className="flex items-center justify-between">
             <SoundSettingsButton bgmOptions={BGM_OPTIONS} />

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -220,8 +220,15 @@ export default function BattlePage() {
               ← 돌아가기
             </button>
           </div>
-          <SoundSettingsButton bgmOptions={BGM_OPTIONS} />
-          <BattleHeader isSkipEnabled={isSkipEnabled} toggleSkip={toggleSkip} totalSkips={totalSkips} />
+          <div className="flex items-center justify-between">
+            <SoundSettingsButton bgmOptions={BGM_OPTIONS} />
+            <BattleHeader
+              isSkipEnabled={isSkipEnabled}
+              toggleSkip={toggleSkip}
+              totalSkips={totalSkips}
+              inviteCode={battleInfo.inviteCode}
+            />
+          </div>
         </div>
         <main className="main-width-closed">
           <div className="flex gap-2 py-4">

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -220,18 +220,13 @@ export default function BattlePage() {
             >
               ← 돌아가기
             </button>
-            <div className="shrink-0">
+            <div className="shrink-0 flex items-center gap-2">
               {battleInfo.inviteCode && <InviteLinkButton inviteCode={battleInfo.inviteCode} />}
             </div>
           </div>
           <div className="flex items-center justify-between">
             <SoundSettingsButton bgmOptions={BGM_OPTIONS} />
-            <BattleHeader
-              isSkipEnabled={isSkipEnabled}
-              toggleSkip={toggleSkip}
-              totalSkips={totalSkips}
-              inviteCode={battleInfo.inviteCode}
-            />
+            <BattleHeader isSkipEnabled={isSkipEnabled} toggleSkip={toggleSkip} totalSkips={totalSkips} />
           </div>
         </div>
         <main className="main-width-closed">

--- a/frontend/src/pages/invitePage/index.tsx
+++ b/frontend/src/pages/invitePage/index.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+
+export default function InvitePage() {
+  const { inviteCode } = useParams<{ inviteCode: string }>();
+
+  useEffect(() => {
+    if (!inviteCode) {
+      return;
+    }
+    window.location.href = `/api/battles/${inviteCode}`;
+  }, [inviteCode]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-center">
+        <div className="w-12 h-12 border-4 border-orange-500 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+        <p className="text-white text-lg">초대 링크를 확인하는 중...</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/teamSelectPage/components/InviteLinkButton.tsx
+++ b/frontend/src/pages/teamSelectPage/components/InviteLinkButton.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import CheckIcon from '@/assets/icon/check.svg?react';
+import CopyIcon from '@/assets/icon/copy.svg?react';
+
+interface InviteLinkButtonProps {
+  inviteCode: string;
+}
+
+export default function InviteLinkButton({ inviteCode }: InviteLinkButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const inviteLink = `${window.location.origin}/battles/${inviteCode}`;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('링크 복사 실패:', error);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex-1 bg-[#1A1A2E] border border-[#2D2D3F] rounded-lg px-4 py-2 flex items-center gap-2">
+        <input
+          type="text"
+          value={inviteLink}
+          readOnly
+          className="flex-1 bg-transparent text-white text-sm focus:outline-none"
+          onClick={(e) => e.currentTarget.select()}
+        />
+      </div>
+
+      <button
+        onClick={handleCopy}
+        className="px-4 py-2 bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white rounded-lg transition-colors flex items-center justify-center min-w-[60px] sm:min-w-[100px]"
+        title="링크 복사"
+      >
+        {copied ? (
+          <div className="flex items-center gap-2">
+            <CheckIcon className="w-4 h-4 shrink-0" />
+            <span className="text-sm hidden sm:inline">복사됨</span>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2">
+            <CopyIcon className="w-4 h-4 shrink-0" />
+            <span className="text-sm hidden sm:inline">복사</span>
+          </div>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/teamSelectPage/index.tsx
+++ b/frontend/src/pages/teamSelectPage/index.tsx
@@ -116,15 +116,21 @@ export default function TeamSelectPage() {
     <main className="min-h-screen bg-[#0a0a1a] py-12 px-4">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
-        <div className="flex items-center justify-between mb-8">
-          <button
-            onClick={() => navigate('/')}
-            className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors"
-          >
-            ← 돌아가기
-          </button>
-          <h1 className="text-3xl font-bold text-white">배틀 참가하기</h1>
-          {battleInfo.inviteCode && <InviteLinkButton inviteCode={battleInfo.inviteCode} />}
+        <div className="relative mb-8">
+          <div className="flex items-center justify-between gap-4">
+            <button
+              onClick={() => navigate('/')}
+              className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors shrink-0 text-sm w-[100px] sm:w-auto sm:min-w-[100px]"
+            >
+              ← 돌아가기
+            </button>
+            <h1 className="text-3xl font-bold text-white absolute left-1/2 -translate-x-1/2 pointer-events-none">
+              배틀 참가하기
+            </h1>
+            <div className="shrink-0">
+              {battleInfo.inviteCode && <InviteLinkButton inviteCode={battleInfo.inviteCode} />}
+            </div>
+          </div>
         </div>
 
         <p className="text-center text-[#99A1AF] mb-8">배틀 정보를 확인하고 진영을 선택하세요</p>

--- a/frontend/src/pages/teamSelectPage/index.tsx
+++ b/frontend/src/pages/teamSelectPage/index.tsx
@@ -13,6 +13,7 @@ import Step4Timeline from './components/steps/Step4Timeline';
 import Step5TeamSelect from './components/steps/Step5TeamSelect';
 import type { Team } from '@/commons/types/battle';
 import { useBattleStore } from '@/pages/battlePage/stores/battleStore';
+import InviteLinkButton from '@/pages/battleCreatePage/components/InviteLinkButton';
 
 export default function TeamSelectPage() {
   const navigate = useNavigate();
@@ -123,7 +124,7 @@ export default function TeamSelectPage() {
             ← 돌아가기
           </button>
           <h1 className="text-3xl font-bold text-white">배틀 참가하기</h1>
-          <div className="w-24" />
+          {battleInfo.inviteCode && <InviteLinkButton inviteCode={battleInfo.inviteCode} />}
         </div>
 
         <p className="text-center text-[#99A1AF] mb-8">배틀 정보를 확인하고 진영을 선택하세요</p>


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

resolve #252

## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

#### Private 배틀 초대 링크 복사 기능 구현
- team-select 페이지와 battle 페이지에 친구 초대 버튼 추가
- 클릭 시 초대 링크(`/battles/{inviteCode}`) 클립보드 복사

#### 배틀 생성 플로우 개선
- 배틀 생성자는 쿠키가 이미 설정되어 있으므로 바로 team-select 페이지로 이동
- 초대 코드로 접근하는 사용자만 InvitePage를 거쳐 쿠키 설정 후 team-select로 이동

#### UI/UX
- 친구 초대 버튼을 뒤로가기 버튼과 같은 높이, 오른쪽 상단에 배치
- 복사 성공 시 "복사됨" 문구 제공

#### 에러 처리
- 비공개 배틀에 초대 코드 없이 접근 시 403 에러 처리
- alert 표시 후 메인 페이지로 리다이렉트

> 참고 흐름 : #269 

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

| 진영 선택 / 배틀 페이지 링크 복사 |  inviteCode 없이 battleId로 직접 진입 시 |
|--|--|
| <img width="1920" height="906" alt="image" src="https://github.com/user-attachments/assets/99bf38a4-4b39-407d-94be-a2511a59fa2e" /> |   <img width="960" height="1020" alt="image" src="https://github.com/user-attachments/assets/b059d55d-139d-4504-baa2-40105001784f" /> |

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->

### 초대 링크 UI 위치에 대한 고민

**현재 구현 (배틀 생성 페이지)**
- 배틀 생성 성공 직후 초대 링크 섹션 표시
- 사용자가 바로 링크를 복사하고 공유할 수 있음
- 배틀 생성 직후가 초대 링크 공유의 가장 적절한 타이밍
- 사용자가 배틀에 참여하기 전에 친구들을 초대할 수 있음

**✔️ 선택됨. 고려했던 대안:**
**- 배틀 페이지 내 초대 링크 표시**
**- 팀 선택 페이지에서 초대 링크 표시**

초대 링크 UI를 배틀 생성 페이지에 두는 것이 적절한지, 아니면 다른 페이지에 두는게 좋을지 의견 부탁드립니당