### PR TITLE
[Feature] 서버에서 사용자별 스킵을 관리하여 페이즈를 스킵한다. 

### DIFF
--- a/backend/prisma/migrations/20260127072202_skip_state/migration.sql
+++ b/backend/prisma/migrations/20260127072202_skip_state/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "battles" ADD COLUMN     "skip_state" UUID[];

--- a/backend/prisma/migrations/20260128103849_reference/migration.sql
+++ b/backend/prisma/migrations/20260128103849_reference/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "battles" ADD COLUMN     "reference_data" JSONB;

--- a/backend/prisma/migrations/20260128104446_skip_state_default/migration.sql
+++ b/backend/prisma/migrations/20260128104446_skip_state_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "battles" ALTER COLUMN "skip_state" SET DEFAULT ARRAY[]::UUID[];

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -85,7 +85,7 @@ model Battle {
   chatsAllState            Json?      @map("chats_all_state")
   chatsTeamAState          Json?      @map("chats_team_a_state")
   chatsTeamBState          Json?      @map("chats_team_b_state")
-  skipState                String[]   @db.Uuid @map("skip_state")
+  skipState                String[]   @db.Uuid @map("skip_state") @default([])
 
   creator                  User?      @relation("BattleCreator", fields: [userId], references: [id])
   participants             BattleParticipant[]

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -74,7 +74,8 @@ model Battle {
   phaseCount               Int?       @map("phase_count")
   startedAt                DateTime?  @map("started_at")
   expiredAt                DateTime?  @map("expired_at")
-
+  
+  /* 배틀 상태 */
   participantsState        Json?      @map("participants_state")
   teamVotesState           Json?      @map("team_votes_state")
   userInfoState            Json?      @map("user_info_state")
@@ -84,6 +85,7 @@ model Battle {
   chatsAllState            Json?      @map("chats_all_state")
   chatsTeamAState          Json?      @map("chats_team_a_state")
   chatsTeamBState          Json?      @map("chats_team_b_state")
+  skipState                String[]   @db.Uuid @map("skip_state")
 
   creator                  User?      @relation("BattleCreator", fields: [userId], references: [id])
   participants             BattleParticipant[]

--- a/backend/src/battles/dto/battleJoinResponse.dto.ts
+++ b/backend/src/battles/dto/battleJoinResponse.dto.ts
@@ -9,6 +9,7 @@ export class BattleJoinResponseDto {
     teamB: number
     teamNone: number
   }
+  totalSkips: number
 
   // 배틀 전체 타임라인 & 채팅
   timelines: { attacks: (BattleDiscussion | null)[]; defenses: (BattleDefense | null)[] }
@@ -30,7 +31,7 @@ export class BattleJoinResponseDto {
 
   static fromEntity(payload: ActiveBattleState, team: string): BattleJoinResponseDto {
     const res = new BattleJoinResponseDto()
-    const { all, teamA, teamB, participants, round, topics, phase, phaseCount, startedAt, expiredAt } = payload
+    const { all, teamA, teamB, participants, round, topics, phase, phaseCount, skipState, startedAt, expiredAt } = payload
 
     const myTeam = team === BATTLE_TEAM.A ? teamA : team === BATTLE_TEAM.B ? teamB : all
 
@@ -40,6 +41,8 @@ export class BattleJoinResponseDto {
       teamB: teamB.users.length,
       teamNone: participants.size - (teamA.users.length + teamB.users.length),
     }
+    res.totalSkips = skipState.size
+
     res.timelines = {
       attacks: all.attacks.filter((attack): attack is BattleDiscussion => attack !== null && attack.status === 'SELECTED'),
       defenses: all.defenses.filter((defense): defense is BattleDefense => defense !== null && defense.status === 'SELECTED'),

--- a/backend/src/battles/dto/battleLeaveResponse.dto.ts
+++ b/backend/src/battles/dto/battleLeaveResponse.dto.ts
@@ -7,10 +7,11 @@ export class BattleLeaveResponseDto {
     teamB: number
     teamNone: number
   }
+  totalSkips: number
 
   static fromEntity(payload: ActiveBattleState): BattleLeaveResponseDto {
     const res = new BattleLeaveResponseDto()
-    const { teamA, teamB, participants } = payload
+    const { teamA, teamB, participants, skipState } = payload
 
     res.battleId = payload.battleId
     res.counts = {
@@ -18,6 +19,7 @@ export class BattleLeaveResponseDto {
       teamB: teamB.users.length,
       teamNone: participants.size - (teamA.users.length + teamB.users.length),
     }
+    res.totalSkips = skipState.size
     return res
   }
 

--- a/backend/src/battles/gateway/battles.gateway.ts
+++ b/backend/src/battles/gateway/battles.gateway.ts
@@ -251,6 +251,28 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     }
   }
 
+  @SubscribeMessage('battle:user:skip')
+  async handlePhaseSkip(@MessageBody() dto: { skip: boolean; battleId: string }, @ConnectedSocket() client: SocketWithUserId) {
+    const stopTimer = this.metricsService.startSocketTimer('battle:user:skip')
+    const userId = this.getUserIdFromSocket(client)
+    try {
+      const { skip, battleId } = dto
+      const totalSkips = await this.battlesService.handlePhaseSkip({ battleId, userId, skip })
+      const battleRoomId = this.battlesService.getBattleRoomId(battleId)
+
+      this.server.to(battleRoomId).emit('battle:user:skipped', { totalSkips })
+
+      stopTimer('success')
+    } catch (error) {
+      stopTimer('error')
+      if (error instanceof Error) {
+        client.emit('battle:user:skip:error', {
+          message: error.message,
+        })
+      }
+    }
+  }
+
   phaseUpdate(payload: BattlePhaseResponseDto) {
     const { battleId } = payload
     const battleRoomId = this.battlesService.getBattleRoomId(battleId)
@@ -299,6 +321,13 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     this.server.to(battleRoomId).emit('battle:user:updated', payload)
   }
 
+  skipPhase(payload: { battleId: string }) {
+    const { battleId } = payload
+    const battleRoomId = this.battlesService.getBattleRoomId(battleId)
+
+    this.server.to(battleRoomId).emit('battle:phase:skipped')
+  }
+
   private bindBattleEvents() {
     this.battlesService.on('battle:phase:updated', (payload: BattlePhaseResponseDto) => this.phaseUpdate(payload))
 
@@ -311,10 +340,9 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect,
     this.battlesService.on('battle:team:updated', (payload: BattleTeamUpdateAllResponseDto) => this.teamUpdate(payload))
 
     this.battlesService.on('battle:user:updated', (payload: BattleUserUpdateResponseDto) => this.userUpdate(payload))
-    // this.battlesService.on('battle:ended', payload => {
-    //   const { battleId } = payload
-    //   this.server.to(`battle:${battleId}`).emit('battle:ended', payload)
-    // })
+
+    this.battlesService.on('battle:phase:skipped', (payload: { battleId: string }) => this.skipPhase(payload))
+
     this.battlesService.on('battle:closed', (payload: BattleClosedResponseDto) => this.closeBattle(payload))
   }
 

--- a/backend/src/battles/service/battles.service.spec.ts
+++ b/backend/src/battles/service/battles.service.spec.ts
@@ -1,5 +1,5 @@
 import { NotFoundException, BadRequestException, ForbiddenException, UnauthorizedException } from '@nestjs/common'
-import { Battle, FinishedBattleState, BattleDefense, ActiveBattleState } from '../types/battles.types'
+import { Battle, FinishedBattleState, BattleDefense, ActiveBattleState, BattleTeam } from '../types/battles.types'
 import { BattlesService } from './battles.service'
 import {
   BATTLE_TYPE,
@@ -1978,6 +1978,114 @@ describe('BattlesService', () => {
       // 같은 객체를 참조
       expect(state.opinionHistory[0]).toBe(state.teamA.attacks[0])
       expect(state.opinionHistory[1]).toBe(state.teamB.attacks[0])
+    })
+  })
+
+  describe('handlePhaseSkip', () => {
+    const battleId = 'battle-id'
+    const userA = 'user-a'
+    const userB = 'user-b'
+
+    const createActiveState = (overrides: Partial<ActiveBattleState> = {}): ActiveBattleState => ({
+      battleId,
+      all: { roomId: `battle:${battleId}`, chats: [], attacks: [], defenses: [] },
+      teamA: { roomId: `battle:${battleId}:A`, chats: [], users: [userA], attacks: [], defenses: [] },
+      teamB: { roomId: `battle:${battleId}:B`, chats: [], users: [userB], attacks: [], defenses: [] },
+      phase: BATTLE_PHASE.OPINION_SHARE.name,
+      participants: new Map([
+        [userA, BATTLE_TEAM.A],
+        [userB, BATTLE_TEAM.B],
+      ]),
+      teamVotes: new Map<string, BattleTeam>(),
+      userInfoMap: new Map<string, string>(),
+      opinionHistory: [],
+      skipState: new Set<string>(),
+      round: 0,
+      topics: [],
+      totalRounds: 0,
+      phaseCount: 0,
+      startedAt: null,
+      expiredAt: null,
+      ...overrides,
+    })
+
+    beforeEach(async () => {
+      const battle = createBattle({ id: battleId })
+      seedBattles([battle])
+
+      await updateState(battleId, state => {
+        Object.assign(state, createActiveState())
+      })
+    })
+
+    it('TEAM_SWITCH 페이즈에서는 스킵할 수 없다', async () => {
+      await updateState(battleId, state => {
+        state.phase = BATTLE_PHASE.TEAM_SWITCH.name
+      })
+
+      await expect(service.handlePhaseSkip({ battleId, userId: userA, skip: true })).rejects.toThrow('진영선택 페이즈는 스킵이 불가합니다.')
+    })
+
+    it('중립(NONE) 유저는 스킵할 수 없다', async () => {
+      await updateState(battleId, state => {
+        state.participants.set(userA, BATTLE_TEAM.NONE)
+      })
+
+      await expect(service.handlePhaseSkip({ battleId, userId: userA, skip: true })).rejects.toThrow('권한이 없습니다.')
+    })
+
+    it('skip=true면 skipState에 유저가 추가된다', async () => {
+      const total = await service.handlePhaseSkip({
+        battleId,
+        userId: userA,
+        skip: true,
+      })
+
+      const state = await getStateUnsafe(battleId)
+
+      expect(state.skipState.has(userA)).toBe(true)
+      expect(total).toBe(1)
+    })
+
+    it('skip=false면 skipState에서 유저가 제거된다', async () => {
+      await service.handlePhaseSkip({ battleId, userId: userA, skip: true })
+
+      const total = await service.handlePhaseSkip({
+        battleId,
+        userId: userA,
+        skip: false,
+      })
+
+      const state = await getStateUnsafe(battleId)
+
+      expect(state.skipState.has(userA)).toBe(false)
+      expect(total).toBe(0)
+    })
+
+    it('모든 참가자가 스킵하면 phase가 스킵되고 skipState가 초기화된다', async () => {
+      const skipPhaseSpy = jest.spyOn(service, 'skipPhase')
+
+      await service.handlePhaseSkip({ battleId, userId: userA, skip: true })
+      const total = await service.handlePhaseSkip({ battleId, userId: userB, skip: true })
+
+      const state = await getStateUnsafe(battleId)
+
+      expect(skipPhaseSpy).toHaveBeenCalledWith(battleId)
+      expect(state.skipState.size).toBe(0)
+      expect(total).toBe(0)
+    })
+
+    it('skipState는 DB에 저장된다', async () => {
+      await service.handlePhaseSkip({ battleId, userId: userA, skip: true })
+
+      expect(mockPrisma.battle.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: battleId },
+          data: {
+            skipState: [userA],
+          },
+        }),
+      )
     })
   })
 })

--- a/backend/src/battles/service/battles.service.spec.ts
+++ b/backend/src/battles/service/battles.service.spec.ts
@@ -289,7 +289,8 @@ describe('BattlesService', () => {
           const end = take ? skip + take : undefined
           return records.slice(skip, end)
         }),
-        count: jest.fn(({ where }: BattleCountArgs = {}) => {
+        count: jest.fn((args?: BattleCountArgs) => {
+          const { where } = args ?? {}
           let records = [...battleStore.values()]
           if (where?.isPrivate !== undefined) {
             records = records.filter(r => r.isPrivate === where.isPrivate)
@@ -312,7 +313,8 @@ describe('BattlesService', () => {
         }),
       },
       battleParticipant: { upsert: jest.fn() },
-      user: { findUnique: jest.fn(() => null) },
+      // eslint-disable-next-line no-empty-pattern
+      user: { findUnique: jest.fn(({}: { where: { id: string }; select?: { id: true } }) => null) },
     }
     service = new BattlesService(mockPrisma as unknown as PrismaService)
     const originalGetBattleState: BattlesService['getBattleState'] = service.getBattleState.bind(service)
@@ -795,21 +797,18 @@ describe('BattlesService', () => {
 
   describe('getOpenBattles', () => {
     it('case', async () => {
-      const publicOpen = toRecord(createBattle({ status: BATTLE_STATUS.OPEN }))
-      mockPrisma.battle.findMany.mockResolvedValue([publicOpen])
-      mockPrisma.battle.count.mockResolvedValue(1)
+      toRecord(createBattle({ status: BATTLE_STATUS.OPEN }))
+      seedBattles([createBattle({ status: BATTLE_STATUS.OPEN })])
 
       const result = (await service.getOpenBattles(10, 0)).battles
 
       expect(result).toHaveLength(1)
       expect(result[0].status).toBe(BATTLE_STATUS.OPEN)
     })
-
     it('case', async () => {
-      const oldBattle = toRecord(createBattle({ id: 'old', createdAt: new Date('2024-01-01') }))
-      const newBattle = toRecord(createBattle({ id: 'new', createdAt: new Date('2024-01-02') }))
-      mockPrisma.battle.findMany.mockResolvedValue([newBattle, oldBattle])
-      mockPrisma.battle.count.mockResolvedValue(2)
+      const oldBattle = createBattle({ id: 'old', createdAt: new Date('2024-01-01') })
+      const newBattle = createBattle({ id: 'new', createdAt: new Date('2024-01-02') })
+      seedBattles([oldBattle, newBattle])
 
       const result = (await service.getOpenBattles(10, 0)).battles
 
@@ -818,9 +817,8 @@ describe('BattlesService', () => {
     })
 
     it('case', async () => {
-      const two = toRecord(createBattle({ id: '2', createdAt: new Date('2024-01-02') }))
-      mockPrisma.battle.findMany.mockResolvedValue([two])
-      mockPrisma.battle.count.mockResolvedValue(3)
+      const two = createBattle({ id: '2', createdAt: new Date('2024-01-02') })
+      seedBattles([createBattle({ id: '1', createdAt: new Date('2024-01-01') }), two, createBattle({ id: '3', createdAt: new Date('2024-01-03') })])
 
       const result = (await service.getOpenBattles(1, 1)).battles
 

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -297,6 +297,7 @@ export class BattlesService extends EventEmitter {
     const attackState = this.parseAttackState(battle.attacksState)
     const defenseState = this.parseDefenseState(battle.defensesState)
     const opinionHistory = this.parseOpinionHistoryState(battle.opinionHistoryState)
+    const skipState = new Set<string>(battle?.skipState ?? [])
 
     const state: ActiveBattleState = {
       battleId,
@@ -324,6 +325,7 @@ export class BattlesService extends EventEmitter {
       teamVotes,
       userInfoMap,
       opinionHistory,
+      skipState,
       round: battle.currentRound ?? 1,
       topics: battle.topics,
       totalRounds: this.getPlayTime(battle.playTime).rounds,
@@ -363,6 +365,7 @@ export class BattlesService extends EventEmitter {
         chatsAllState: this.serializeChatState(state.all.chats) as unknown as Prisma.InputJsonValue,
         chatsTeamAState: this.serializeChatState(state.teamA.chats) as unknown as Prisma.InputJsonValue,
         chatsTeamBState: this.serializeChatState(state.teamB.chats) as unknown as Prisma.InputJsonValue,
+        skipState: Array.from(state.skipState),
         updatedAt: new Date(),
       },
     })
@@ -620,6 +623,7 @@ export class BattlesService extends EventEmitter {
     // battleState.guestInfoMap.delete(userId)
     battleState.teamVotes.delete(userId)
     battleState.participants.delete(userId)
+    battleState.skipState.delete(userId)
 
     await this.saveBattleState(battleId, battleState)
 
@@ -853,6 +857,7 @@ export class BattlesService extends EventEmitter {
     state.phase = nextPhase.name
     state.startedAt = now
     state.expiredAt = now + nextPhase.time
+    state.skipState = new Set<string>()
 
     if (prevRound !== state.round) {
       const res = BattleRoundResponseDto.of({
@@ -1278,6 +1283,50 @@ export class BattlesService extends EventEmitter {
 
     await this.saveBattleState(battleId, battleState)
     return updatedDiscussions
+  }
+
+  async handlePhaseSkip(payload: { battleId: string; userId: string; skip: boolean }): Promise<number> {
+    const { battleId, skip, userId } = payload
+
+    const { battleState } = await this.getBattleState(battleId)
+    const ABParticipants = [...battleState.participants.values()].filter(p => p !== BATTLE_TEAM.NONE).length
+    const participant = battleState.participants.get(userId)
+
+    if (battleState.phase === BATTLE_PHASE.TEAM_SWITCH.name) throw new BadRequestException('진영선택 페이즈는 스킵이 불가합니다.')
+    if (!participant || participant === BATTLE_TEAM.NONE) throw new UnauthorizedException('권한이 없습니다.')
+
+    const skipList = battleState.skipState
+    if (skip) {
+      skipList.add(userId)
+    } else {
+      skipList.delete(userId)
+    }
+
+    let totalSkips = skipList.size
+    await this.updateSkipState(battleId, skipList)
+
+    if (skipList.size && skipList.size === ABParticipants) {
+      await this.skipPhase(battleId)
+      totalSkips = 0
+    }
+
+    return totalSkips
+  }
+
+  async skipPhase(battleId: string) {
+    await this.updateSkipState(battleId, new Set<string>())
+    await this.updatePhase(battleId)
+
+    this.emit('battle:phase:skipped', { battleId })
+  }
+
+  private async updateSkipState(battleId: string, skipList: Set<string>) {
+    await this.prisma.battle.update({
+      where: { id: battleId },
+      data: {
+        skipState: Array.from(skipList),
+      },
+    })
   }
 
   //turn 끝나면 최고 득표한 이의제기 항목 선정 후 이벤트 발행

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -626,6 +626,7 @@ export class BattlesService extends EventEmitter {
     battleState.skipState.delete(userId)
 
     await this.saveBattleState(battleId, battleState)
+    await this.checkAndSkipPhase(battleId, battleState)
 
     return BattleLeaveResponseDto.of(battleState)
   }
@@ -1289,28 +1290,21 @@ export class BattlesService extends EventEmitter {
     const { battleId, skip, userId } = payload
 
     const { battleState } = await this.getBattleState(battleId)
-    const ABParticipants = [...battleState.participants.values()].filter(p => p !== BATTLE_TEAM.NONE).length
     const participant = battleState.participants.get(userId)
 
     if (battleState.phase === BATTLE_PHASE.TEAM_SWITCH.name) throw new BadRequestException('진영선택 페이즈는 스킵이 불가합니다.')
     if (!participant || participant === BATTLE_TEAM.NONE) throw new UnauthorizedException('권한이 없습니다.')
 
-    const skipList = battleState.skipState
     if (skip) {
-      skipList.add(userId)
+      battleState.skipState.add(userId)
     } else {
-      skipList.delete(userId)
+      battleState.skipState.delete(userId)
     }
 
-    let totalSkips = skipList.size
-    await this.updateSkipState(battleId, skipList)
+    await this.updateSkipState(battleId, battleState.skipState)
 
-    if (skipList.size && skipList.size === ABParticipants) {
-      await this.skipPhase(battleId)
-      totalSkips = 0
-    }
-
-    return totalSkips
+    const skipped = await this.checkAndSkipPhase(battleId, battleState)
+    return skipped ? 0 : battleState.skipState.size
   }
 
   async skipPhase(battleId: string) {
@@ -1329,9 +1323,20 @@ export class BattlesService extends EventEmitter {
     })
   }
 
-  //turn 끝나면 최고 득표한 이의제기 항목 선정 후 이벤트 발행
-  //battle:defensed
-  //battle:attacked
+  private async checkAndSkipPhase(battleId: string, state: ActiveBattleState) {
+    const activeParticipants = this.getActiveParticipantsCount(state)
+
+    if (activeParticipants > 0 && state.skipState.size === activeParticipants) {
+      await this.skipPhase(battleId)
+      return true
+    }
+
+    return false
+  }
+
+  private getActiveParticipantsCount(state: ActiveBattleState): number {
+    return [...state.participants.values()].filter(team => team !== BATTLE_TEAM.NONE).length
+  }
 
   private canUserVoteAttack(battleState: ActiveBattleState): boolean {
     return battleState.phase === BATTLE_PHASE.ATTACK.name ? true : false

--- a/backend/src/battles/types/battles.types.ts
+++ b/backend/src/battles/types/battles.types.ts
@@ -115,6 +115,7 @@ export interface ActiveBattleState {
   userInfoMap: Map<string, string>
 
   opinionHistory: BattleDiscussion[]
+  skipState: Set<string>
 
   round: number
   topics: string[]


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 예: Closes #123, Relates to #456 -->

Closes #246

## ✅ 작업 내용

- [x] Schema에 `skip_state` 필드 추가

  ```
    skipState   String[]   @db.Uuid @map("skip_state")
  ```

  - 코드 상에서는 `Set<string>()`으로 `userId` 배열을 관리합니다.
  - DB에 저장할 때는 `String[]`으로 저장하며 UUID만 허용합니다.

- [x] `battle:user:skip` 이벤트 수신
  - [x] `skip: true`일 경우, `skipState`에 추가하며 그 반대는 제거합니다.
  - [x] 중립의 유저가 요청을 보내면 에러를 발생합니다.
  - [x] 현재 스킵한 유저의 수를 `battle:user:skipped`로 반환합니다.
- [x] 중립을 제외한 모든 유저 수가 스킵 희망 유저 수와 같다면 해당 페이즈를 스킵합니다.
  - [x] `battle:phase:skipped` 이벤트를 발행하여 페이즈 스킵을 클라이언트에 알립니다.
  - [x] 현재 진행되는 페이즈를 종료하고 다음 페이즈로 넘어갑니다.
- [x] 매 페이즈가 넘어갈 때마다 DB에 저장된 `skipState`를 제거합니다.

- [x] 스킵한 인원이 배틀을 나가면 `skipState`에서 제거합니다.
  - `battle:leaved`에 `totalSkips`를 전달하여 현재 스킵 인원을 업데이트합니다.
- [x] 유저가 배틀에 참여하면 `battle:joined` 이벤트에서 `totalSkips`를 전달하여 현재 스킵 인원을 표시합니다.

### 💡개선 사항

<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항

<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)

크롬 2 / 사파리 1로 3기통을 돌려서 테스트를 해봤을 때 별 이상없었는데, 혼자서 테스트해보기에는 무리가 있는 것 같더라고요..!
함께 테스트해보면 좋을 것 같습니다.

🔥🔥🔥🔥🔥 React Strict 때문에 이벤트가 두 번씩 전달되어서 테스트 시에 App.tsx에 Strict를 주석처리해주셔야 합니다!! 🔥🔥🔥🔥