### PR TITLE
[Fix] 사이드 바 타임라인 A 영역과 B 영역의 반박이 변경되어야 한다.

### DIFF
--- a/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/index.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/index.tsx
@@ -53,8 +53,8 @@ export default function SidebarTimelineSection({ isWide = false, topics }: Sideb
           topic: topics[round - 1],
           attackA: attackList[pairIndex] || null,
           attackB: attackList[pairIndex + 1] || null,
-          defenseB: defenseList[pairIndex] || null,
-          defenseA: defenseList[pairIndex + 1] || null
+          defenseA: defenseList[pairIndex] || null,
+          defenseB: defenseList[pairIndex + 1] || null
         };
       });
     }).flat();


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #281

## ✅ 작업 내용

- [x]  A, B 반박 순서 변경

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<img width="1244" height="699" alt="스크린샷 2026-01-28 오후 4 50 37" src="https://github.com/user-attachments/assets/67902103-ccfe-402f-85a2-7aa9dfc6d4e8" />


<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
