### PR TITLE
[Fix] 게임에 새롭게 입장하거나 재입장 한 경우 직전 상대팀의 이의제기/반론 항목이 표시되지 않는 버그 수정 한다.

### DIFF
--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -67,6 +67,35 @@ export function useBattleSocket() {
       setAllChats(data.allChats || []);
       setChatInitialized(true);
 
+      // 적팀 최신 공지 설정
+      const currentTeam = useBattleStore.getState().selectedTeam;
+      if (currentTeam !== 'NONE') {
+        const opponentTeam = currentTeam === 'A' ? 'B' : 'A';
+        const allDiscussions = [
+          ...(data.timelines?.attacks || []).map((d) => ({ ...d, discussionType: 'attack' as const })),
+          ...(data.timelines?.defenses || []).map((d) => ({ ...d, discussionType: 'defense' as const }))
+        ];
+
+        const latest = allDiscussions
+          .filter((d) => d.team === opponentTeam)
+          .sort((a, b) => (b.selectedAt || 0) - (a.selectedAt || 0))[0];
+
+        if (latest) {
+          useBattleStore.getState().setOpponentNoticePending({
+            battleId: data.battleId,
+            scope: 'ALL',
+            messageId: `notice-${latest.discussionType}-${latest.discussionId}`,
+            sender: { userId: latest.author.id, nickname: latest.author.nickname },
+            team: latest.team,
+            text: latest.content,
+            createdAt: new Date(latest.selectedAt || Date.now()),
+            type: latest.discussionType,
+            votes: latest.upvotes
+          });
+          useBattleStore.getState().commitOpponentNotice();
+        }
+      }
+
       // 초기 투표 리스트 동기화 (ATTACK/DEFENSE 페이즈만)
       const team = useBattleStore.getState().selectedTeam;
       if (team !== 'NONE') {


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #277

## ✅ 작업 내용

### 💡개선 사항
#### 게임에 새롭게 입장하거나 재입장 한 경우 직전 상대팀의 이의제기/반론 항목이 표시되지 않는 버그 수정 
- 배틀페이지에서 직전 상대팀 이의제기 text가 참조 중인 BattleStore의 opponentNotice 값을 joined 이벤트를 수신 받았을 떄 payload중 timeline 값을 기입 하는 로직 추가함으로써 버그 수정

<br />

## 버그 수정 후 시연



https://github.com/user-attachments/assets/22ad6ad8-66ca-417c-b3cb-706364af34c3

