### PR TITLE
[Fix] 배틀 페이지에서 게임 진행중 새로고침 시 접근 제한하는 로직 제거

### DIFF
--- a/frontend/src/commons/stores/authStore.ts
+++ b/frontend/src/commons/stores/authStore.ts
@@ -8,33 +8,64 @@ interface AuthStore {
   user: AuthUser | null;
   isLoggingIn: boolean;
 
-  loginGuest: (battleId: string) => Promise<{ id: string; nickname: string }>;
+  loginGuest: (battleId: string, selectedTeam?: 'A' | 'B') => Promise<{ id: string; nickname: string }>;
   getOAuthUser: () => Promise<AuthUser | null>;
   logout: () => Promise<void>;
   clearAuth: () => void;
+  updateGuestTeam: (selectedTeam: 'A' | 'B') => void;
 }
 
-const AUTH_KEY = 'CMC_BATTLE_USER';
+const OAUTH_KEY = 'CMC_OAUTH_USER';
+const GUEST_KEY = 'CMC_GUEST_USER';
+
+const getInitialUser = (): AuthUser | null => {
+  try {
+    // OAuth 유저 확인
+    const oauthStored = localStorage.getItem(OAUTH_KEY);
+    if (oauthStored) {
+      return JSON.parse(oauthStored) as AuthUser;
+    }
+
+    // 비회원 유저 확인 (URL battleId와 비교)
+    const pathMatch = window.location.pathname.match(/\/battle\/([^/]+)/);
+    if (pathMatch) {
+      const currentBattleId = pathMatch[1];
+      const guestStored = localStorage.getItem(GUEST_KEY);
+
+      if (guestStored) {
+        const guestUser = JSON.parse(guestStored) as AuthUser;
+        if (guestUser.battleId === currentBattleId) {
+          return guestUser;
+        }
+      }
+    }
+  } catch (error: Error | unknown) {
+    if (error instanceof Error) throw new Error('사용자 정보 로드 실패', error);
+  }
+  return null;
+};
 
 export const useAuthStore = create<AuthStore>((set, get) => {
   return {
-    user: null,
+    user: getInitialUser(),
     isLoggingIn: false,
 
-    loginGuest: async (battleId) => {
+    loginGuest: async (battleId, selectedTeam) => {
       set({ isLoggingIn: true });
 
       try {
         const data = await fetchPostGuestLogin(battleId);
 
-        const user = {
+        const user: AuthUser = {
           id: data.id,
-          nickname: data.nickname
+          nickname: data.nickname,
+          type: 'guest' as const,
+          battleId,
+          selectedTeam
         };
-
-        localStorage.setItem(AUTH_KEY, JSON.stringify(user));
+        localStorage.setItem(GUEST_KEY, JSON.stringify(user));
         set({
-          user: { ...user, type: 'guest' as const },
+          user,
           isLoggingIn: false
         });
 
@@ -45,29 +76,34 @@ export const useAuthStore = create<AuthStore>((set, get) => {
       }
     },
 
+    updateGuestTeam: (selectedTeam) => {
+      const currentUser = get().user;
+      if (currentUser?.type === 'guest') {
+        const updatedUser = { ...currentUser, selectedTeam };
+        localStorage.setItem(GUEST_KEY, JSON.stringify(updatedUser));
+        set({ user: updatedUser });
+      }
+    },
+
     getOAuthUser: async () => {
       const currentUser = get().user;
       if (currentUser?.type === 'oauth') {
         return currentUser;
       }
 
+      // 비회원 상태면 OAuth 체크 안 함
+      if (currentUser?.type === 'guest') {
+        return null;
+      }
+
       try {
         const oauthUser = await getOAuthUser();
-
-        // store에 저장
         set({ user: oauthUser });
-
-        localStorage.setItem(
-          AUTH_KEY,
-          JSON.stringify({
-            id: oauthUser.id,
-            nickname: oauthUser.nickname
-          })
-        );
-
+        localStorage.setItem(OAUTH_KEY, JSON.stringify(oauthUser));
         return oauthUser;
       } catch {
-        get().clearAuth();
+        localStorage.removeItem(OAUTH_KEY);
+        set({ user: null });
         return null;
       }
     },
@@ -84,7 +120,8 @@ export const useAuthStore = create<AuthStore>((set, get) => {
     },
 
     clearAuth: () => {
-      localStorage.removeItem(AUTH_KEY);
+      localStorage.removeItem(OAUTH_KEY);
+      localStorage.removeItem(GUEST_KEY);
       set({ user: null });
     }
   };

--- a/frontend/src/commons/stores/test/authStore.test.ts
+++ b/frontend/src/commons/stores/test/authStore.test.ts
@@ -36,14 +36,22 @@ describe('authStore', () => {
 
       const result = await useAuthStore.getState().loginGuest('battle-1');
 
-      expect(result).toEqual(mockGuestData);
+      expect(result).toEqual({
+        id: 'guest-123',
+        nickname: '심심한 레오',
+        type: 'guest',
+        battleId: 'battle-1',
+        selectedTeam: undefined
+      });
       expect(useAuthStore.getState().user).toEqual({
         id: 'guest-123',
         nickname: '심심한 레오',
-        type: 'guest'
+        type: 'guest',
+        battleId: 'battle-1',
+        selectedTeam: undefined
       });
-      expect(localStorage.getItem('CMC_BATTLE_USER')).toBe(
-        JSON.stringify({ id: 'guest-123', nickname: '심심한 레오' })
+      expect(localStorage.getItem('CMC_GUEST_USER')).toBe(
+        JSON.stringify({ id: 'guest-123', nickname: '심심한 레오', type: 'guest', battleId: 'battle-1' })
       );
       expect(vi.mocked(fetchPostGuestLogin)).toHaveBeenCalledWith('battle-1');
     });
@@ -72,7 +80,7 @@ describe('authStore', () => {
 
       expect(result).toEqual(mockOAuthUser);
       expect(useAuthStore.getState().user).toEqual(mockOAuthUser);
-      expect(localStorage.getItem('CMC_BATTLE_USER')).toBe(JSON.stringify({ id: 'oauth-123', nickname: 'OAuth유저' }));
+      expect(localStorage.getItem('CMC_OAUTH_USER')).toBe(JSON.stringify(mockOAuthUser));
     });
 
     it('이미 OAuth 사용자가 로그인되어 있으면 API 호출 없이 반환한다', async () => {
@@ -143,7 +151,7 @@ describe('authStore', () => {
 
       expect(vi.mocked(logoutApi)).not.toHaveBeenCalled();
       expect(useAuthStore.getState().user).toBeNull();
-      expect(localStorage.getItem('CMC_BATTLE_USER')).toBeNull();
+      expect(localStorage.getItem('CMC_GUEST_USER')).toBeNull();
     });
 
     it('로그아웃 API 실패 시에는 에러를 던진다', async () => {
@@ -163,19 +171,21 @@ describe('authStore', () => {
 
       // 로그아웃 실패 시에는 clearAuth가 호출되지 않아야 함
       expect(useAuthStore.getState().user).toEqual(mockOAuthUser);
-      expect(localStorage.getItem('CMC_BATTLE_USER')).not.toBeNull();
+      expect(localStorage.getItem('CMC_OAUTH_USER')).not.toBeNull();
     });
   });
 
   describe('clearAuth', () => {
     it('store의 user를 null로 설정하고 localStorage를 삭제한다', () => {
-      localStorage.setItem('CMC_BATTLE_USER', JSON.stringify({ id: 'test', nickname: 'test' }));
+      localStorage.setItem('CMC_GUEST_USER', JSON.stringify({ id: 'test', nickname: 'test' }));
+      localStorage.setItem('CMC_OAUTH_USER', JSON.stringify({ id: 'test', nickname: 'test' }));
       useAuthStore.setState({ user: { id: 'test', nickname: 'test', type: 'guest' } });
 
       useAuthStore.getState().clearAuth();
 
       expect(useAuthStore.getState().user).toBeNull();
-      expect(localStorage.getItem('CMC_BATTLE_USER')).toBeNull();
+      expect(localStorage.getItem('CMC_GUEST_USER')).toBeNull();
+      expect(localStorage.getItem('CMC_OAUTH_USER')).toBeNull();
     });
   });
 

--- a/frontend/src/commons/types/AuthUser.ts
+++ b/frontend/src/commons/types/AuthUser.ts
@@ -7,5 +7,6 @@ export interface AuthUser {
   avatarUrl?: string;
   tier?: string;
   rating?: number;
-  battleId?: string; // 비회원 로그인인 경우에만 존재
+  battleId?: string;
+  selectedTeam?: 'A' | 'B';
 }

--- a/frontend/src/pages/battlePage/hooks/useBattle.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattle.ts
@@ -20,13 +20,18 @@ export function useBattle({ battleId, onOpenTeamChangeModal, onCloseTeamChangeMo
   const selectedTeamFromState = (location.state as { selectedTeam?: 'A' | 'B' | 'NONE' })?.selectedTeam;
   const user = useAuthStore((state) => state.user);
 
-  // 배틀 초기화 (selectedTeam 먼저 설정)
   useEffect(() => {
     if (!battleId || !user) return;
+    let teamToSet: 'A' | 'B' | 'NONE' = 'NONE';
 
-    // selectedTeam을 먼저 설정
-    if (selectedTeamFromState) {
-      useBattleStore.getState().setSelectedTeam(selectedTeamFromState);
+    if (user.type === 'guest' && user.selectedTeam) {
+      teamToSet = user.selectedTeam;
+    } else if (selectedTeamFromState) {
+      teamToSet = selectedTeamFromState;
+    }
+
+    if (teamToSet !== 'NONE') {
+      useBattleStore.getState().setSelectedTeam(teamToSet);
     }
 
     useBattleStore.getState().initializeBattle({
@@ -35,7 +40,6 @@ export function useBattle({ battleId, onOpenTeamChangeModal, onCloseTeamChangeMo
     });
   }, [battleId, selectedTeamFromState, user]);
 
-  // 모든 배틀 관련 훅 초기화
   useBattleSocket();
   useBattleSocketErrorHandling();
 

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -1,13 +1,14 @@
 import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import { io } from 'socket.io-client';
 import type { BattleJoinData } from '@/commons/types/battle';
 import { useBattleStore } from '../stores/battleStore';
 import { useAuthStore, selectUser } from '@/commons/stores/authStore';
 
 export function useBattleSocket() {
+  const { id: battleIdFromUrl } = useParams<{ id: string }>();
   const {
-    userId,
-    battleId,
+    battleId: battleIdFromStore,
     selectedTeam,
     setSocket,
     setIsConnected,
@@ -23,7 +24,12 @@ export function useBattleSocket() {
   const user = useAuthStore(selectUser);
 
   useEffect(() => {
-    if (!userId || !battleId || !user) return;
+    if (!user) return;
+
+    const userId = user.id;
+    const battleId = battleIdFromUrl || battleIdFromStore;
+
+    if (!userId || !battleId) return;
 
     const newSocket = io(import.meta.env.VITE_API_URL, {
       transports: ['websocket'],
@@ -150,19 +156,5 @@ export function useBattleSocket() {
       setIsConnected(false);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    userId,
-    battleId,
-    user,
-    setSocket,
-    setIsConnected,
-    setCurrentStage,
-    setBattleProgress,
-    setDiscussions,
-    setTeamCounts,
-    setTimelines,
-    setTeamChats,
-    setAllChats,
-    setChatInitialized
-  ]);
+  }, []);
 }

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -58,13 +58,6 @@ export default function BattlePage() {
   }, [leaveBattle]);
 
   useEffect(() => {
-    if (!user) {
-      alert('잘못된 진입입니다.');
-      navigate(`/battle/${battleId}/team-select`, { replace: true });
-    }
-  }, [user, navigate, battleId]);
-
-  useEffect(() => {
     const handlePageHide = () => {
       soundManager.stopAllBGM();
       safeLeaveBattle();

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -93,7 +93,9 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
   isTeamVoteResultShowing: false,
   pendingBattleClosed: false,
 
-  initializeBattle: (config) => set({ userId: config.userId, battleId: config.battleId, chatInitialized: false }),
+  initializeBattle: (config) => {
+    set({ userId: config.userId, battleId: config.battleId, chatInitialized: false });
+  },
   setSocket: (socket) => set({ socket }),
   setIsConnected: (connected) => set({ isConnected: connected }),
   setConnectionError: (error) => set({ connectionError: error }),
@@ -130,7 +132,6 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
   addAttackTimeline: (attack) =>
     set((state) => {
       const existingAttacks = state.timelines?.attacks || [];
-      // 중복 체크: 같은 discussionId가 이미 있으면 추가하지 않음
       const isDuplicate = existingAttacks.some((a) => a.discussionId === attack.discussionId);
 
       return {

--- a/frontend/src/pages/nicknamePage/index.test.tsx
+++ b/frontend/src/pages/nicknamePage/index.test.tsx
@@ -50,7 +50,8 @@ describe('NicknamePage', () => {
       loginGuest: vi.fn(),
       getOAuthUser: vi.fn(),
       logout: vi.fn(),
-      clearAuth: vi.fn()
+      clearAuth: vi.fn(),
+      updateGuestTeam: vi.fn()
     });
     vi.mocked(useAuthStore.setState).mockImplementation(() => {});
   });

--- a/frontend/src/pages/teamSelectPage/index.tsx
+++ b/frontend/src/pages/teamSelectPage/index.tsx
@@ -57,7 +57,7 @@ export default function TeamSelectPage() {
 
       // 비회원이거나 로그인 안 된 경우 서버에서 랜덤 닉네임 생성 후 로그인
       try {
-        const guestUser = await loginGuest(id);
+        const guestUser = await loginGuest(id, selectedTeam !== 'NONE' ? selectedTeam : undefined);
 
         useBattleStore.getState().initializeBattle({
           userId: guestUser.id,


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #327

## ✅ 작업 내용

### 💡개선 사항

#### 배틀 페이지에서 새로고침 시 진영 선택 페이지로 보내는 로직 제거 
- 새로고침시 `잘못된 접근입니다` alert 나오는 로직 제거  
- 진영 선택 페이지로 강제 리다이렉트 로직 제거

#### 배틀 페이지 새로고침 시 소켓 재연결 로직 적용
- 비회원 및 OAuth 유저 localStorage 기반 복원
  - `CMC_OAUTH_USER`: OAuth 유저 정보 저장 (id, nickname, avatarUrl, tier, rating 등)
  - `CMC_GUEST_USER`: 비회원 유저 정보 저장 (id, nickname, battleId, selectedTeam)
  -  배틀 중 진영 변경 시에도 localStorage에 진영 변경 결과 업데이트 하는 로직 추가 
- 새로고침 시 URL 파라미터에서 battleId 추출 한 값과 localStorage에 저장된 battleId/userId를 사용하여소켓 재연결
- URL의 battleId와 localStorage에 저장된 battleId 비교하여 동일한 배틀일 때만 복원

<br/>

### 동작 플로우

##### 기존 로직
<img width="903" height="158" alt="image" src="https://github.com/user-attachments/assets/2bdbe3ea-9977-4909-8dc9-e8ffd2d86605" />

##### 현재 개선한 로직
<img width="1134" height="180" alt="image" src="https://github.com/user-attachments/assets/2a5a8d21-9564-4c94-8161-002db413c711" />

<br/>

### 시연 영상 

https://github.com/user-attachments/assets/dc63e072-51c8-4ae7-a12c-53a8909ecac1

