### PR TITLE
[Feature]: 메인 배틀 페이지에서 튜토리얼 로직/컴포넌트 제거

### DIFF
--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useParams, useLoaderData } from 'react-router-dom';
 import type { BattleInfo } from '@/commons/types/battle';
 import { useBattle } from './hooks/useBattle';
 import { useTeamVoteResult } from './hooks/useTeamVoteResult';
-import { useTutorial } from './hooks/useTutorial';
 import useModal from '@/commons/hooks/useModal';
 import { soundManager } from '@/commons/utils/soundManager';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from './stores/battleStore';
@@ -16,8 +15,6 @@ import DiscussionInput from './components/discussion/DiscussionInput';
 import DiscussionVote from './components/discussion/DiscussionVote';
 import BattleSidebar from './components/sidebar';
 import BookmarkButton from './components/sidebar/BookmarkButton';
-import TutorialModal from './components/tutorial/TutorialModal';
-import TutorialStepModal from './components/tutorial/TutorialStepModal';
 import TeamChangeModal from './components/modals/TeamChangeModal';
 import DiscussionModal from './components/effects/DiscussionModal';
 import BattleProgressBoard from './components/progressBoard/ProgressBoard';
@@ -38,7 +35,6 @@ export default function BattlePage() {
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
   const [activeSidebarTab, setActiveSidebarTab] = useState<Tab>('info');
-  const sidebarOpenedForTutorial = useRef(false);
   const user = useAuthStore(selectUser);
   const leaveBattle = useBattleStore((s) => s.leaveBattle);
   const battleProgress = useBattleStore(selectBattleProgress);
@@ -89,17 +85,6 @@ export default function BattlePage() {
     };
   }, [safeLeaveBattle]);
 
-  // 튜토리얼 관리
-  const {
-    isModalOpen: isTutorialOpen,
-    currentStep,
-    dontShowAgain,
-    startTutorial,
-    nextStep,
-    prevStep,
-    setDontShowAgain
-  } = useTutorial();
-
   // 사운드 초기화
   useEffect(() => {
     soundManager.preload('timerWarning', '/sounds/timerSound.wav');
@@ -121,22 +106,6 @@ export default function BattlePage() {
       soundManager.playBGM(BGM_OPTIONS[0].key);
     }
   }, []);
-
-  useEffect(() => {
-    const shouldOpenSidebar = isTutorialOpen && currentStep === 'sidebarPanel';
-
-    if (shouldOpenSidebar && !isSidebarOpen) {
-      setActiveSidebarTab('info');
-      handleOpenSidebar();
-      sidebarOpenedForTutorial.current = true;
-      return;
-    }
-
-    if (!shouldOpenSidebar && sidebarOpenedForTutorial.current) {
-      handleCloseSidebar();
-      sidebarOpenedForTutorial.current = false;
-    }
-  }, [currentStep, isSidebarOpen, isTutorialOpen, handleCloseSidebar, handleOpenSidebar]);
 
   const {
     isOpen: isTeamChangeModalOpen,
@@ -181,7 +150,6 @@ export default function BattlePage() {
           handleOpenSidebar();
         }}
         isOpen={isSidebarOpen}
-        highlight={isTutorialOpen && currentStep === 'sidebar'}
         hasReferenceData={!!battleInfo.referenceData}
       />
 
@@ -194,7 +162,6 @@ export default function BattlePage() {
         language={battleInfo.language}
         category={battleInfo.category}
         topics={battleInfo.topics}
-        raiseZIndex={isTutorialOpen && currentStep === 'sidebarPanel'}
         referenceData={battleInfo.referenceData}
         activeTab={activeSidebarTab}
         onActiveTabChange={setActiveSidebarTab}
@@ -290,18 +257,6 @@ export default function BattlePage() {
         {roundModal.isPending && !isVoteResultModalOpen && (
           <RoundUpdateModal isOpen={true} round={roundModal.round} topic={roundModal.topic} onClose={hideRoundEffect} />
         )}
-        <TutorialModal
-          isOpen={isTutorialOpen && currentStep === 'welcome'}
-          onStart={startTutorial}
-          dontShowAgain={dontShowAgain}
-          onDontShowAgainChange={setDontShowAgain}
-        />
-        <TutorialStepModal
-          isOpen={isTutorialOpen && currentStep !== 'welcome' && currentStep !== 'completed'}
-          currentStep={currentStep}
-          onNext={nextStep}
-          onPrev={prevStep}
-        />
       </div>
     </div>
   );


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->
Closes #312 
## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

튜토리얼 페이지에서 튜토리얼을 제공하므로 메인 배틀 페이지에서는 튜토리얼을 표시하지 않도록 수정

`frontend/src/pages/battlePage/index.tsx`
- 튜토리얼 모달/스텝 모달, useTutorial 훅, 튜토리얼 사이드바 제어 효과 제거
- 사이드바 props도 일반 상태만 유지

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
