### PR TITLE
[Fix] 공개/비공개 배틀 구별 및 접근 방법 수정

### DIFF
--- a/backend/src/battles/controller/battles.controller.spec.ts
+++ b/backend/src/battles/controller/battles.controller.spec.ts
@@ -110,8 +110,10 @@ describe('BattlesController', () => {
       }
 
       const jsonMock = jest.fn()
+      const cookieMock = jest.fn()
       const res = {
         json: jsonMock,
+        cookie: cookieMock,
       } as unknown as Response
 
       jest.spyOn(service, 'create').mockResolvedValue(mockBattle as never)
@@ -132,6 +134,7 @@ describe('BattlesController', () => {
         res,
       )
 
+      expect(cookieMock).toHaveBeenCalledWith('inviteAccess_battle-1', 'true', expect.any(Object))
       expect(jsonMock).toHaveBeenCalledWith({
         battleId: 'battle-1',
         inviteCode: 'test-invite-code-1234',
@@ -146,8 +149,10 @@ describe('BattlesController', () => {
       }
 
       const jsonMock = jest.fn()
+      const cookieMock = jest.fn()
       const res = {
         json: jsonMock,
+        cookie: cookieMock,
       } as unknown as Response
 
       jest.spyOn(service, 'create').mockResolvedValue(mockBattle as never)
@@ -168,6 +173,7 @@ describe('BattlesController', () => {
         res,
       )
 
+      expect(cookieMock).not.toHaveBeenCalled()
       expect(jsonMock).toHaveBeenCalledWith({
         battleId: 'battle-1',
         inviteCode: null,
@@ -181,13 +187,16 @@ describe('BattlesController', () => {
       const getBattleByInviteCodeSpy = jest.spyOn(service, 'getBattleByInviteCode').mockResolvedValue(mockResult)
 
       const redirectMock = jest.fn()
+      const cookieMock = jest.fn()
       const res = {
         redirect: redirectMock,
+        cookie: cookieMock,
       } as unknown as Response
 
       await controller.getBattleByInviteCode('test-invite-code', res)
 
       expect(getBattleByInviteCodeSpy).toHaveBeenCalledWith('test-invite-code')
+      expect(cookieMock).toHaveBeenCalledWith('inviteAccess_battle-1', 'true', expect.any(Object))
       expect(redirectMock).toHaveBeenCalledWith(303, 'http://localhost:5173/battle/battle-1/team-select')
     })
 
@@ -195,8 +204,10 @@ describe('BattlesController', () => {
       jest.spyOn(service, 'getBattleByInviteCode').mockRejectedValue(new NotFoundException())
 
       const redirectMock = jest.fn()
+      const cookieMock = jest.fn()
       const res = {
         redirect: redirectMock,
+        cookie: cookieMock,
       } as unknown as Response
 
       await expect(controller.getBattleByInviteCode('invalid-code', res)).rejects.toThrow(NotFoundException)

--- a/backend/src/battles/controller/battles.controller.spec.ts
+++ b/backend/src/battles/controller/battles.controller.spec.ts
@@ -109,10 +109,8 @@ describe('BattlesController', () => {
         type: BATTLE_TYPE.PRIVATE,
       }
 
-      const cookieMock = jest.fn()
       const jsonMock = jest.fn()
       const res = {
-        cookie: cookieMock,
         json: jsonMock,
       } as unknown as Response
 
@@ -134,24 +132,21 @@ describe('BattlesController', () => {
         res,
       )
 
-      expect(cookieMock).toHaveBeenCalledWith('inviteAccess_battle-1', 'true', expect.any(Object))
       expect(jsonMock).toHaveBeenCalledWith({
         battleId: 'battle-1',
         inviteCode: 'test-invite-code-1234',
       })
     })
 
-    it('공개 배틀 생성 시 쿠키를 설정하지 않는다', async () => {
+    it('공개 배틀 생성 시 battleId와 inviteCode를 반환한다', async () => {
       const mockBattle = {
         id: 'battle-1',
         inviteCode: null,
         type: BATTLE_TYPE.PUBLIC,
       }
 
-      const cookieMock = jest.fn()
       const jsonMock = jest.fn()
       const res = {
-        cookie: cookieMock,
         json: jsonMock,
       } as unknown as Response
 
@@ -173,7 +168,6 @@ describe('BattlesController', () => {
         res,
       )
 
-      expect(cookieMock).not.toHaveBeenCalled()
       expect(jsonMock).toHaveBeenCalledWith({
         battleId: 'battle-1',
         inviteCode: null,
@@ -182,21 +176,18 @@ describe('BattlesController', () => {
   })
 
   describe('getBattleByInviteCode', () => {
-    it('inviteCode로 배틀을 찾고 쿠키를 설정한 후 리다이렉트한다', async () => {
+    it('inviteCode로 배틀을 찾고 리다이렉트한다', async () => {
       const mockResult = { battleId: 'battle-1' }
       const getBattleByInviteCodeSpy = jest.spyOn(service, 'getBattleByInviteCode').mockResolvedValue(mockResult)
 
       const redirectMock = jest.fn()
-      const cookieMock = jest.fn()
       const res = {
         redirect: redirectMock,
-        cookie: cookieMock,
       } as unknown as Response
 
       await controller.getBattleByInviteCode('test-invite-code', res)
 
       expect(getBattleByInviteCodeSpy).toHaveBeenCalledWith('test-invite-code')
-      expect(cookieMock).toHaveBeenCalledWith('inviteAccess_battle-1', 'true', expect.any(Object))
       expect(redirectMock).toHaveBeenCalledWith(303, 'http://localhost:5173/battle/battle-1/team-select')
     })
 
@@ -204,14 +195,11 @@ describe('BattlesController', () => {
       jest.spyOn(service, 'getBattleByInviteCode').mockRejectedValue(new NotFoundException())
 
       const redirectMock = jest.fn()
-      const cookieMock = jest.fn()
       const res = {
         redirect: redirectMock,
-        cookie: cookieMock,
       } as unknown as Response
 
       await expect(controller.getBattleByInviteCode('invalid-code', res)).rejects.toThrow(NotFoundException)
-      expect(cookieMock).not.toHaveBeenCalled()
     })
   })
 

--- a/backend/src/battles/controller/battles.controller.ts
+++ b/backend/src/battles/controller/battles.controller.ts
@@ -1,12 +1,10 @@
-import { Body, Controller, Post, Get, Query, Param, HttpCode, InternalServerErrorException, HttpException, Res, UseGuards } from '@nestjs/common'
+import { Body, Controller, Post, Get, Query, Param, HttpCode, InternalServerErrorException, HttpException, Res } from '@nestjs/common'
 import type { Response } from 'express'
 import { BattlesService } from '../service/battles.service'
 import { BattleResultResponseDto } from '../dto/battleResult.dto'
 import { BattleCreateQueryDto } from '../dto/battleCreateQuery.dto'
 import { BattleJoinInfoResponseDto } from '../dto/battleJoinResponse.dto'
 import { BattleListRequestQueryDto } from '../dto/battleListRequestQuery.dto'
-import { BATTLE_TYPE } from '../const/battles.const'
-import { InviteAccessGuard } from '../guards/inviteAccess.guard'
 
 @Controller('battles')
 export class BattlesController {
@@ -16,9 +14,9 @@ export class BattlesController {
   async createBattle(@Body() body: BattleCreateQueryDto, @Res() res: Response): Promise<void> {
     const battle = await this.battlesService.create(body)
 
-    if (battle.type === BATTLE_TYPE.PRIVATE) {
-      this.setInviteAccessCookie(battle.id, res)
-    }
+    // if (battle.type === BATTLE_TYPE.PRIVATE) {
+    //   this.setInviteAccessCookie(battle.id, res)
+    // }
 
     res.json({
       battleId: battle.id,
@@ -42,7 +40,7 @@ export class BattlesController {
     const { battleId } = await this.battlesService.getBattleByInviteCode(inviteCode)
 
     // 초대 코드로 접근했음을 쿠키에 기록
-    this.setInviteAccessCookie(battleId, res)
+    // this.setInviteAccessCookie(battleId, res)
 
     const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5173'
     return res.redirect(303, `${frontendUrl}/battle/${battleId}/team-select`)
@@ -50,7 +48,7 @@ export class BattlesController {
 
   @Post(':id/join')
   @HttpCode(200)
-  @UseGuards(InviteAccessGuard)
+  // @UseGuards(InviteAccessGuard) // 임시로 주석 처리, 공개/비공개 구별 시 활성화
   async joinBattleInfo(@Param('id') battleId: string): Promise<BattleJoinInfoResponseDto> {
     return this.battlesService.joinBattleInfo(battleId)
   }

--- a/backend/src/battles/controller/battles.controller.ts
+++ b/backend/src/battles/controller/battles.controller.ts
@@ -1,10 +1,12 @@
-import { Body, Controller, Post, Get, Query, Param, HttpCode, InternalServerErrorException, HttpException, Res } from '@nestjs/common'
+import { Body, Controller, Post, Get, Query, Param, HttpCode, InternalServerErrorException, HttpException, Res, UseGuards } from '@nestjs/common'
 import type { Response } from 'express'
 import { BattlesService } from '../service/battles.service'
 import { BattleResultResponseDto } from '../dto/battleResult.dto'
 import { BattleCreateQueryDto } from '../dto/battleCreateQuery.dto'
 import { BattleJoinInfoResponseDto } from '../dto/battleJoinResponse.dto'
 import { BattleListRequestQueryDto } from '../dto/battleListRequestQuery.dto'
+import { InviteAccessGuard } from '../guards/inviteAccess.guard'
+import { BATTLE_TYPE } from '../const/battles.const'
 
 @Controller('battles')
 export class BattlesController {
@@ -14,9 +16,9 @@ export class BattlesController {
   async createBattle(@Body() body: BattleCreateQueryDto, @Res() res: Response): Promise<void> {
     const battle = await this.battlesService.create(body)
 
-    // if (battle.type === BATTLE_TYPE.PRIVATE) {
-    //   this.setInviteAccessCookie(battle.id, res)
-    // }
+    if (battle.type === BATTLE_TYPE.PRIVATE) {
+      this.setInviteAccessCookie(battle.id, res)
+    }
 
     res.json({
       battleId: battle.id,
@@ -40,7 +42,7 @@ export class BattlesController {
     const { battleId } = await this.battlesService.getBattleByInviteCode(inviteCode)
 
     // 초대 코드로 접근했음을 쿠키에 기록
-    // this.setInviteAccessCookie(battleId, res)
+    this.setInviteAccessCookie(battleId, res)
 
     const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5173'
     return res.redirect(303, `${frontendUrl}/battle/${battleId}/team-select`)
@@ -48,7 +50,7 @@ export class BattlesController {
 
   @Post(':id/join')
   @HttpCode(200)
-  // @UseGuards(InviteAccessGuard) // 임시로 주석 처리, 공개/비공개 구별 시 활성화
+  @UseGuards(InviteAccessGuard)
   async joinBattleInfo(@Param('id') battleId: string): Promise<BattleJoinInfoResponseDto> {
     return this.battlesService.joinBattleInfo(battleId)
   }

--- a/backend/src/battles/dto/battleCreateQuery.dto.ts
+++ b/backend/src/battles/dto/battleCreateQuery.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsBoolean, IsIn, IsNotEmpty, IsString } from 'class-validator'
+import { IsArray, IsIn, IsNotEmpty, IsString } from 'class-validator'
 import type { BattleLanguage, BattleCategory, BattleType, BattlePlayTimeName } from '../types/battles.types'
 
 export class BattleCreateQueryDto {
@@ -43,8 +43,4 @@ export class BattleCreateQueryDto {
   @IsString({ each: true })
   @IsNotEmpty()
   topics: string[]
-
-  @IsBoolean()
-  @IsNotEmpty()
-  isPrivate!: boolean
 }

--- a/backend/src/battles/dto/battleCreateQuery.dto.ts
+++ b/backend/src/battles/dto/battleCreateQuery.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsIn, IsNotEmpty, IsString } from 'class-validator'
+import { IsArray, IsBoolean, IsIn, IsNotEmpty, IsString } from 'class-validator'
 import type { BattleLanguage, BattleCategory, BattleType, BattlePlayTimeName } from '../types/battles.types'
 
 export class BattleCreateQueryDto {
@@ -43,4 +43,8 @@ export class BattleCreateQueryDto {
   @IsString({ each: true })
   @IsNotEmpty()
   topics: string[]
+
+  @IsBoolean()
+  @IsNotEmpty()
+  isPrivate!: boolean
 }

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -380,7 +380,7 @@ export class BattlesService extends EventEmitter {
     const now = new Date()
     const battleId = this.generateId()
     const shuffledTopics = this.shuffleTopics(payload.topics, payload.playTime)
-    const isPrivate = payload.isPrivate
+    const isPrivate = payload.type === BATTLE_TYPE.PRIVATE
 
     // AI 참고 자료 생성 (실패해도 배틀 생성은 진행)
     let referenceData: BattleReferenceData | null = null

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -380,7 +380,7 @@ export class BattlesService extends EventEmitter {
     const now = new Date()
     const battleId = this.generateId()
     const shuffledTopics = this.shuffleTopics(payload.topics, payload.playTime)
-    const isPrivate = true
+    const isPrivate = payload.isPrivate
 
     // AI 참고 자료 생성 (실패해도 배틀 생성은 진행)
     let referenceData: BattleReferenceData | null = null
@@ -443,7 +443,7 @@ export class BattlesService extends EventEmitter {
   //실시간 배틀 목록 조회
   async getOpenBattles(limit: number, offset: number) {
     const where = {
-      // isPrivate: false,
+      isPrivate: false,
       status: { in: [BATTLE_STATUS.OPEN, BATTLE_STATUS.PENDING] },
     }
 

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -397,7 +397,8 @@ export class BattlesService extends EventEmitter {
     } catch {
       // AI 참고 자료 생성 실패 시 null로 유지하고 배틀 생성은 계속 진행
     }
-    const inviteCode = this.generateInviteCode()
+
+    const inviteCode = isPrivate ? this.generateInviteCode() : null
 
     const created = await this.prisma.battle.create({
       data: {

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -443,7 +443,7 @@ export class BattlesService extends EventEmitter {
   //실시간 배틀 목록 조회
   async getOpenBattles(limit: number, offset: number) {
     const where = {
-      isPrivate: false,
+      // isPrivate: false,
       status: { in: [BATTLE_STATUS.OPEN, BATTLE_STATUS.PENDING] },
     }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider, redirect } from 'react-router-dom';
 import BattleCreatePage from './pages/battleCreatePage';
 import MainPage from './pages/mainPage';
 import BattlePage from './pages/battlePage';
@@ -12,22 +12,16 @@ import NicknamePage from './pages/nicknamePage';
 import OnboardingPage from './pages/onboardingPage';
 import TutorialTeamSelectPage from './pages/tutorialTeamSelectPage';
 import TutorialBattlePage from './pages/tutorialBattlePage';
-import { useAuthStore } from './commons/stores/authStore';
+import { TUTORIAL_BATTLE_INFO } from './pages/tutorial/const/tutorialBattle';
 import { ToastContainer } from './commons/components/toast/ToastContainer';
 import ErrorPage from './pages/errorPage';
-import { useEffect } from 'react';
-import { TUTORIAL_BATTLE_INFO } from './pages/tutorial/const/tutorialBattle';
+import { useAuthStore } from './commons/stores/authStore';
 
 const router = createBrowserRouter([
   {
     path: '/',
     element: <MainPage />,
-    errorElement: <ErrorPage />,
-    loader: async () => {
-      // OAuth 로그인 후 리다이렉트 시 인증 상태 확인
-      await useAuthStore.getState().getOAuthUser();
-      return null;
-    }
+    errorElement: <ErrorPage />
   },
   {
     path: '/onboarding',
@@ -76,7 +70,15 @@ const router = createBrowserRouter([
   {
     path: '/battle/create',
     element: <BattleCreatePage />,
-    errorElement: <ErrorPage />
+    errorElement: <ErrorPage />,
+    loader: async () => {
+      const oauthUser = await useAuthStore.getState().getOAuthUser();
+      if (!oauthUser) {
+        alert('로그인이 필요합니다.');
+        return redirect('/login');
+      }
+      return null;
+    }
   },
   {
     path: '/tutorial/team-select',
@@ -103,14 +105,6 @@ const router = createBrowserRouter([
 ]);
 
 function App() {
-  useEffect(() => {
-    async function getUserInfo() {
-      await useAuthStore.getState().getOAuthUser();
-    }
-
-    getUserInfo();
-  }, []);
-
   return (
     <>
       <ToastContainer />

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -103,13 +103,14 @@ export default function BattleCreatePage() {
   return (
     <div className="min-h-screen w-full px-6 py-8">
       <div className="mx-auto create-max-width">
-        <button
-          type="button"
-          onClick={() => navigate(-1)}
-          className="text-sm text-gray-300 hover:text-white transition-colors"
-        >
-          ← 뒤로 가기
-        </button>
+        <div className="flex items-center justify-start gap-4 mt-10 mb-8">
+          <button
+            onClick={() => navigate(-1)}
+            className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors shrink-0 text-sm w-[100px] sm:w-auto sm:min-w-[100px]"
+          >
+            ← 돌아가기
+          </button>
+        </div>
 
         <div className="mt-4 rounded-2xl border border-[#2b2b3e] bg-[#121226] shadow-[0_18px_35px_rgba(0,0,0,0.35)]">
           <div className="h-1 w-full rounded-t-2xl bg-orange-500" />

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -22,10 +22,10 @@ const PLAYTIME_OPTIONS: Array<{ label: string; value: BattlePlayTime; rounds: nu
   { label: '30분', value: 'THIRTY_MIN', rounds: 2 }
 ];
 
-// const VISIBILITY_OPTIONS: Array<{ label: string; value: BattleType }> = [
-//   { label: '공개', value: 'PUBLIC' },
-//   { label: '비공개', value: 'PRIVATE' }
-// ];
+const VISIBILITY_OPTIONS: Array<{ label: string; value: BattleType }> = [
+  { label: '공개', value: 'PUBLIC' },
+  { label: '비공개', value: 'PRIVATE' }
+];
 
 export default function BattleCreatePage() {
   const navigate = useNavigate();
@@ -49,7 +49,7 @@ export default function BattleCreatePage() {
   const [category, setCategory] = useState(categoryOptions[0]?.value ?? 'ALGORITHM');
   const [playTime, setPlayTime] = useState<BattlePlayTime>('FIFTEEN_MIN');
   const [topics, setTopics] = useState<string[]>([]);
-  const [type] = useState<BattleType>('PRIVATE'); // 현재는 비공개만
+  const [type, setType] = useState<BattleType>('PRIVATE');
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -220,7 +220,7 @@ export default function BattleCreatePage() {
                 </div>
               </div>
 
-              {/* <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                 <div className="space-y-2">
                   <label className="text-sm text-gray-300">배틀 공개 여부</label>
                   <select
@@ -228,14 +228,14 @@ export default function BattleCreatePage() {
                     onChange={(e) => setType(e.target.value as BattleType)}
                     className="w-full rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-orange-500/60"
                   >
-                    {VISIBILITY_OPTIONS.map((o) => (
+                    {VISIBILITY_OPTIONS.map((o: { label: string; value: BattleType }) => (
                       <option key={o.value} value={o.value}>
                         {o.label}
                       </option>
                     ))}
                   </select>
                 </div>
-              </div> */}
+              </div>
 
               <BattleTopicInput rounds={rounds} selectedTopics={topics} onTopicsChange={setTopics} />
 

--- a/frontend/src/pages/mainPage/index.tsx
+++ b/frontend/src/pages/mainPage/index.tsx
@@ -4,6 +4,7 @@ import { StatCard, LiveBattleCard, BattleCategoryCard, PastBattleCard } from './
 import { type BattleCardItem, type ClosedBattleItem, BATTLE_CATEGORY_CONFIG } from './types/battle';
 import BattleIcon from '@/assets/icon/battle.svg?react';
 import Header from '@/commons/components/Header';
+import { useAuthStore } from '@/commons/stores/authStore';
 
 import { getOpenBattles, getClosedBattles } from './api/getBattleList';
 
@@ -15,6 +16,11 @@ export default function MainPage() {
 
   const [openTotal, setOpenTotal] = useState(0);
   const [closedTotal, setClosedTotal] = useState(0);
+
+  useEffect(() => {
+    // OAuth 로그인 후 리다이렉트 시 인증 상태 확인
+    useAuthStore.getState().getOAuthUser();
+  }, []);
 
   useEffect(() => {
     const fetchBattles = async () => {


### PR DESCRIPTION
## 🔗 관련 이슈
resolve #286

## ✅ 작업 내용
### 💡개선 사항
#### 배틀 생성 로직 개선
- 배틀 생성 시 공개 여부 선택 ui 다시 복구
   - 공개/비공개 배틀 구분 가능
#### 접근 제한
- 공개 배틀은 메인화면에서 조회하여 battleID로 바로 접속 가능
- 비공개 배틀은 메인페이지에서 노출되지 않고, 초대링크로만 접근가능
- 비회원은 배틀 생성 페이지 접근 제한

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
