### PR TITLE
[Fix] 이의제기 목록에 투표 시 애니메이션 제거

### DIFF
--- a/frontend/src/pages/battlePage/components/discussion/DiscussionVote.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionVote.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef, useState } from 'react';
 import ScaleIcon from '@/assets/icon/scale.svg?react';
 import DiscussionVoteItem from './DiscussionVoteItem';
 import { isMyTeamAttacking } from '../../utils/battlePhase';
@@ -25,34 +24,8 @@ export default function DiscussionVote({ onVote }: DiscussionVoteProps) {
   const battleProgress = useBattleStore(selectBattleProgress);
   const team = useBattleStore(selectSelectedTeam);
 
-  const [animatingIds, setAnimatingIds] = useState<Set<number>>(new Set());
-  const prevVotesRef = useRef<Map<number, number>>(new Map());
-
   const phase = battleProgress?.phase;
   const isAttacking = isMyTeamAttacking(team, phase);
-
-  // 투표수 변경 감지하여 애니메이션 트리거
-  useEffect(() => {
-    const changedIds = new Set<number>();
-
-    discussions.forEach((discussion) => {
-      const prevVotes = prevVotesRef.current.get(discussion.id);
-      if (prevVotes !== undefined && prevVotes !== discussion.votes) {
-        changedIds.add(discussion.id);
-      }
-      prevVotesRef.current.set(discussion.id, discussion.votes);
-    });
-
-    if (changedIds.size > 0) {
-      setAnimatingIds(changedIds);
-
-      const timer = setTimeout(() => {
-        setAnimatingIds(new Set());
-      }, 800);
-
-      return () => clearTimeout(timer);
-    }
-  }, [discussions]);
 
   // ATTACK/DEFENSE 외 단계에서는 표시하지 않음
   if (phase !== 'ATTACK' && phase !== 'DEFENSE') {
@@ -87,27 +60,18 @@ export default function DiscussionVote({ onVote }: DiscussionVoteProps) {
         <div className="space-y-3 max-h-[280px] xl:max-h-[320px] min-[1920px]:max-h-[360px] overflow-y-auto pr-2 scrollbar-thin scrollbar-thumb-purple-500/50 scrollbar-track-transparent">
           {discussions
             .sort((a, b) => b.votes - a.votes)
-            .map((discussion) => {
-              const isAnimating = animatingIds.has(discussion.id);
-              return (
-                <div
-                  key={discussion.id}
-                  className={`transition-all duration-300 ${
-                    isAnimating ? 'animate-[fadeOut_0.4s_ease-in-out,fadeIn_0.4s_0.4s_ease-in-out]' : ''
-                  }`}
-                >
-                  <DiscussionVoteItem
-                    user={discussion.user}
-                    team={discussion.team}
-                    content={discussion.content}
-                    votes={discussion.votes}
-                    totalVotes={discussion.totalVotes}
-                    hasVoted={discussion.hasVoted}
-                    onVote={() => onVote(discussion.id)}
-                  />
-                </div>
-              );
-            })}
+            .map((discussion) => (
+              <DiscussionVoteItem
+                key={discussion.id}
+                user={discussion.user}
+                team={discussion.team}
+                content={discussion.content}
+                votes={discussion.votes}
+                totalVotes={discussion.totalVotes}
+                hasVoted={discussion.hasVoted}
+                onVote={() => onVote(discussion.id)}
+              />
+            ))}
         </div>
       </div>
       <div className="py-4 bg-gradient-to-r from-[#1C398E] to-[#59168B] border-t border-[#2D2D3F] flex items-center justify-center gap-2 text-sm">

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionVoteItem.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionVoteItem.tsx
@@ -43,7 +43,7 @@ export default function DiscussionVoteItem({
         </div>
       </div>
 
-      <p className="text-sm text-white mb-3">{content}</p>
+      <p className="text-sm text-white mb-3 break-words">{content}</p>
 
       <div className="space-y-2">
         <div className="flex items-center gap-2">

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionVoteItem.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionVoteItem.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useRef, useState } from 'react';
-
 interface DiscussionVoteItemProps {
   user: string;
   team: 'A' | 'B';
@@ -19,18 +17,6 @@ export default function DiscussionVoteItem({
   hasVoted,
   onVote
 }: DiscussionVoteItemProps) {
-  const [isAnimating, setIsAnimating] = useState(false);
-  const prevVotesRef = useRef(votes);
-
-  useEffect(() => {
-    if (prevVotesRef.current !== votes) {
-      setIsAnimating(true);
-      const timer = setTimeout(() => setIsAnimating(false), 500);
-      prevVotesRef.current = votes;
-      return () => clearTimeout(timer);
-    }
-  }, [votes]);
-
   const getVotePercentage = (votes: number, total: number) => {
     if (total === 0) return 0;
     return Math.round((votes / total) * 100);
@@ -42,9 +28,7 @@ export default function DiscussionVoteItem({
       disabled={hasVoted}
       className={`w-full p-3 rounded-lg border text-left transition-all ${
         hasVoted ? 'bg-[#1E3A2E] border-[#2ECC71]' : 'bg-[#2D2D3F] border-[#3D3D4F] hover:border-[#4D4D5F]'
-      } ${!hasVoted ? 'cursor-pointer' : 'cursor-default'} ${
-        isAnimating ? 'animate-[fadeOut_0.2s_ease-in-out,fadeIn_0.2s_0.2s_ease-in-out]' : ''
-      }`}
+      } ${!hasVoted ? 'cursor-pointer' : 'cursor-default'}`}
     >
       <div className="flex items-start justify-between mb-2">
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #307

## ✅ 작업 내용

### 💡개선 사항
- 이의제기/반론 목록에서 투표 시 발생하던 깜빡임(fadeOut/fadeIn) 애니메이션 제거
- `DiscussionVote.tsx`: animatingIds 상태 및 투표 변경 감지 useEffect 제거
- `DiscussionVoteItem.tsx`: isAnimating 상태 및 fadeOut/fadeIn 애니메이션 클래스 제거
- DiscussionVoteItem content에 break-words 추가하여 영어 개행 문제 수정

<br />

## 📸 참고 사항
- 투표 시 깜빡임 없이 바로 상태가 반영됨
- 다른 모달(이의제기 모달, 라운드 결과 모달 등)의 애니메이션은 변경하지 않음

<br />

## 💬 질문사항 (고민했던 부분)
- 없음