### PR TITLE
[Fix] 영어 개행 안 되는 문제

### DIFF
--- a/frontend/src/commons/components/timeline/RoundCard/MessageCard.tsx
+++ b/frontend/src/commons/components/timeline/RoundCard/MessageCard.tsx
@@ -34,7 +34,7 @@ export default function MessageCard({ message, team, formatTime }: MessageCardPr
         <span className="text-gray-500 text-xs">{formatTime(new Date(message.createdAt).getTime())}</span>
       </div>
 
-      <p className="text-gray-300 mb-4 leading-relaxed text-sm">{message.content}</p>
+      <p className="text-gray-300 mb-4 leading-relaxed text-sm break-all">{message.content}</p>
       <div
         className={`flex items-center gap-2 px-4 py-2 rounded-lg border-2 w-fit ${
           isTeamA ? 'bg-blue-600/20 border-blue-500/30' : 'bg-red-600/20 border-red-500/30'

--- a/frontend/src/pages/battlePage/components/modals/TeamChangeModal/TimelineMessage.tsx
+++ b/frontend/src/pages/battlePage/components/modals/TeamChangeModal/TimelineMessage.tsx
@@ -38,7 +38,7 @@ export default function TimelineMessage({ message, team, type }: TimelineMessage
       </div>
 
       {/* 메시지 내용 */}
-      <p className="text-gray-300 leading-relaxed text-sm">{message.content}</p>
+      <p className="text-gray-300 leading-relaxed text-sm break-words">{message.content}</p>
     </div>
   );
 }

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/MessageCard.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/MessageCard.tsx
@@ -34,7 +34,7 @@ export default function MessageCard({ message, team, type }: MessageCardProps) {
           <span className="text-gray-500 text-[0.625rem]">{message.upvotes}명 지지</span>
         </div>
       </div>
-      <p className="text-gray-300 mb-2 leading-relaxed text-[0.688rem] break-words">{message.content}</p>
+      <p className="text-gray-300 mb-2 leading-relaxed text-[0.688rem] break-all">{message.content}</p>
     </div>
   );
 }

--- a/frontend/src/pages/battleResultPage/components/MvpCard.tsx
+++ b/frontend/src/pages/battleResultPage/components/MvpCard.tsx
@@ -67,7 +67,7 @@ export default function MvpCard({ mvpList, bestOpinion }: MvpCardProps) {
                   <Award className="w-4 h-4 text-yellow-300 flex-shrink-0 mt-1" />
                   <div className="flex-1 text-left">
                     <div className="text-white/90 text-xs font-medium mb-1">가장 많은 좋아요를 받은 의견</div>
-                    <p className="text-white text-sm leading-relaxed">{bestOpinion.content}</p>
+                    <p className="text-white text-sm leading-relaxed break-all">{bestOpinion.content}</p>
                   </div>
                 </div>
                 <div className="flex items-center justify-end gap-2 mt-3 pt-3 border-t border-white/10">

--- a/frontend/src/pages/teamSelectPage/components/TimelineItem.tsx
+++ b/frontend/src/pages/teamSelectPage/components/TimelineItem.tsx
@@ -90,12 +90,12 @@ export default function TimelineItem({
             <span className="text-[#4CAF50] text-xs font-semibold">이의제기</span>
             <span className="text-[#99A1AF] text-xs">by {relatedAttack.author}</span>
           </div>
-          <p className="text-[#B0B0B0] text-xs line-clamp-2">{relatedAttack.content}</p>
+          <p className="text-[#B0B0B0] text-xs line-clamp-2 break-words">{relatedAttack.content}</p>
         </div>
       )}
 
       {/* 내용 */}
-      <p className="text-[#E0E0E0] text-sm mb-3">{content}</p>
+      <p className="text-[#E0E0E0] text-sm mb-3 break-words">{content}</p>
 
       {/* 좋아요 */}
       <div className="flex items-center gap-1">

--- a/frontend/src/pages/teamSelectPage/components/steps/Step1BattleInfo.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/Step1BattleInfo.tsx
@@ -81,10 +81,10 @@ export default function Step1BattleInfo({
         {/* 배틀 정보 카드 */}
         <div className="bg-[#16162a] rounded-lg battle-info-card-padding border border-[#2d2d3f] mb-4 shadow-lg w-full">
           <div className="flex items-center gap-2 mb-3">
-            <Swords className="battle-info-swords-size text-orange-500" />
-            <h3 className="text-white battle-info-title-size font-bold">{title}</h3>
+            <Swords className="battle-info-swords-size text-orange-500 flex-shrink-0" />
+            <h3 className="text-white battle-info-title-size font-bold break-words min-w-0 text-left">{title}</h3>
           </div>
-          <p className="text-gray-400 battle-info-desc-size mb-4 text-left">{description}</p>
+          <p className="text-gray-400 battle-info-desc-size mb-4 text-left break-words">{description}</p>
           <div className="flex flex-wrap gap-3">
             <div className="flex flex-col gap-1">
               <span className="text-xs text-gray-500">카테고리</span>


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #315

## ✅ 작업 내용

### 💡개선 사항
- 여러 화면에서 영어 텍스트가 개행되지 않는 문제 수정
- 진영 선택 페이지: 제목/설명에 `break-words`, `min-w-0` 추가
- 진영 선택 페이지: 타임라인 content에 `break-words` 추가
- 팀 변경 모달: 타임라인 메시지에 `break-words` 추가
- 사이드바 타임라인: 메시지에 `break-all` 추가
- MVP 카드: 최고 의견에 `break-all` 추가
- 배틀 결과 페이지: 타임라인 메시지에 `break-all` 추가

<br />

## 📸 참고 사항
- `break-words`: 단어 단위로 개행 (가능하면 단어를 유지)
- `break-all`: 글자 단위로 강제 개행 (긴 영어 단어도 잘림)
- flex 컨테이너 내 텍스트 개행을 위해 `min-w-0` 추가 필요

<br />

## 💬 질문사항 (고민했던 부분)
- mvp 카드에서 길어지면 어떻게 처리할 것인가?
  - 일정 길이 이상의 텍스트면 생략하고 ...으로 표시하기?