### PR TITLE
[Fix] 마지막 결과 페이지 나오기 전에 진영 변경 UI 보여주지 않는 버그를 수정한다. 

### DIFF
--- a/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
@@ -45,9 +45,14 @@ export function useBattleProgress() {
     socket.on('battle:phase:updated', handlePhaseUpdate);
     socket.on('battle:round:updated', handleRoundUpdate);
 
-    // 배틀 종료 이벤트 구독
     const handleBattleClosed = (data: { battleId: string }) => {
-      navigate(`/battles/${data.battleId}/result`);
+      const { isTeamVoteResultShowing, setPendingBattleClosed } = useBattleStore.getState();
+
+      if (isTeamVoteResultShowing) {
+        setPendingBattleClosed(true);
+      } else {
+        navigate(`/battles/${data.battleId}/result`);
+      }
     };
     socket.on('battle:closed', handleBattleClosed);
 

--- a/frontend/src/pages/battlePage/hooks/useTeamVoteResult.ts
+++ b/frontend/src/pages/battlePage/hooks/useTeamVoteResult.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useBattleStore, selectSocket, selectBattleId } from '../stores/battleStore';
 import type { BattleTeamUpdateAllResponse } from '@/commons/types/battle';
 import { soundManager } from '@/commons/utils/soundManager';
@@ -6,10 +7,12 @@ import { soundManager } from '@/commons/utils/soundManager';
 export function useTeamVoteResult() {
   const socket = useBattleStore(selectSocket);
   const battleId = useBattleStore(selectBattleId);
-  const { setTeamCounts } = useBattleStore();
+  const navigate = useNavigate();
+  const { setTeamCounts, setIsTeamVoteResultShowing, setPendingBattleClosed } = useBattleStore();
 
   const [voteResult, setVoteResult] = useState<BattleTeamUpdateAllResponse | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const autoCloseTimerRef = useRef<number | null>(null);
 
   // battle:all:updated 이벤트 구독
   useEffect(() => {
@@ -28,21 +31,46 @@ export function useTeamVoteResult() {
       // 모달용 전체 데이터 저장
       setVoteResult(data);
       setIsModalOpen(true);
+      setIsTeamVoteResultShowing(true); // 모달 표시 중 플래그 ON
 
       // 팀 투표 결과 효과음 재생
       soundManager.play('fanfare', 0.5);
+
+      // battle:closed가 대기 중이면 5초 후 자동 이동
+      const { pendingBattleClosed } = useBattleStore.getState();
+      if (pendingBattleClosed) {
+        autoCloseTimerRef.current = setTimeout(() => {
+          navigate(`/battles/${battleId}/result`);
+        }, 5000);
+      }
     };
 
     socket.on('battle:all:updated', handleTeamUpdateAll);
 
     return () => {
       socket.off('battle:all:updated', handleTeamUpdateAll);
+      if (autoCloseTimerRef.current) {
+        clearTimeout(autoCloseTimerRef.current);
+      }
     };
-  }, [socket, battleId, setTeamCounts]);
+  }, [socket, battleId, setTeamCounts, setIsTeamVoteResultShowing, navigate]);
 
   const closeModal = () => {
     setIsModalOpen(false);
     setVoteResult(null);
+    setIsTeamVoteResultShowing(false); // 모달 닫힘 플래그 OFF
+
+    // 타이머가 있으면 취소하고 즉시 이동
+    if (autoCloseTimerRef.current) {
+      clearTimeout(autoCloseTimerRef.current);
+      autoCloseTimerRef.current = null;
+    }
+
+    const { pendingBattleClosed } = useBattleStore.getState();
+    if (pendingBattleClosed) {
+      setPendingBattleClosed(false);
+      navigate(`/battles/${battleId}/result`);
+    }
   };
 
   return {

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -34,6 +34,8 @@ interface BattleStore {
   chatInitialized: boolean;
   opponentNotice: BattleChat | null;
   opponentNoticePending: BattleChat | null;
+  isTeamVoteResultShowing: boolean;
+  pendingBattleClosed: boolean;
 
   initializeBattle: (config: { userId: string; battleId: string }) => void;
   setSocket: (socket: Socket | null) => void;
@@ -55,6 +57,8 @@ interface BattleStore {
   setChatInitialized: (initialized: boolean) => void;
   setOpponentNoticePending: (notice: BattleChat | null) => void;
   commitOpponentNotice: () => void;
+  setIsTeamVoteResultShowing: (showing: boolean) => void;
+  setPendingBattleClosed: (pending: boolean) => void;
   leaveBattle: () => void;
 }
 
@@ -75,6 +79,8 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
   chatInitialized: false,
   opponentNotice: null,
   opponentNoticePending: null,
+  isTeamVoteResultShowing: false,
+  pendingBattleClosed: false,
 
   initializeBattle: (config) => set({ userId: config.userId, battleId: config.battleId, chatInitialized: false }),
   setSocket: (socket) => set({ socket }),
@@ -156,6 +162,8 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
       opponentNotice: state.opponentNoticePending,
       opponentNoticePending: null
     })),
+  setIsTeamVoteResultShowing: (showing) => set({ isTeamVoteResultShowing: showing }),
+  setPendingBattleClosed: (pending) => set({ pendingBattleClosed: pending }),
   leaveBattle: () => {
     const { socket, battleId } = get();
     socket?.emit('battle:leave', { battleId });
@@ -180,7 +188,9 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
       selectedTeam: 'NONE',
       chatInitialized: false,
       opponentNotice: null,
-      opponentNoticePending: null
+      opponentNoticePending: null,
+      isTeamVoteResultShowing: false,
+      pendingBattleClosed: false
     });
   }
 }));


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #263

## ✅ 작업 내용

### `battle:all:updated`와 `battle:closed`이벤트가 동시에 도착할 때 팀 투표 결과 이펙트 모달이 표시되지 않는 문제 해결
버그 원인으로는 진영 변경 결과 이벤트랑 게임 종료 이벤트가 동시에 수신 받게 돼서, 진영 변경 결과 이펙트를 띄움과 동시에 게임 종료 결과 페이지로 라우팅 되서 문제가 생기는 것으로 발견 됐습니다.

그래서 두 이벤트 도착 순서와 무관하게 항상 팀 변경 결과를 5초간 표시 하도록 수정 했습니다.

#### 이벤트 순서 케이스별 처리:
  1. `battle:all:updated` → `battle:closed`: 모달 표시 후 5초 자동 이동
  2. `battle:closed` → `battle:all:updated`: pending 저장 후 모달 뜨면 5초 타이머 시작
  3. 동시 도착: pending 체크하여 모달 표시 후 5초 자동 이동
  4. 사용자가 수동 닫기 시 타이머 취소 후 즉시 결과 페이지 이동 하는 로직 구현

<br />

### 수정 완료 후 시연

https://github.com/user-attachments/assets/ab457bdb-110b-4470-8535-77cfc16e4a5e


## 📸 참고 사항
**주요 변경 파일:**
- `battleStore.ts`: 모달 상태 관리 플래그 `pendingBattleClosed` 추가
- `useTeamVoteResult.ts`: 5초 자동 닫기 타이머 로직 (`useRef` 사용)
- `useBattleProgress.ts`: `battle:closed` 핸들러에서 모달 상태 확인 로직 추가
