### PR TITLE
[Fix] http환경에서 클립보드 적용

### DIFF
--- a/frontend/src/pages/battleCreatePage/components/InviteLinkButton.tsx
+++ b/frontend/src/pages/battleCreatePage/components/InviteLinkButton.tsx
@@ -11,9 +11,30 @@ export default function InviteLinkButton({ inviteCode }: InviteLinkProps) {
 
   const inviteLink = `${window.location.origin}/battles/${inviteCode}`;
 
+  // HTTPS 환경
+  const copyWithNavigator = async (text: string) => {
+    await navigator.clipboard.writeText(text);
+  };
+
+  // HTTP 환경
+  const copyWithExecCommand = (text: string) => {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+  };
+
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(inviteLink);
+      if (navigator.clipboard && window.isSecureContext) {
+        await copyWithNavigator(inviteLink);
+      } else {
+        copyWithExecCommand(inviteLink);
+      }
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (error) {

--- a/frontend/src/pages/battleCreatePage/components/test/InviteLinkButton.test.tsx
+++ b/frontend/src/pages/battleCreatePage/components/test/InviteLinkButton.test.tsx
@@ -9,6 +9,12 @@ Object.assign(navigator, {
   }
 });
 
+// window.isSecureContext를 true로 설정
+Object.defineProperty(window, 'isSecureContext', {
+  value: true,
+  writable: true
+});
+
 describe('InviteLinkButton', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -41,7 +47,7 @@ describe('InviteLinkButton', () => {
     fireEvent.click(button);
 
     await waitFor(() => {
-      const copiedText = screen.queryByText('복사됨');
+      const copiedText = screen.getByText('복사됨');
       expect(copiedText).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

resolve #300

## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->
- http 환경에서는 clipboard API를 사용할 수 없어서, 임시로 execCommand를 활용한 클립보드 기능을 구현
   - 우선 clipboardAPI로 클립보드 실행 후, 안되면 execCommand 클립보드 로직 실행
- https 적용 후에 해당 로직 제거
> execCommand는 현재 deprecated되어서 권장되진 않지만, 데모를 위해서 임시로 구현했습니다

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->
| 클립보드 복사 |
|--|
| <img width="810" height="287" alt="image" src="https://github.com/user-attachments/assets/dea06df7-aafe-4e3f-ad34-e677336c5825" />|
<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
