### PR TITLE
 [Fix] 배틀 결과 페이지 UI 버그 수정

### DIFF
--- a/frontend/src/pages/battleResultPage/components/TimelineSection.tsx
+++ b/frontend/src/pages/battleResultPage/components/TimelineSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import RoundCard from '@/commons/components/timeline/RoundCard';
 import { getTimeAgo } from '@/commons/utils/getTimeAgo';
 import { organizeTimelineByRounds } from '../utils/organizeTimelineByRounds';
@@ -10,6 +11,14 @@ interface TimelineSectionProps {
 
 export default function TimelineSection({ timelines, topics }: TimelineSectionProps) {
   const roundsData = organizeTimelineByRounds({ timelines, topics });
+  const [expandedRounds, setExpandedRounds] = useState<Record<string, boolean>>({});
+
+  const handleToggle = (round: string) => {
+    setExpandedRounds((prev) => ({
+      ...prev,
+      [round]: !prev[round]
+    }));
+  };
 
   const formatTime = (timestamp?: number) => {
     if (!timestamp) return '알 수 없음';
@@ -28,8 +37,8 @@ export default function TimelineSection({ timelines, topics }: TimelineSectionPr
             <RoundCard
               key={roundData.round}
               roundData={roundData}
-              isExpanded={true}
-              onToggle={() => {}}
+              isExpanded={expandedRounds[roundData.round] ?? false}
+              onToggle={() => handleToggle(roundData.round)}
               formatTime={formatTime}
               showStatus={false}
             />

--- a/frontend/src/pages/battleResultPage/components/WinnerSection.tsx
+++ b/frontend/src/pages/battleResultPage/components/WinnerSection.tsx
@@ -8,6 +8,21 @@ interface WinnerSectionProps {
   teamBVotes: number;
 }
 
+const WINNER_STYLES = {
+  A: {
+    gradient: 'bg-gradient-to-br from-[#155DFC] to-[#1447E6]',
+    shadow: 'shadow-blue-500/40'
+  },
+  B: {
+    gradient: 'bg-gradient-to-br from-[#DC2626] to-[#B91C1C]',
+    shadow: 'shadow-red-500/40'
+  },
+  DRAW: {
+    gradient: 'bg-gradient-to-br from-[#4B5563] to-[#374151]',
+    shadow: 'shadow-gray-500/40'
+  }
+} as const;
+
 export default function WinnerSection({
   winner,
   teamAPercentage,
@@ -16,10 +31,11 @@ export default function WinnerSection({
   teamBVotes
 }: WinnerSectionProps) {
   const winnerTeam = winner === 'A' ? 'A' : winner === 'B' ? 'B' : '무승부';
+  const style = WINNER_STYLES[winner];
 
   return (
     <div className="max-w-7xl mx-auto mb-12">
-      <div className="bg-gradient-to-br from-[#155DFC] to-[#1447E6] rounded-3xl p-8 md:p-12 text-center shadow-2xl shadow-blue-500/40">
+      <div className={`${style.gradient} rounded-3xl p-8 md:p-12 text-center shadow-2xl ${style.shadow}`}>
         <div className="flex justify-center mb-4">
           <TrophyIcon className="w-[48px] h-[48px]" />
         </div>

--- a/frontend/src/pages/battleResultPage/index.tsx
+++ b/frontend/src/pages/battleResultPage/index.tsx
@@ -41,6 +41,12 @@ export default function BattleResultPage() {
 
   const { result } = battleData;
 
+  const totalVotesWithoutNeutral = result.teamA.votes + result.teamB.votes;
+  const teamAPercentageWithoutNeutral =
+    totalVotesWithoutNeutral > 0 ? Math.round((result.teamA.votes / totalVotesWithoutNeutral) * 100) : 0;
+  const teamBPercentageWithoutNeutral =
+    totalVotesWithoutNeutral > 0 ? Math.round((result.teamB.votes / totalVotesWithoutNeutral) * 100) : 0;
+
   return (
     <div className="min-h-screen text-white p-6 md:p-10">
       <header className="text-center mb-10">
@@ -53,9 +59,9 @@ export default function BattleResultPage() {
 
       <WinnerSection
         winner={result.winner}
-        teamAPercentage={result.teamA.percentage}
+        teamAPercentage={teamAPercentageWithoutNeutral}
         teamAVotes={result.teamA.votes}
-        teamBPercentage={result.teamB.percentage}
+        teamBPercentage={teamBPercentageWithoutNeutral}
         teamBVotes={result.teamB.votes}
       />
 


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #295

## ✅ 작업 내용

### 💡개선 사항
- WinnerSection 승리 진영에 따른 배경색 변경 (A팀: 파랑, B팀: 빨강, 무승부: 회색)
- TimelineSection 기본 접힌 상태로 변경 및 토글 기능 활성화
- WinnerSection 투표 비율에서 중립 제외하여 A/B만으로 100% 계산

<br />

## 📸 참고 사항
- `WinnerSection.tsx`: WINNER_STYLES 객체로 승자별 스타일 관리
- `TimelineSection.tsx`: useState로 라운드별 펼침 상태 관리, 기본값 false
- `index.tsx`: 중립 제외 비율 계산 로직 추가 (VoteChart는 기존 중립 포함 비율 유지)
<img width="530" height="210" alt="image" src="https://github.com/user-attachments/assets/da4dcc66-f9fd-45f1-8cf5-b470b59c6fa3" />
<img width="525" height="200" alt="image" src="https://github.com/user-attachments/assets/ee65f808-11c0-48c3-8360-8033509ab218" />
<img width="525" height="200" alt="image" src="https://github.com/user-attachments/assets/d1e5becc-864d-4e7e-a8c9-773cbe58daa3" />
<img width="525" height="322" alt="image" src="https://github.com/user-attachments/assets/5299ec51-0b9a-4d89-97ab-ab784c20a06d" />
<img width="525" height="475" alt="image" src="https://github.com/user-attachments/assets/8e7edbca-8192-4313-8871-3dff193aefa4" />

<br />

## 💬 질문사항 (고민했던 부분)
- 타임라인에 토글 없애고 무조건 펼쳐놓을 시 홈페이지로 나가기 위해 스크롤을 많이 내려야 하므로 기본적으로 토글을 닫아 놓고 확인하고 싶은 사람만 열어서 확인하는 형태가 낫다고 판단해서 진행함
- 중립 제외 비율 계산을 백엔드가 아닌 프론트엔드에서 처리 (VoteChart와 WinnerSection이 다른 비율을 사용하기 때문)