### PR TITLE
[Feature] Gemini API 다중 키 관리

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,5 +7,5 @@ PORT=3000
 # Prisma
 DATABASE_URL="postgresql://<username>:<password>@<hostname>:<port>/<database>"
 
-# Google Gemini API
-GEMINI_API_KEY=your_gemini_api_key_here
+# Google Gemini API (콤마로 구분하여 여러 키 등록)
+GEMINI_API_KEYS=key1,key2,key3

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,9 +6,10 @@ import { ConfigModule } from '@nestjs/config'
 import { OauthModule } from './oauth/oauth.module'
 import { MetricsModule } from './metrics/metrics.module'
 import { HttpMetricsMiddleware } from './metrics/http-metrics.middleware'
+import { GeminiModule } from './gemini/gemini.module'
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), BattlesModule, OauthModule, MetricsModule],
+  imports: [ConfigModule.forRoot({ isGlobal: true }), GeminiModule, BattlesModule, OauthModule, MetricsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/src/battles/service/battles.service.ts
+++ b/backend/src/battles/service/battles.service.ts
@@ -8,7 +8,7 @@ import {
   InternalServerErrorException,
   UnauthorizedException,
 } from '@nestjs/common'
-import { GoogleGenerativeAI } from '@google/generative-ai'
+import { GeminiService } from '../../gemini/gemini.service'
 
 import { TimelineItem, Mvp, BattleResult } from '../types/battleResult.types'
 import { calculateOpinionScore, compareMvpCandidates, createMvpCandidate, applyWinnerBonus } from './utils/mvp.util'
@@ -53,7 +53,6 @@ import {
   BUILD_AI_REFERENCE_PROMPT,
   AI_REFERENCE_SCHEMA,
 } from '../const/battles.const'
-import { ConfigService } from '@nestjs/config'
 import type { BattleReferenceData } from '../types/ai.types'
 import type { GenerateReferenceRequestDto } from '../dto/generateReference.dto'
 import { BattlePhaseResponseDto, BattleRoundResponseDto } from '../dto/battleTurnResponse.dto'
@@ -75,7 +74,7 @@ export class BattlesService extends EventEmitter {
 
   constructor(
     private readonly prisma: PrismaService,
-    private readonly configService: ConfigService,
+    private readonly geminiService: GeminiService,
   ) {
     super()
   }
@@ -1602,11 +1601,6 @@ export class BattlesService extends EventEmitter {
   }
 
   async generateReferenceData(dto: GenerateReferenceRequestDto): Promise<BattleReferenceData> {
-    const apiKey = this.configService.get<string>('GEMINI_API_KEY')
-    if (!apiKey) {
-      throw new InternalServerErrorException('AI 서비스를 사용할 수 없습니다.')
-    }
-
     const prompt = BUILD_AI_REFERENCE_PROMPT({
       title: dto.title,
       description: dto.description,
@@ -1618,21 +1612,19 @@ export class BattlesService extends EventEmitter {
     })
 
     try {
-      const genAI = new GoogleGenerativeAI(apiKey)
-      const model = genAI.getGenerativeModel({
-        model: 'gemini-3-flash-preview',
-        generationConfig: {
+      return await this.geminiService.execute(
+        async model => {
+          const result = await model.generateContent(prompt)
+          const response = result.response
+          const text = response.text()
+          return JSON.parse(text) as BattleReferenceData
+        },
+        'gemini-3-flash-preview',
+        {
           responseMimeType: 'application/json',
           responseSchema: AI_REFERENCE_SCHEMA,
         },
-      })
-
-      const result = await model.generateContent(prompt)
-      const response = result.response
-      const text = response.text()
-
-      const referenceData = JSON.parse(text) as BattleReferenceData
-      return referenceData
+      )
     } catch (error: unknown) {
       if (error instanceof InternalServerErrorException) {
         throw error

--- a/backend/src/gemini/gemini.module.ts
+++ b/backend/src/gemini/gemini.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common'
+import { GeminiService } from './gemini.service'
+
+@Global()
+@Module({
+  providers: [GeminiService],
+  exports: [GeminiService],
+})
+export class GeminiModule {}

--- a/backend/src/gemini/gemini.service.ts
+++ b/backend/src/gemini/gemini.service.ts
@@ -23,8 +23,8 @@ export class GeminiService implements OnModuleInit {
   private keyStats: Map<string, KeyUsageStats> = new Map()
   private keys: string[] = []
 
-  private rateLimitPerMinute: number = 15
-  private rateLimitPerDay: number = 1500
+  private rateLimitPerMinute: number = 5
+  private rateLimitPerDay: number = 20
   private readonly MINUTE_MS = 60 * 1000
   private readonly DAY_MS = 24 * 60 * 60 * 1000
   private readonly MAX_RETRIES = 3
@@ -48,8 +48,8 @@ export class GeminiService implements OnModuleInit {
       throw new Error('GEMINI_API_KEYS에 유효한 키가 없습니다.')
     }
 
-    this.rateLimitPerMinute = this.configService.get<number>('GEMINI_RATE_LIMIT_PER_MINUTE') ?? 15
-    this.rateLimitPerDay = this.configService.get<number>('GEMINI_RATE_LIMIT_PER_DAY') ?? 1500
+    this.rateLimitPerMinute = this.configService.get<number>('GEMINI_RATE_LIMIT_PER_MINUTE') ?? 5
+    this.rateLimitPerDay = this.configService.get<number>('GEMINI_RATE_LIMIT_PER_DAY') ?? 20
 
     for (const key of this.keys) {
       this.keyStats.set(key, {
@@ -104,7 +104,7 @@ export class GeminiService implements OnModuleInit {
         stats.consecutiveFailures++
 
         const errorType = this.classifyError(error)
-        this.logger.warn(`Gemini API 호출 실패 (시도 ${attempt + 1}/${this.MAX_RETRIES}, 키: ${apiKey.substring(0, 8)}...): ${errorType}`)
+        this.logger.warn(`Gemini API 호출 실패 (시도 ${attempt + 1}/${this.MAX_RETRIES}, 키: ${apiKey.substring(6, 14)}...): ${errorType}`)
 
         this.handleKeyFailure(apiKey, errorType)
 
@@ -189,7 +189,7 @@ export class GeminiService implements OnModuleInit {
     if (stats.consecutiveFailures >= 3) {
       stats.isDisabled = true
       stats.disabledUntil = Date.now() + disableDuration
-      this.logger.warn(`API 키 비활성화: ${apiKey.substring(0, 8)}... (${errorType})`)
+      this.logger.warn(`API 키 비활성화: ${apiKey.substring(6, 14)}... (${errorType})`)
     }
   }
 
@@ -241,7 +241,7 @@ export class GeminiService implements OnModuleInit {
     const keyStatuses = Array.from(this.keyStats.entries()).map(([key, stats]) => {
       this.cleanupOldRequests(stats, now)
       return {
-        keyPrefix: key.substring(0, 8) + '...',
+        keyPrefix: key.substring(6, 14) + '...',
         minuteUsage: stats.minuteRequests.length,
         dailyUsage: stats.dailyRequests.length,
         isDisabled: stats.isDisabled,

--- a/backend/src/gemini/gemini.service.ts
+++ b/backend/src/gemini/gemini.service.ts
@@ -1,0 +1,258 @@
+import { Injectable, OnModuleInit, Logger, InternalServerErrorException } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { GoogleGenerativeAI, GenerativeModel, Schema } from '@google/generative-ai'
+
+interface KeyUsageStats {
+  apiKey: string
+  minuteRequests: number[]
+  dailyRequests: number[]
+  lastUsed: number
+  isDisabled: boolean
+  disabledUntil: number | null
+  consecutiveFailures: number
+}
+
+export interface GeminiGenerationConfig {
+  responseMimeType?: string
+  responseSchema?: Schema
+}
+
+@Injectable()
+export class GeminiService implements OnModuleInit {
+  private readonly logger = new Logger(GeminiService.name)
+  private keyStats: Map<string, KeyUsageStats> = new Map()
+  private keys: string[] = []
+
+  private rateLimitPerMinute: number = 15
+  private rateLimitPerDay: number = 1500
+  private readonly MINUTE_MS = 60 * 1000
+  private readonly DAY_MS = 24 * 60 * 60 * 1000
+  private readonly MAX_RETRIES = 3
+  private readonly BACKOFF_BASE_MS = 1000
+
+  constructor(private readonly configService: ConfigService) {}
+
+  onModuleInit() {
+    const keysString = this.configService.get<string>('GEMINI_API_KEYS')
+
+    if (!keysString) {
+      throw new Error('GEMINI_API_KEYS 환경변수가 필요합니다.')
+    }
+
+    this.keys = keysString
+      .split(',')
+      .map(k => k.trim())
+      .filter(Boolean)
+
+    if (this.keys.length === 0) {
+      throw new Error('GEMINI_API_KEYS에 유효한 키가 없습니다.')
+    }
+
+    this.rateLimitPerMinute = this.configService.get<number>('GEMINI_RATE_LIMIT_PER_MINUTE') ?? 15
+    this.rateLimitPerDay = this.configService.get<number>('GEMINI_RATE_LIMIT_PER_DAY') ?? 1500
+
+    for (const key of this.keys) {
+      this.keyStats.set(key, {
+        apiKey: key,
+        minuteRequests: [],
+        dailyRequests: [],
+        lastUsed: 0,
+        isDisabled: false,
+        disabledUntil: null,
+        consecutiveFailures: 0,
+      })
+    }
+
+    this.logger.log(`Gemini 서비스 초기화 완료: ${this.keys.length}개 키 등록`)
+  }
+
+  async execute<T>(
+    executor: (model: GenerativeModel) => Promise<T>,
+    modelName: string = 'gemini-3-flash-preview',
+    generationConfig?: GeminiGenerationConfig,
+  ): Promise<T> {
+    const triedKeys = new Set<string>()
+    let lastError: Error | null = null
+
+    for (let attempt = 0; attempt < this.MAX_RETRIES; attempt++) {
+      const apiKey = this.getBestAvailableKey(triedKeys)
+
+      if (!apiKey) {
+        this.logger.warn('사용 가능한 API 키가 없습니다.')
+        break
+      }
+
+      triedKeys.add(apiKey)
+      const stats = this.keyStats.get(apiKey)!
+
+      try {
+        this.recordUsage(apiKey)
+
+        const genAI = new GoogleGenerativeAI(apiKey)
+        const model = genAI.getGenerativeModel({
+          model: modelName,
+          generationConfig,
+        })
+
+        const result = await executor(model)
+
+        stats.consecutiveFailures = 0
+
+        return result
+      } catch (error) {
+        lastError = error as Error
+        stats.consecutiveFailures++
+
+        const errorType = this.classifyError(error)
+        this.logger.warn(`Gemini API 호출 실패 (시도 ${attempt + 1}/${this.MAX_RETRIES}, 키: ${apiKey.substring(0, 8)}...): ${errorType}`)
+
+        this.handleKeyFailure(apiKey, errorType)
+
+        if (attempt < this.MAX_RETRIES - 1) {
+          const backoffMs = this.BACKOFF_BASE_MS * Math.pow(2, attempt)
+          await this.sleep(backoffMs)
+        }
+      }
+    }
+
+    throw lastError ?? new InternalServerErrorException('Gemini API 호출에 실패했습니다.')
+  }
+
+  private getBestAvailableKey(excludeKeys: Set<string> = new Set()): string | null {
+    const now = Date.now()
+    let bestKey: string | null = null
+    let maxAvailability = -1
+
+    for (const [key, stats] of this.keyStats.entries()) {
+      if (excludeKeys.has(key)) continue
+
+      if (stats.isDisabled) {
+        if (stats.disabledUntil && now > stats.disabledUntil) {
+          stats.isDisabled = false
+          stats.disabledUntil = null
+          stats.consecutiveFailures = 0
+        } else {
+          continue
+        }
+      }
+
+      this.cleanupOldRequests(stats, now)
+
+      const minuteAvailable = this.rateLimitPerMinute - stats.minuteRequests.length
+      const dailyAvailable = this.rateLimitPerDay - stats.dailyRequests.length
+
+      if (minuteAvailable <= 0 || dailyAvailable <= 0) {
+        continue
+      }
+
+      const availability = minuteAvailable * (1 - stats.consecutiveFailures * 0.1)
+
+      if (availability > maxAvailability) {
+        maxAvailability = availability
+        bestKey = key
+      }
+    }
+
+    return bestKey
+  }
+
+  private recordUsage(apiKey: string): void {
+    const stats = this.keyStats.get(apiKey)
+    if (!stats) return
+
+    const now = Date.now()
+    stats.minuteRequests.push(now)
+    stats.dailyRequests.push(now)
+    stats.lastUsed = now
+  }
+
+  private handleKeyFailure(apiKey: string, errorType: string): void {
+    const stats = this.keyStats.get(apiKey)
+    if (!stats) return
+
+    let disableDuration: number
+
+    switch (errorType) {
+      case 'RATE_LIMIT':
+        disableDuration = this.MINUTE_MS
+        break
+      case 'QUOTA_EXCEEDED':
+        disableDuration = this.DAY_MS
+        break
+      case 'AUTH_ERROR':
+        disableDuration = this.DAY_MS
+        break
+      default:
+        disableDuration = 5 * this.MINUTE_MS
+    }
+
+    if (stats.consecutiveFailures >= 3) {
+      stats.isDisabled = true
+      stats.disabledUntil = Date.now() + disableDuration
+      this.logger.warn(`API 키 비활성화: ${apiKey.substring(0, 8)}... (${errorType})`)
+    }
+  }
+
+  private classifyError(error: unknown): string {
+    if (!(error instanceof Error)) return 'UNKNOWN'
+
+    const message = error.message.toLowerCase()
+
+    if (message.includes('429') || message.includes('resource_exhausted')) {
+      return 'RATE_LIMIT'
+    }
+    if (message.includes('quota')) {
+      return 'QUOTA_EXCEEDED'
+    }
+    if (message.includes('401') || message.includes('403') || message.includes('unauthenticated')) {
+      return 'AUTH_ERROR'
+    }
+    if (message.includes('timeout') || message.includes('econnreset')) {
+      return 'NETWORK_ERROR'
+    }
+
+    return 'UNKNOWN'
+  }
+
+  private cleanupOldRequests(stats: KeyUsageStats, now: number): void {
+    const minuteAgo = now - this.MINUTE_MS
+    const dayAgo = now - this.DAY_MS
+
+    stats.minuteRequests = stats.minuteRequests.filter(ts => ts > minuteAgo)
+    stats.dailyRequests = stats.dailyRequests.filter(ts => ts > dayAgo)
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms))
+  }
+
+  getHealthStatus(): {
+    totalKeys: number
+    activeKeys: number
+    keyStatuses: Array<{
+      keyPrefix: string
+      minuteUsage: number
+      dailyUsage: number
+      isDisabled: boolean
+      consecutiveFailures: number
+    }>
+  } {
+    const now = Date.now()
+    const keyStatuses = Array.from(this.keyStats.entries()).map(([key, stats]) => {
+      this.cleanupOldRequests(stats, now)
+      return {
+        keyPrefix: key.substring(0, 8) + '...',
+        minuteUsage: stats.minuteRequests.length,
+        dailyUsage: stats.dailyRequests.length,
+        isDisabled: stats.isDisabled,
+        consecutiveFailures: stats.consecutiveFailures,
+      }
+    })
+
+    return {
+      totalKeys: this.keys.length,
+      activeKeys: keyStatuses.filter(s => !s.isDisabled).length,
+      keyStatuses,
+    }
+  }
+}

--- a/backend/src/gemini/gemini.service.ts
+++ b/backend/src/gemini/gemini.service.ts
@@ -27,7 +27,6 @@ export class GeminiService implements OnModuleInit {
   private rateLimitPerDay: number = 20
   private readonly MINUTE_MS = 60 * 1000
   private readonly DAY_MS = 24 * 60 * 60 * 1000
-  private readonly MAX_RETRIES = 3
   private readonly BACKOFF_BASE_MS = 1000
 
   constructor(private readonly configService: ConfigService) {}
@@ -74,7 +73,9 @@ export class GeminiService implements OnModuleInit {
     const triedKeys = new Set<string>()
     let lastError: Error | null = null
 
-    for (let attempt = 0; attempt < this.MAX_RETRIES; attempt++) {
+    const maxAttempts = this.keys.length
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
       const apiKey = this.getBestAvailableKey(triedKeys)
 
       if (!apiKey) {
@@ -104,11 +105,11 @@ export class GeminiService implements OnModuleInit {
         stats.consecutiveFailures++
 
         const errorType = this.classifyError(error)
-        this.logger.warn(`Gemini API 호출 실패 (시도 ${attempt + 1}/${this.MAX_RETRIES}, 키: ${apiKey.substring(6, 14)}...): ${errorType}`)
+        this.logger.warn(`Gemini API 호출 실패 (시도 ${attempt + 1}/${maxAttempts}, 키: ${apiKey.substring(6, 14)}...): ${errorType}`)
 
         this.handleKeyFailure(apiKey, errorType)
 
-        if (attempt < this.MAX_RETRIES - 1) {
+        if (attempt < maxAttempts - 1) {
           const backoffMs = this.BACKOFF_BASE_MS * Math.pow(2, attempt)
           await this.sleep(backoffMs)
         }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #329

## ✅ 작업 내용

### 💡개선 사항
- Gemini API 다중 키 관리 시스템 구현
  - 여러 API 키를 환경변수로 등록 (`GEMINI_API_KEYS=key1,key2,key3`)
  - 분당/일일 사용량 추적으로 최적의 키 자동 선택
  - API 호출 실패 시 다른 키로 Fallback (등록된 키 수만큼 재시도)
  - Rate Limit, 인증 오류 시 키 임시 비활성화

- 파일 변경 목록
  - `backend/src/gemini/gemini.service.ts` (신규)
  - `backend/src/gemini/gemini.module.ts` (신규)
  - `backend/src/app.module.ts` (수정)
  - `backend/src/battles/service/battles.service.ts` (수정)
  - `backend/.env.example` (수정)

<br />

## 📸 참고 사항
- 기존 `GEMINI_API_KEY` 환경변수는 `GEMINI_API_KEYS`로 변경됨
- Rate Limit 기본값: 분당 5회, 일일 20회 (환경변수로 조정 가능)
- 서버 재시작 시 사용량 기록 초기화됨 (인메모리 방식)
  - 재시작 후 Rate Limit 초과해도 Fallback으로 다음 키 사용
- 변경된 .env 노션에 수정함
<img width="987" height="114" alt="Image" src="https://github.com/user-attachments/assets/1e440731-985e-4977-a9d8-fec9dd05cdf9" />

<br />

## 💬 질문사항 (고민했던 부분)
- 사용량 기록을 Redis/DB에 저장할지 고민했으나, 다음과 같은 이유로 Redis 도입 후 수정하는 것이 좋아보였음
  - Redis는 TTL(Time To Live) 기능이 내장되어 있음
  ```
  SET gemini:daily:key1 5 EX 86400   // 86400초(24시간) 후 자동 삭제
  SET gemini:minute:key1 3 EX 60     // 60초 후 자동 삭제
  별도 코드 없이 시간 지나면 자동으로 키가 삭제되어 횟수가 초기화됩니다.

  PostgreSQL은 이 기능이 없어서 직접 "1분/1일 지난 기록 삭제" 로직을 구현해야 합니다 (현재 cleanupOldRequests()처럼)
  ```
  - 추후 트래픽 증가 시 Redis가 유리함