### PR TITLE
[Refactor] 스킵 기능 개선 (모달 딜레이, disabled 조건 설명)

### DIFF
--- a/frontend/src/pages/battlePage/components/effects/SkipModal.tsx
+++ b/frontend/src/pages/battlePage/components/effects/SkipModal.tsx
@@ -8,7 +8,7 @@ interface SkipModalProps {
 
 const ANIMATION_DURATION = {
   SHOW: 50,
-  AUTO_CLOSE: 3000,
+  AUTO_CLOSE: 2000,
   HIDE: 300
 } as const;
 

--- a/frontend/src/pages/battlePage/components/header/PhaseSkip.tsx
+++ b/frontend/src/pages/battlePage/components/header/PhaseSkip.tsx
@@ -44,7 +44,8 @@ export default function PhaseSkip({ phase, isSkipEnabled, toggleSkip, totalSkips
               group-hover:opacity-100 group-hover:translate-y-0
             "
           >
-            모든 인원이 스킵에 동의하면 페이즈가 넘어갑니다.
+            <div>모든 인원이 스킵에 동의하면 페이즈가 넘어갑니다.</div>
+            <div>배틀 대기 상태 및 진영 변경 시간에는 비활성화됩니다.</div>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/battlePage/components/header/index.tsx
+++ b/frontend/src/pages/battlePage/components/header/index.tsx
@@ -43,7 +43,7 @@ export default function BattleHeader({ isSkipEnabled, toggleSkip, totalSkips }: 
 
   return (
     <header
-      className="header-height main-width-closed bg-[#1E1E2F] rounded-lg mb-2 overflow-hidden flex flex-col"
+      className="header-height main-width-closed bg-[#1E1E2F] rounded-lg mb-2 flex flex-col"
       data-tutorial="phase-guide"
     >
       <div className="px-8 flex-1 grid grid-cols-3 items-center">

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -265,7 +265,7 @@ export default function BattlePage() {
             onClose={handleCloseTeamChangeModal}
           />
         )}
-        {effectModal.isOpen && effectModal.team !== 'NONE' && (
+        {!isPhaseSkipModalOpen && effectModal.isOpen && effectModal.team !== 'NONE' && (
           <DiscussionModal
             isOpen={effectModal.isOpen}
             team={effectModal.team}
@@ -274,6 +274,7 @@ export default function BattlePage() {
             onClose={hideEffect}
           />
         )}
+        {isPhaseSkipModalOpen && <SkipModal isOpen={true} onClose={closeSkipModal} />}
         {isVoteResultModalOpen && voteResult && (
           <TeamVoteResultModal
             isOpen={isVoteResultModalOpen}
@@ -291,7 +292,6 @@ export default function BattlePage() {
         {roundModal.isPending && !isVoteResultModalOpen && (
           <RoundUpdateModal isOpen={true} round={roundModal.round} topic={roundModal.topic} onClose={hideRoundEffect} />
         )}
-        {isPhaseSkipModalOpen && <SkipModal isOpen={true} onClose={closeSkipModal} />}
         <TutorialModal
           isOpen={isTutorialOpen && currentStep === 'welcome'}
           onClose={skipTutorial}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

#290 

## ✅ 작업 내용

- [x] 스킵 툴팁에 추가 설명
<img width="1000" alt="스크린샷 2026-01-29 오전 9 30 45" src="https://github.com/user-attachments/assets/b0d3c0ba-5157-4c4e-9f2b-2e5e95927a61" />

- [x] 스킵 모달이 사라지면 이의제기 및 반박 모달이 생기도록 수정 (스킵 2초 / 이의제기 & 반박 3초)

![123123](https://github.com/user-attachments/assets/29d70ed5-fe6c-4693-b43a-ffbadf06ea57)

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->

이의제기 및 반박 모달이 등장하는 애니메이션이 포함되면 좋겠다고 생각해서 `스킵 모달 -> 이의제기 & 반박 모달` 이 생기도록 순서를 정했는데, 만약 딜레이가 너무 심하면 이전처럼 두 모달을 겹쳐서 생기게하고 스킵 모달의 딜레이를 짧게 설정해도 될 것 같습니다.
아래는 스킵 1.3초 반박은 3초(실질적으로 1.7초) 기준입니다.

![123](https://github.com/user-attachments/assets/25f94360-99c2-4e36-99df-e62601ef35d1)

