### PR TITLE
[Fix] 게임에 새롭게 입장하거나 재입장 한 경우 이전 채팅 기록이 보이지 않는 문제를 해결 한다.

### DIFF
--- a/frontend/src/pages/battlePage/hooks/useBattleChat.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleChat.ts
@@ -21,16 +21,13 @@ export function useBattleChat() {
   const addChat = useBattleStore((state) => state.addChat);
   const user = useAuthStore(selectUser);
 
-  // 팀 채팅
   const teamMessages = useMemo(() => {
     if (!user) return [];
-    const myTeamChats = teamChats
-      .filter((chat) => chat.team === team && chat.scope === 'TEAM' && (!chat.type || chat.type === 'chat'))
-      .map((chat) => convertBattleChatToMessage(chat));
+
+    const myTeamChats = teamChats.map((chat) => convertBattleChatToMessage(chat));
 
     return myTeamChats.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
-  }, [teamChats, team, user]);
-  // 전체 채팅
+  }, [teamChats, user]);
 
   const allMessages = useMemo(() => {
     if (!user) return [];
@@ -46,7 +43,6 @@ export function useBattleChat() {
     if (team === 'NONE' || !opponentNoticeChat) return null;
     return convertBattleChatToMessage(opponentNoticeChat);
   }, [opponentNoticeChat, team, user]);
-  // 실시간 채팅 업데이트 이벤트 구독
 
   useEffect(() => {
     if (!socket) return;
@@ -58,7 +54,7 @@ export function useBattleChat() {
       socket.off('battle:chatted', handleChatUpdate);
     };
   }, [socket, addChat]);
-  // 메시지 전송
+
   const sendMessage = useCallback(
     (content: string, scope: 'TEAM' | 'ALL') => {
       if (!socket || !user) return;

--- a/frontend/src/pages/battlePage/stores/battleStore.ts
+++ b/frontend/src/pages/battlePage/stores/battleStore.ts
@@ -160,10 +160,7 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
       if (chat.scope === 'TEAM') {
         return { teamChats: [...state.teamChats, chat] };
       } else {
-        return {
-          allChats: [...state.allChats, chat],
-          teamChats: [...state.teamChats, chat]
-        };
+        return { allChats: [...state.allChats, chat] };
       }
     }),
   setSelectedTeam: (team) => set({ selectedTeam: team }),


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #336

## ✅ 작업 내용
최초 배틀 입장 시 진행 중인 게임과 동기화하는 로직에서 이전 채팅 기록이 표시되지 않는 문제를 수정했습니다.

### 💡개선 사항
#### 최초 배틀 입장 시 진행 중인 게임과 동기화하는 로직에서 이전 채팅 기록이 표시되지 않는 문제를 수정
문제 원인은  백엔드에서 보내주는 `battle:joined` 응답의 채팅 데이터에 `scope` 필드가 따로 내려오지 않는 상황에서 프론트엔드가 `chat.scope === 'TEAM'` 조건으로 필터링하고 있어서 battleStore에는 결국 채팅 관련 로그들은 undefined 형태로 저장되고 있었습니다. 

scope가 필요 없는 이유는... 이미 팀 채팅만 내려주고 있더라구요.

####  팀 채팅 필터링 조건 수정
   ```typescript
   // Before: scope 조건으로 필터링 (모두 걸러짐)
   teamChats.filter((chat) => chat.scope === 'TEAM' && ...)
   
   // After: scope 조건 제거
   teamChats.map((chat) => convertBattleChatToMessage(chat))
```
백엔드에서 이미 해당 팀의 채팅만 보내주므로 추가 필터링은 진행하지 않았습니다. 


#### 전체 채팅 동기화 로직 수정
위와 같이 전체 채팅 데이터도 프론트에서 `chat.scope === 'ALL`로 동기화 하고 있었는데, 다시 점검해보니 AllChat이라는 필드로 내려주고 있었더라구요 그래서 해당 로직을 지우고 AllChat 내용으로 동기화 시켰습니다. 