### PR TITLE
[Refactor] 이의제기 Input UI 디자인을 수정한다

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -168,7 +168,7 @@
   --header-height: 10rem;
   --chat-height: 30rem;
   --code-height: 30rem;
-  --discussion-input-width: 450px;
+  --discussion-input-width: 370px;
   --create-max-width: 960px;
   --create-padding: 1.5rem;
   --create-title-size: 1.5rem;
@@ -213,7 +213,7 @@
     --header-height: 10.5rem;
     --chat-height: 33rem;
     --code-height: 33rem;
-    --discussion-input-width: 580px;    
+    --discussion-input-width: 450px;    
     --create-max-width: 1120px;
     --create-padding: 1.75rem;
     --create-title-size: 1.75rem;
@@ -257,7 +257,7 @@
     --header-height: 11.1875rem;
     --chat-height: 36rem;
     --code-height: 36rem;
-    --discussion-input-width: 650px;    
+    --discussion-input-width: 610px;    
     --create-max-width: 1280px;
     --create-padding: 2rem;
     --create-title-size: 2rem;

--- a/frontend/src/pages/battlePage/utils/battlePhase.ts
+++ b/frontend/src/pages/battlePage/utils/battlePhase.ts
@@ -46,13 +46,13 @@ export const getDiscussionConfig = (phase?: BattlePhase) => {
       isAttacking: false,
       isActive: true,
       colors: {
-        iconBox: 'bg-blue-500/20 border-blue-500/40',
+        iconBox: 'bg-blue-600/40 border-blue-500/40',
         icon: 'text-blue-400',
         border: 'border-blue-500/30',
         glowBorder: 'border-blue-500',
         focusBorder: 'border-blue-500',
         focusRing: 'focus:ring-blue-500/30',
-        bg: 'bg-gradient-to-r ffrom-black/50 to-blue-900/30',
+        bg: 'bg-gradient-to-r from-black/90 to-blue-900',
         badge: 'bg-blue-500/20 border-blue-500/40 text-blue-400',
         button: 'bg-gradient-to-r from-blue-500 to-blue-600 shadow-lg shadow-blue-500/25 text-white'
       }

--- a/frontend/src/pages/battlePage/utils/battlePhase.ts
+++ b/frontend/src/pages/battlePage/utils/battlePhase.ts
@@ -25,13 +25,13 @@ export const getDiscussionConfig = (phase?: BattlePhase) => {
       isAttacking: true,
       isActive: true,
       colors: {
-        iconBox: 'bg-red-500/20 border-red-500/40',
+        iconBox: 'bg-red-700/50 border-red-500/40',
         icon: 'text-red-400',
         border: 'border-red-500/30',
         glowBorder: 'border-red-500',
         focusBorder: 'border-red-500',
         focusRing: 'focus:ring-red-500/30',
-        bg: 'bg-gradient-to-r from-black/50 to-red-900/30',
+        bg: 'bg-gradient-to-r from-black/90 to-red-900',
         badge: 'bg-red-500/20 border-red-500/40 text-red-400',
         button: 'bg-gradient-to-r from-red-500 to-red-600 shadow-lg shadow-red-500/25 text-white'
       }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #274

## ✅ 작업 내용
### 💡개선 사항
#### **이의 제기/ 반론 Input 색상  개선**
  - 이의제기 input** / 반론 Input 모두 투명도를 기존 20%에서 90%로 하향 조정했습니다.

##### 기존 이의제기/반론 input
<img width="632" height="145" alt="image" src="https://github.com/user-attachments/assets/97b473be-129b-43a1-9660-77bac1adae5b" />


##### 이의제기/반론 input 변경 후 
<img width="584" height="148" alt="image" src="https://github.com/user-attachments/assets/442aae57-3752-4d94-bf81-38d99e74f803" />

<img width="580" height="133" alt="image" src="https://github.com/user-attachments/assets/2d5d10b7-0f5b-4640-8d70-a79f2da601fd" />


<br/>

#### 이의제기 / 반론 input의 크기를 조절하여 채팅 input을 가리지 않게 했습니다.
- 이의제기 반론 input 크기 조절
 - 1280px 스크린 기준 450px -> 370px 
 - 1600px 스크린 기준 580px -> 450px
 - 1920px 스크린 기준 650px -> 610px

##### 이전 이의제기 input이 채팅창 input을 침범하던 문제
<img width="457" height="190" alt="image" src="https://github.com/user-attachments/assets/b53a120b-e163-4d78-a87b-694aa3415a2c" />


##### 적용 사진
<img width="807" height="813" alt="image" src="https://github.com/user-attachments/assets/1fb9cb67-c624-44d2-aeae-1ac0dd1bf1f0" />



<br />

