### PR TITLE
[Feature] 소켓 에러 핸들링 전략 적용 및 재연결 로직을 구현한다.

### DIFF
--- a/frontend/src/pages/battlePage/components/header/StageIndicator.tsx
+++ b/frontend/src/pages/battlePage/components/header/StageIndicator.tsx
@@ -59,7 +59,7 @@ export default function StageIndicator() {
   const battleInfo = useLoaderData<BattleInfo>();
   if (!battleProgress) return;
 
-  const topics = battleInfo.topics;
+  const topics = battleInfo?.topics || [];
   const { round, phaseCount } = battleProgress;
   const phase = (battleProgress?.phase as BattlePhase) || 'PENDING';
   const { IconComponent, category, message, container, icon } = PHASE_CONFIG[phase] || PHASE_CONFIG.PENDING;

--- a/frontend/src/pages/battlePage/components/modals/ConnectionErrorModal.tsx
+++ b/frontend/src/pages/battlePage/components/modals/ConnectionErrorModal.tsx
@@ -1,0 +1,89 @@
+import { useBattleStore } from '../../stores/battleStore';
+
+interface ModalContent {
+  title: string;
+  message: string;
+  showSpinner: boolean;
+  showReconnectButton: boolean;
+}
+
+export default function ConnectionErrorModal() {
+  const connectionError = useBattleStore((state) => state.connectionError);
+  const socket = useBattleStore((state) => state.socket);
+
+  if (!connectionError.type) return null;
+
+  const getModalContent = (): ModalContent | null => {
+    const { type, message } = connectionError;
+
+    switch (type) {
+      case 'disconnected':
+        return {
+          title: '연결 끊김',
+          message,
+          showSpinner: false,
+          showReconnectButton: false
+        };
+
+      case 'reconnecting':
+        return {
+          title: '재연결 중',
+          message,
+          showSpinner: true,
+          showReconnectButton: false
+        };
+
+      case 'failed':
+        return {
+          title: '연결 실패',
+          message,
+          showSpinner: false,
+          showReconnectButton: true
+        };
+
+      default:
+        return null;
+    }
+  };
+
+  const content = getModalContent();
+  if (!content) return null;
+
+  const handleReconnect = () => {
+    socket?.connect();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm select-none">
+      <div
+        className="relative rounded-2xl bg-gradient-to-br from-[#1a1f2e] to-[#0f1419] p-8 shadow-2xl border border-[#2B7FFF]/30"
+        style={{ minWidth: '420px', maxWidth: '500px' }}
+      >
+        <div className="mb-6 text-center">
+          <h2 className="text-3xl font-bold text-white select-none">{content.title}</h2>
+        </div>
+
+        {content.showSpinner && (
+          <div className="mb-6 flex justify-center">
+            <div className="h-16 w-16 animate-spin rounded-full border-4 border-[#2B7FFF]/20 border-t-[#2B7FFF]" />
+          </div>
+        )}
+
+        <div className="mb-8 text-center px-4">
+          <p className="text-lg text-gray-300 leading-relaxed select-none">{content.message}</p>
+        </div>
+
+        {content.showReconnectButton && (
+          <div className="flex justify-center">
+            <button
+              onClick={handleReconnect}
+              className="rounded-xl bg-gradient-to-r from-[#2B7FFF] to-[#1a5fd9] px-8 py-3.5 font-bold text-white transition-all duration-200 hover:scale-105 hover:shadow-lg hover:shadow-[#2B7FFF]/50"
+            >
+              다시 연결
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/battlePage/hooks/useBattle.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattle.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useBattleStore } from '../stores/battleStore';
 import { useBattleSocket } from './useBattleSocket';
+import { useBattleSocketErrorHandling } from './useBattleSocketErrorHandling';
 import { useBattleProgress } from './useBattleProgress';
 import { useBattleDiscussions } from './useBattleDiscussions';
 import { useBattleTimeline } from './useBattleTimeline';
@@ -36,6 +37,7 @@ export function useBattle({ battleId, onOpenTeamChangeModal, onCloseTeamChangeMo
 
   // 모든 배틀 관련 훅 초기화
   useBattleSocket();
+  useBattleSocketErrorHandling();
 
   const { handleVote, handleDiscussionSubmit } = useBattleDiscussions();
   const { roundModal, hideRoundEffect } = useBattleProgress();

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -48,8 +48,8 @@ export function useBattleSocket() {
       });
     });
 
-    // 배틀 참여 성공시 데이터 수신
-    newSocket.once('battle:joined', (data: BattleJoinData) => {
+    // 배틀 참여 성공시 데이터 동기화
+    newSocket.on('battle:joined', (data: BattleJoinData) => {
       // 초기 battleState 설정
       setBattleProgress({
         round: data.round,

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -30,8 +30,8 @@ export function useBattleSocket() {
       auth: { userId },
       reconnection: true,
       reconnectionAttempts: 3,
-      reconnectionDelay: 500,
-      reconnectionDelayMax: 3000,
+      reconnectionDelay: 2000,
+      reconnectionDelayMax: 5000,
       timeout: 5000,
       upgrade: false
     });

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -134,19 +134,8 @@ export function useBattleSocket() {
       });
     });
 
-    // 연결 해제 핸들러
-    newSocket.on('disconnect', (reason) => {
-      console.log('[Socket] Disconnected:', reason);
-      setIsConnected(false);
-
-      if (reason === 'io server disconnect') {
-        newSocket.connect();
-      }
-    });
-
     return () => {
       newSocket.off('connect');
-      newSocket.off('disconnect');
       newSocket.off('battle:joined');
       newSocket.off('battle:phase:updated');
       newSocket.off('battle:round:updated');

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -134,8 +134,19 @@ export function useBattleSocket() {
       });
     });
 
+    // 연결 해제 핸들러
+    newSocket.on('disconnect', (reason) => {
+      console.log('[Socket] Disconnected:', reason);
+      setIsConnected(false);
+
+      if (reason === 'io server disconnect') {
+        newSocket.connect();
+      }
+    });
+
     return () => {
       newSocket.off('connect');
+      newSocket.off('disconnect');
       newSocket.off('battle:joined');
       newSocket.off('battle:phase:updated');
       newSocket.off('battle:round:updated');

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -27,7 +27,13 @@ export function useBattleSocket() {
 
     const newSocket = io(import.meta.env.VITE_API_URL, {
       transports: ['websocket'],
-      auth: { userId }
+      auth: { userId },
+      reconnection: true,
+      reconnectionAttempts: 3,
+      reconnectionDelay: 500,
+      reconnectionDelayMax: 3000,
+      timeout: 5000,
+      upgrade: false
     });
 
     setSocket(newSocket);

--- a/frontend/src/pages/battlePage/hooks/useBattleSocketErrorHandling.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocketErrorHandling.ts
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+import { useBattleStore } from '../stores/battleStore';
+
+export function useBattleSocketErrorHandling() {
+  const { socket, setIsConnected, setConnectionError } = useBattleStore();
+
+  useEffect(() => {
+    if (!socket) return;
+
+    // 연결 해제 핸들러
+    socket.on('disconnect', (reason) => {
+      console.log('[Socket] Disconnected:', reason);
+      setIsConnected(false);
+      setConnectionError({ type: 'disconnected', attemptCount: 0, message: '소켓 연결이 끊어졌습니다' });
+
+      if (reason === 'io server disconnect') {
+        socket.connect();
+      }
+    });
+
+    // 연결 에러 핸들러
+    socket.on('connect_error', (error) => {
+      console.error('[Socket] Connection error:', error.message);
+      setConnectionError({
+        type: 'disconnected',
+        attemptCount: 0,
+        message: '서버 연결에 실패했습니다'
+      });
+    });
+
+    // 재연결 시도 핸들러
+    socket.on('reconnect_attempt', (attemptNumber) => {
+      console.log(`[Socket] Reconnecting... (${attemptNumber}/3)`);
+      setConnectionError({
+        type: 'reconnecting',
+        attemptCount: attemptNumber,
+        message: `재연결 시도중 (${attemptNumber}/3)`
+      });
+    });
+
+    // 재연결 실패 핸들러
+    socket.on('reconnect_failed', () => {
+      console.error('[Socket] Reconnection failed after 3 attempts');
+      setConnectionError({
+        type: 'failed',
+        attemptCount: 3,
+        message: '재연결에 실패했습니다'
+      });
+    });
+
+    return () => {
+      socket.off('disconnect');
+      socket.off('connect_error');
+      socket.off('reconnect_attempt');
+      socket.off('reconnect_failed');
+    };
+  }, [socket, setIsConnected, setConnectionError]);
+}

--- a/frontend/src/pages/battlePage/hooks/useBattleSocketErrorHandling.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocketErrorHandling.ts
@@ -7,9 +7,20 @@ export function useBattleSocketErrorHandling() {
   useEffect(() => {
     if (!socket) return;
 
+    // 연결 성공 핸들러
+    socket.on('connect', () => {
+      setIsConnected(true);
+      setConnectionError({ type: null, attemptCount: 0, message: '' });
+    });
+
+    // 재연결 성공 핸들러
+    socket.io.on('reconnect', () => {
+      setIsConnected(true);
+      setConnectionError({ type: null, attemptCount: 0, message: '' });
+    });
+
     // 연결 해제 핸들러
     socket.on('disconnect', (reason) => {
-      console.log('[Socket] Disconnected:', reason);
       setIsConnected(false);
       setConnectionError({ type: 'disconnected', attemptCount: 0, message: '소켓 연결이 끊어졌습니다' });
 
@@ -29,7 +40,7 @@ export function useBattleSocketErrorHandling() {
     });
 
     // 재연결 시도 핸들러
-    socket.on('reconnect_attempt', (attemptNumber) => {
+    socket.io.on('reconnect_attempt', (attemptNumber) => {
       console.log(`[Socket] Reconnecting... (${attemptNumber}/3)`);
       setConnectionError({
         type: 'reconnecting',
@@ -39,20 +50,22 @@ export function useBattleSocketErrorHandling() {
     });
 
     // 재연결 실패 핸들러
-    socket.on('reconnect_failed', () => {
-      console.error('[Socket] Reconnection failed after 3 attempts');
+    socket.io.on('reconnect_failed', () => {
+      setIsConnected(false);
       setConnectionError({
         type: 'failed',
         attemptCount: 3,
-        message: '재연결에 실패했습니다'
+        message: '재연결에 실패했습니다. 다시 시도해주세요.'
       });
     });
 
     return () => {
+      socket.off('connect');
       socket.off('disconnect');
       socket.off('connect_error');
-      socket.off('reconnect_attempt');
-      socket.off('reconnect_failed');
+      socket.io.off('reconnect');
+      socket.io.off('reconnect_attempt');
+      socket.io.off('reconnect_failed');
     };
   }, [socket, setIsConnected, setConnectionError]);
 }

--- a/frontend/src/pages/battlePage/hooks/useBattleSocketErrorHandling.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocketErrorHandling.ts
@@ -1,8 +1,14 @@
 import { useEffect } from 'react';
 import { useBattleStore } from '../stores/battleStore';
+import { useToastStore } from '@/commons/stores/toastStore';
+
+interface ErrorPayload {
+  message: string;
+}
 
 export function useBattleSocketErrorHandling() {
   const { socket, setIsConnected, setConnectionError } = useBattleStore();
+  const addToast = useToastStore((state) => state.addToast);
 
   useEffect(() => {
     if (!socket) return;
@@ -59,6 +65,39 @@ export function useBattleSocketErrorHandling() {
       });
     });
 
+    // 서버 비즈니스 에러 핸들러
+    socket.on('battle:join:error', (data: ErrorPayload) => {
+      addToast({ message: data.message || '배틀 입장에 실패했습니다.' });
+    });
+
+    socket.on('battle:attack:error', (data: ErrorPayload) => {
+      addToast({ message: data.message || '공격 제출에 실패했습니다.' });
+    });
+
+    socket.on('battle:defense:error', (data: ErrorPayload) => {
+      addToast({ message: data.message || '방어 제출에 실패했습니다.' });
+    });
+
+    socket.on('battle:attack:vote:error', (data: ErrorPayload) => {
+      addToast({ message: data.message || '투표에 실패했습니다.' });
+    });
+
+    socket.on('battle:defense:vote:error', (data: ErrorPayload) => {
+      addToast({ message: data.message || '투표에 실패했습니다.' });
+    });
+
+    socket.on('battle:chat:error', (data: ErrorPayload) => {
+      addToast({ message: data.message || '메시지 전송에 실패했습니다.' });
+    });
+
+    socket.on('battle:team:vote:error', (data: ErrorPayload) => {
+      addToast({ message: data.message || '팀 투표에 실패했습니다.' });
+    });
+
+    socket.on('battle:user:skip:error', (data: ErrorPayload) => {
+      addToast({ message: data.message || '스킵 요청에 실패했습니다.' });
+    });
+
     return () => {
       socket.off('connect');
       socket.off('disconnect');
@@ -66,6 +105,14 @@ export function useBattleSocketErrorHandling() {
       socket.io.off('reconnect');
       socket.io.off('reconnect_attempt');
       socket.io.off('reconnect_failed');
+      socket.off('battle:join:error');
+      socket.off('battle:attack:error');
+      socket.off('battle:defense:error');
+      socket.off('battle:attack:vote:error');
+      socket.off('battle:defense:vote:error');
+      socket.off('battle:chat:error');
+      socket.off('battle:team:vote:error');
+      socket.off('battle:user:skip:error');
     };
-  }, [socket, setIsConnected, setConnectionError]);
+  }, [socket, setIsConnected, setConnectionError, addToast]);
 }

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -16,6 +16,7 @@ import DiscussionVote from './components/discussion/DiscussionVote';
 import BattleSidebar from './components/sidebar';
 import BookmarkButton from './components/sidebar/BookmarkButton';
 import TeamChangeModal from './components/modals/TeamChangeModal';
+import ConnectionErrorModal from './components/modals/ConnectionErrorModal';
 import DiscussionModal from './components/effects/DiscussionModal';
 import BattleProgressBoard from './components/progressBoard/ProgressBoard';
 import TeamVoteResultModal from './components/effects/TeamVoteResultModal';
@@ -262,6 +263,7 @@ export default function BattlePage() {
         {roundModal.isPending && !isVoteResultModalOpen && (
           <RoundUpdateModal isOpen={true} round={roundModal.round} topic={roundModal.topic} onClose={hideRoundEffect} />
         )}
+        <ConnectionErrorModal />
       </div>
     </div>
   );

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -7,6 +7,11 @@ interface BattleStore {
   battleId: string;
   socket: Socket | null;
   isConnected: boolean;
+  connectionError: {
+    type: 'disconnected' | 'reconnecting' | 'failed' | null;
+    attemptCount: number;
+    message: string;
+  };
   currentStage: string | null;
   battleProgress: BattleProgressState | null;
   discussions: Array<{
@@ -40,6 +45,11 @@ interface BattleStore {
   initializeBattle: (config: { userId: string; battleId: string }) => void;
   setSocket: (socket: Socket | null) => void;
   setIsConnected: (connected: boolean) => void;
+  setConnectionError: (error: {
+    type: 'disconnected' | 'reconnecting' | 'failed' | null;
+    attemptCount: number;
+    message: string;
+  }) => void;
   setCurrentStage: (stage: string | null) => void;
   setBattleProgress: (progress: BattleProgressState | null) => void;
   updateBattleProgress: (updates: Partial<BattleProgressState>) => void;
@@ -67,6 +77,7 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
   battleId: '',
   socket: null,
   isConnected: false,
+  connectionError: { type: null, attemptCount: 0, message: '' },
   currentStage: null,
   battleProgress: null,
   discussions: [],
@@ -85,6 +96,7 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
   initializeBattle: (config) => set({ userId: config.userId, battleId: config.battleId, chatInitialized: false }),
   setSocket: (socket) => set({ socket }),
   setIsConnected: (connected) => set({ isConnected: connected }),
+  setConnectionError: (error) => set({ connectionError: error }),
   setCurrentStage: (stage) => set({ currentStage: stage }),
   setBattleProgress: (progress) => set({ battleProgress: progress }),
   updateBattleProgress: (updates) =>
@@ -177,6 +189,7 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
       battleId: '',
       socket: null,
       isConnected: false,
+      connectionError: { type: null, attemptCount: 0, message: '' },
       currentStage: null,
       battleProgress: null,
       discussions: [],


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #319

## ✅ 작업 내용

### 💡개선 사항

#### Socket.io 재연결 옵션 설정
Socket.io에서 제공해주는 재연결 옵션을 설정해봤습니다. 
```js
reconnection: true,           // 재연결 활성화
reconnectionAttempts: 3,      // 최대 3회까지만 재연결 시도
reconnectionDelay: 2000,      // 재연결 시도 간격 2초
reconnectionDelayMax: 5000,   // 재연결 지연 최대값 5초
timeout: 5000                 // 연결 타임아웃 5초
upgrade: false 
```

`reconnection: true`의 경우 네트워크 불안정이나 서버 재시작 시 사용자가 수동으로 새로고침하지 않아도 자동으로 재연결이 되며, `reconnectionAttempts: 3`로 무한 재시도를 방지하고 3회로 제한했습니다.
재연결 시도 간격 경우에는 너무 짧으면 서버에 부하를 주고, 너무 길면 사용자 경험이 나빠지기에  2초로 설정하며, 시도마다 백오프를 적용하는데 최대 5초로 제한했습니다.

`timeout: 5000`로 연결 시도 후 5초 이내에 응답이 없으면 실패로 처리합니다. 빠르게 실패를 감지해서 다음 재연결 시도하게 했습니다. 

`transports: ['websocket'], upgrade: false`를 설정하여  HTTP long-polling을 거치지 않고 처음부터 WebSocket만 사용하도록 했습니다. 실시간 배틀 게임은 양방향 통신이 많고 저지연이 중요하므로 polling의 오버헤드를 제거하고 WebSocket으로 바로 연결하는 것이 성능상 유리하다고 생각했습니다

<br/>

####  Socket.IO에서 제공하는 소켓 연결/재연결 에러 핸들링 시스템 구축
에러가 뜬 경우 해당 상태 값에 소켓 상태 / 원인 / 재시도 횟수를 저장 후 사용자에게 모달로 관련 모달을 표시 하기 위해  BattleStore에서  `connectionError {type, reason, attemptCount}`상태에 저장하여 관리하고 있습니다.

- **`disconnect` 이벤트**: 연결이 끊기면 BattleStore에 `connectionError/type` 상태를 'disconnected' 로 설정 및 `socket.connect()`로 즉시 수동 재연결을 로직 적용 

- **`connect_error` 이벤트**: 연결 시도가 실패하면 `connectionError` 상태를 'disconnected' 타입으로 설정하여 사용자에게 "서버 연결에 실패했습니다" 메시지를 표시

- **`reconnect` 이벤트**: Socket.IO Manager의 재연결 성공 시 `setIsConnected(true)`로 연결 복구하고, `connectionError`를 초기화하며 에러 모달을 닫기

- **`reconnect_attempt` 이벤트** : 재연결을 시도할 때마다 호출되며, 시도 횟수를 받아서 battleStore에  `attemptCount` 값을 최신화하고 소켓 상태를 'reconnecting'으로 설정합니다.  "재연결 시도중 (2/3)" 모달을 표시합니다. 

- **`reconnect_failed` 이벤트**: 3회 재연결 시도가 모두 실패하면 `setIsConnected(false)`로 연결 실패를 확정하고, `connectionError`를 'failed' 타입으로 설정하여 사용자에게 수동 재연결 버튼을 제공합니다.

<br/>

####  소켓 에러 표시 모달 구현
- 위에서 언급한 소켓에 문제가 생긴 경우 모달 표시로 사용자에게 현재 상황 안내 하기 위해 만들었습니다. 
  - `disconnected`: 연결 끊김 상태 표시 (버튼 없음, 자동 재연결 대기)
  - `reconnecting`: 재연결 시도 중 스피너 + 시도 횟수 표시 (예: "재연결 시도중 (2/3)")
  - `failed`: 재연결 실패 시 수동 재연결 버튼 제공

<img width="1137" height="761" alt="image" src="https://github.com/user-attachments/assets/0833a588-acf1-4ac9-b754-142b9d8b569f" />

<img width="1188" height="764" alt="image" src="https://github.com/user-attachments/assets/7b7aeee6-11d8-4d33-ae78-0f77027564fd" />

<br/>

#### 서버에서 제공 하는 배틀 에러 이벤트 에러 수신 받는 경우 토스트 알림 띄우는 기능
서버에서 소켓 이벤트 수신 받아 제대로 처리 하지 못한 경우 클라이언트로 해당 이벤트들에 대한 에러 이벤트들을 수신하는데 관련 핸들링 로직을 적용했습니다.
- `useBattleSocketErrorHandling`에 서버에서 emit하는 8개 비즈니스 에러 이벤트 핸들러 추가
  - `battle:join:error`: 배틀 입장 실패
  - `battle:attack:error`: 공격 제출 실패
  - `battle:defense:error`: 방어 제출 실패
  - `battle:attack:vote:error`: 공격 투표 실패
  - `battle:defense:vote:error`: 방어 투표 실패
  - `battle:chat:error`: 채팅 전송 실패
  - `battle:team:vote:error`: 팀 투표 실패
  - `battle:user:skip:error`: 스킵 요청 실패

<img width="375" height="68" alt="image" src="https://github.com/user-attachments/assets/48bb0904-d820-45c7-97f1-90c5b8b51035" />


<br />

## 📸 참고 사항

**BattleStore 상태 추가**
- `connectionError` 상태 추가
  - `type`: 에러 타입 (disconnected, reconnecting, failed)
  - `attemptCount`: 재연결 시도 횟수
  - `message`: 사용자에게 표시할 에러 메시지

<br />

