### PR TITLE
[Fix] mvps Column Data Type을 수정한다.

### DIFF
--- a/backend/prisma/migrations/20260202041927_mvps_varchar20/migration.sql
+++ b/backend/prisma/migrations/20260202041927_mvps_varchar20/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "battles" ALTER COLUMN "mvps" SET DATA TYPE VARCHAR(20)[];

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -56,7 +56,7 @@ model Battle {
   teamBCount               Int?       @map("team_b_count")
   totalParticipantsCount   Int?       @map("total_participants_count")
   winningTeam              String?    @db.VarChar(10) @map("winning_team")
-  mvps                     String[]   @db.VarChar(10)
+  mvps                     String[]   @db.VarChar(20)
   mvpsState                Json?      @map("mvps_state")
     
   /* 시간 */


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #323 

## ✅ 작업 내용

배틀 결과를 생성할 때, `mvps` 필드 값이 `varChar(10)`이라 데이터를 삽입할 수 없는 에러가 발생하였습니다.
OAuth 로그인 후 기본으로 생성되는 로그인이 10자가 넘어, 데이터를 삽입할 수 없는 이슈가 발생하였습니다.

```
a/client/src/runtime/core/engines/client/LocalExecutor.ts:81:12) {
      cause: {
        originalCode: '22001',
        originalMessage: 'value too long for type character varying(10)',
        kind: 'LengthMismatch',
        column: undefined
      }
    }
  },
  clientVersion: '7.3.0'
}
```

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

- [x] `varChar(10)` -> `varChar(20)`으로 마이그레이션

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->
<img width="300" alt="스크린샷 2026-02-02 오후 1 23 19" src="https://github.com/user-attachments/assets/1b8f5834-cbe1-4fb7-9993-a74563b4341d" />

<br />


## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
