### PR TITLE
[Refactor] Relase 문서 내용 자동화 

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,8 +3,8 @@ changelog:
     - title: "🚀 기능"
       labels:
         - "task"
-        - "FE"
-        - "BE"
+        - "story"
+        - "epic"
 
     - title: "🛠 버그 수정"
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  categories:
+    - title: "🚀 기능"
+      labels:
+        - "task"
+
+    - title: "🛠 버그 수정"
+      labels:
+        - "fix"
+        - "test"
+
+    - title: "♻️ 리팩토링"
+      labels:
+        - "refactoring"
+
+    - title: "⚙️ 설정/인프라"
+      labels:
+        - "settings"
+        - "documentation"
+
+  exclude:
+    labels:
+      - "skip-changelog"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,6 +3,8 @@ changelog:
     - title: "🚀 기능"
       labels:
         - "task"
+        - "FE"
+        - "BE"
 
     - title: "🛠 버그 수정"
       labels:

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -130,21 +130,13 @@ jobs:
       # === GitHub Release 생성 ===
       - name: Create GitHub Release
         if: steps.pr_labels.outputs.should_skip != 'true'
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.semver.outputs.version_tag }}
-          release_name: Release ${{ steps.semver.outputs.version_tag }}
-          body: |
-            ## Release ${{ steps.semver.outputs.version_tag }}
-            
-            ### Changes
-            - Merged PR: #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}
-            
-            ### Version Bump
-            - Type: ${{ steps.pr_labels.outputs.bump_type }}
-            - Previous version: ${{ steps.get_latest_tag.outputs.latest_tag }}
-            - New version: ${{ steps.semver.outputs.version_tag }}
+          name: Release ${{ steps.semver.outputs.version_tag }}
+          generate_release_notes: true
+          previous_tag: ${{ steps.get_latest_tag.outputs.latest_tag }}
           draft: false
           prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->
resolve #287 

## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

- GitHub Release 자동 생성 시 `generate_release_notes` 옵션 적용
- `.github/release.yml`을 추가하여 PR라벨에 따라 릴리즈 노트 카테고리(기능/버그/리팩토링/설정) 분류
- release 브랜치 머지 시 태그 기반으로 여러 PR을 묶어 릴리즈 노트가 생성되도록 개선

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

| 테스트 release 노트 |
|--|
| <img width="1201" height="770" alt="image" src="https://github.com/user-attachments/assets/69e32c08-2a42-4555-88eb-010db8f1fb0e" /> |

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
### 🏷 PR 라벨
PR 라벨을 기준으로 릴리즈 노트가 분류되므로, dev에 머지할 때 라벨을 꼭 붙여주시길 바랍니다! Assignees 도 잊지마세여
| PR 라벨 | Release Note 분류 |
|--------|------------------|
| `task` | 🚀 기능 |
| `fix`, `test` | 🛠 버그 수정 |
| `refactoring` | ♻️ 리팩토링 |
| `settings`, `documentation` | ⚙️ 설정 / 인프라 |