### PR TITLE
fix(fe): 튜토리얼 종료 후 메인 화면으로 리다이렉트 되지 않는 버그 수정

### DIFF
--- a/frontend/src/pages/tutorialBattlePage/index.tsx
+++ b/frontend/src/pages/tutorialBattlePage/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useLocation, useNavigate, useLoaderData } from 'react-router-dom';
 import type { BattleInfo, Team } from '@/commons/types/battle';
 import useModal from '@/commons/hooks/useModal';
@@ -101,7 +101,11 @@ export default function TutorialBattlePage() {
   const phase = battleProgress?.phase;
   const shouldShowInput = !isInputDisabled(selectedTeam, phase);
 
-  useAutoExitOnDone(practicePhase === 'done', () => navigate('/'));
+  const handleAutoExit = useCallback(() => {
+    navigate('/');
+  }, [navigate]);
+
+  useAutoExitOnDone(practicePhase === 'done', handleAutoExit);
 
   return (
     <div className="text-white relative">


### PR DESCRIPTION

## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #321 

## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->
- 튜토리얼 완료 후 자동 이동이 실패 :  `useAutoExitOnDone`의 effect cleanup이 원인이었음
    -   useAutoExitOnDone의 dependency에 메인화면으로 이동시키는 onExit 함수가 포함되어 있었음
    -  TutorialBattlePage에서 인라인 함수로 넘기고 있어 리렌더마다 onExit 함수가 새롭게 참조되면서 cleanup 됨
- `onExit` 콜백을 `useCallback`으로 고정해 effect 재실행 및 타이머 제거되는 버그 수정

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
