### PR TITLE
[Chore] release 문서 자동화 라벨명 변경

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,23 +2,23 @@ changelog:
   categories:
     - title: "🚀 기능"
       labels:
-        - "task"
-        - "story"
-        - "epic"
+        - "🎯 task"
+        - "📖 story"
+        - "⭐️ epic"
 
     - title: "🛠 버그 수정"
       labels:
-        - "fix"
-        - "test"
+        - "🔥 fix"
+        - "🪄 test"
 
     - title: "♻️ 리팩토링"
       labels:
-        - "refactoring"
+        - "🔍 refactoring"
 
     - title: "⚙️ 설정/인프라"
       labels:
-        - "settings"
-        - "documentation"
+        - "⚙️ settings"
+        - "📄 documentation"
 
   exclude:
     labels:


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->
resolve #287 
## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->
- release 문서에서 PR을 카테고라이징할 때 PR에 부착된 라벨을 기준으로 분류하는데, 기존 설정에는 라벨 이모지가 반영되지 않아 매칭이 되지 않음.  
- 라벨 이름(이모지 포함)과 changelog 설정을 동일하게 맞추도록 수정해 정상적으로 분류되도록 수정
 
<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
