### PR TITLE
[Fix] 영어로 채팅치면 개행이 안되는 문제

### DIFF
--- a/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
@@ -45,7 +45,7 @@ export default function ChatMessage({ user, team, content, timestamp, showTeamBa
         <span className="text-[0.688rem] text-[#666]">{getTimeAgo(timestamp)}</span>
       </div>
       <div className={`flex items-center gap-2 ${isYou ? 'flex-row-reverse' : ''}`}>
-        <div className={`${isYou ? 'bg-[#6B3410]' : 'bg-[#2D2D3F]'}  rounded-lg px-3 py-2 max-w-[17.5rem]`}>
+        <div className={`${isYou ? 'bg-[#6B3410]' : 'bg-[#2D2D3F]'}  rounded-lg px-3 py-2 max-w-[17.5rem] break-words`}>
           <p className="text-xs text-white text-left">{content}</p>
         </div>
       </div>


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #304 

## ✅ 작업 내용

CSS 를 통해 영어로 채팅을 작성해도 개행이 되도록 수정한다.

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<img width="553" height="508" alt="스크린샷 2026-01-29 오후 11 32 00" src="https://github.com/user-attachments/assets/b7c93dab-61e1-4210-b4a2-f9c2a724acc9" />



<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
