### PR TITLE
[Fix] 배틀 모달 깜빡임 효과 속도 감소

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -220,6 +220,20 @@
   animation: shake-fade-out 0.8s cubic-bezier(0.68, -0.55, 0.265, 1.55);
 }
 
+@keyframes pulse-slow {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 0.15;
+  }
+}
+
+.animate-pulse-slow {
+  animation: pulse-slow 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
 /* Custom styles */
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;

--- a/frontend/src/pages/battlePage/components/effects/DiscussionModal.tsx
+++ b/frontend/src/pages/battlePage/components/effects/DiscussionModal.tsx
@@ -71,7 +71,7 @@ export default function DiscussionModal({ isOpen, team, content, type, onClose }
         className={`relative flex flex-col items-center transition-all duration-500 ${scaleClass}`}
         onClick={handleClose}
       >
-        <div className={`absolute inset-0 blur-3xl bg-gradient-to-r ${gradient} opacity-30 animate-pulse`} />
+        <div className={`absolute inset-0 blur-3xl bg-gradient-to-r ${gradient} animate-pulse-slow`} />
 
         <div className="relative z-10 flex flex-col items-center gap-8">
           <div

--- a/frontend/src/pages/battlePage/components/effects/ObjectionModal.tsx
+++ b/frontend/src/pages/battlePage/components/effects/ObjectionModal.tsx
@@ -71,7 +71,7 @@ export default function DiscussionModal({ isOpen, team, content, type, onClose }
         className={`relative flex flex-col items-center transition-all duration-500 ${scaleClass}`}
         onClick={handleClose}
       >
-        <div className={`absolute inset-0 blur-3xl bg-gradient-to-r ${gradient} opacity-30 animate-pulse`} />
+        <div className={`absolute inset-0 blur-3xl bg-gradient-to-r ${gradient} animate-pulse-slow`} />
 
         <div className="relative z-10 flex flex-col items-center gap-8">
           <div

--- a/frontend/src/pages/battlePage/components/effects/TeamVoteResultModal.tsx
+++ b/frontend/src/pages/battlePage/components/effects/TeamVoteResultModal.tsx
@@ -67,7 +67,7 @@ export default function TeamVoteResultModal({
         className={`relative flex flex-col items-center transition-all duration-500 ${scaleClass}`}
         onClick={handleClose}
       >
-        <div className="absolute inset-0 blur-[6.25rem] bg-gradient-to-r from-orange-500 to-red-500 opacity-25 animate-pulse scale-125" />
+        <div className="absolute inset-0 blur-[6.25rem] bg-gradient-to-r from-orange-500 to-red-500 animate-pulse-slow scale-125" />
 
         <div className="flex flex-col items-center gap-16 min-w-[50rem]">
           <div


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #307

## ✅ 작업 내용

### 💡개선 사항
- 배틀 모달의 깜빡임 효과(animate-pulse) 속도를 2초에서 4초로 감소
- DiscussionModal, ObjectionModal, TeamVoteResultModal에 적용

<br />

## 📸 참고 사항
- `index.css`: animate-pulse-slow 커스텀 애니메이션 추가 (4초 주기)
- `DiscussionModal.tsx`: animate-pulse → animate-pulse-slow
- `ObjectionModal.tsx`: animate-pulse → animate-pulse-slow
- `TeamVoteResultModal.tsx`: animate-pulse → animate-pulse-slow

### 수정 전

https://github.com/user-attachments/assets/6b306e88-fa68-40f5-9d19-6bd59e609f41

### 수정 후

https://github.com/user-attachments/assets/80ab3c69-fcef-4947-bf7f-405956a9a0f2


<br />

## 💬 질문사항 (고민했던 부분)
- 개인적으로 사라졌다가 블러 처리되는 시간이 좀 길다고 느껴지는데 이 시간을 줄이는 것이 나을지