### PR TITLE
[Feature] 백엔드 에러 핸들링 GlobalExceptionFilter 추가

### DIFF
--- a/backend/src/battles/adapters/in/battles.controller.ts
+++ b/backend/src/battles/adapters/in/battles.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Get, Query, Param, HttpCode, InternalServerErrorException, HttpException, Res, UseGuards } from '@nestjs/common'
+import { Body, Controller, Post, Get, Query, Param, HttpCode, Res, UseGuards } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import type { Response } from 'express'
 import { BattleResultResponseDto } from '../../dto/battleResult.dto'
@@ -67,14 +67,7 @@ export class BattlesController {
   @Get(':id/result')
   @HttpCode(200)
   async getBattleResult(@Param('id') battleId: string): Promise<BattleResultResponseDto> {
-    try {
-      return await this.queryUseCase.getBattleResult(battleId)
-    } catch (error) {
-      if (error instanceof HttpException) {
-        throw error
-      }
-      throw new InternalServerErrorException('배틀 결과 조회 중 오류가 발생했습니다.')
-    }
+    return this.queryUseCase.getBattleResult(battleId)
   }
 
   private setInviteAccessCookie(battleId: string, res: Response) {

--- a/backend/src/common/filters/custom-global-exception.filter.ts
+++ b/backend/src/common/filters/custom-global-exception.filter.ts
@@ -31,6 +31,14 @@ export class CustomGlobalExceptionFilter implements ExceptionFilter {
         message = exception.message
       }
 
+      // HTTP 예외 로깅 (5xx는 error, 4xx는 warn)
+      const logMessage = `[${request.method}] ${request.url} - ${status} ${message}`
+      if (status >= 500) {
+        this.logger.error(logMessage, exception.stack)
+      } else {
+        this.logger.warn(logMessage)
+      }
+
       response.status(status).json({
         statusCode: status,
         message,
@@ -42,8 +50,10 @@ export class CustomGlobalExceptionFilter implements ExceptionFilter {
       return
     }
 
-    // 예상치 못한 에러
-    this.logger.error('Unexpected error:', exception)
+    // 예상치 못한 에러 (Error 객체가 아닌 경우 포함)
+    const errorMessage = exception instanceof Error ? exception.message : String(exception)
+    const errorStack = exception instanceof Error ? exception.stack : undefined
+    this.logger.error(`[${request.method}] ${request.url} - 500 ${errorMessage}`, errorStack)
 
     response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
       statusCode: HttpStatus.INTERNAL_SERVER_ERROR,

--- a/backend/src/common/filters/custom-global-exception.filter.ts
+++ b/backend/src/common/filters/custom-global-exception.filter.ts
@@ -1,0 +1,56 @@
+import { ExceptionFilter, Catch, ArgumentsHost, HttpException, HttpStatus, Logger } from '@nestjs/common'
+import { Request, Response } from 'express'
+
+@Catch()
+export class CustomGlobalExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(CustomGlobalExceptionFilter.name)
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp()
+    const response = ctx.getResponse<Response>()
+    const request = ctx.getRequest<Request>()
+
+    // HTTP 예외인 경우
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus()
+      const exceptionResponse = exception.getResponse()
+
+      // Validation 에러 처리 (message가 배열인 경우)
+      let message: string
+      let details: string[] | undefined
+
+      if (typeof exceptionResponse === 'object' && 'message' in exceptionResponse) {
+        const msg = (exceptionResponse as { message: unknown }).message
+        if (Array.isArray(msg)) {
+          message = '입력 값이 올바르지 않습니다.'
+          details = msg
+        } else {
+          message = String(msg)
+        }
+      } else {
+        message = exception.message
+      }
+
+      response.status(status).json({
+        statusCode: status,
+        message,
+        error: HttpStatus[status],
+        ...(details && { details }),
+        timestamp: new Date().toISOString(),
+        path: request.url,
+      })
+      return
+    }
+
+    // 예상치 못한 에러
+    this.logger.error('Unexpected error:', exception)
+
+    response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: '서버 내부 오류가 발생했습니다.',
+      error: 'Internal Server Error',
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    })
+  }
+}

--- a/backend/src/common/filters/custom-global-exception.filter.ts
+++ b/backend/src/common/filters/custom-global-exception.filter.ts
@@ -1,5 +1,6 @@
 import { ExceptionFilter, Catch, ArgumentsHost, HttpException, HttpStatus, Logger } from '@nestjs/common'
 import { Request, Response } from 'express'
+import { ErrorResponse } from '../responses/error-response'
 
 @Catch()
 export class CustomGlobalExceptionFilter implements ExceptionFilter {
@@ -39,14 +40,7 @@ export class CustomGlobalExceptionFilter implements ExceptionFilter {
         this.logger.warn(logMessage)
       }
 
-      response.status(status).json({
-        statusCode: status,
-        message,
-        error: HttpStatus[status],
-        ...(details && { details }),
-        timestamp: new Date().toISOString(),
-        path: request.url,
-      })
+      response.status(status).json(new ErrorResponse(status, message, HttpStatus[status], request.url, details))
       return
     }
 
@@ -55,12 +49,7 @@ export class CustomGlobalExceptionFilter implements ExceptionFilter {
     const errorStack = exception instanceof Error ? exception.stack : undefined
     this.logger.error(`[${request.method}] ${request.url} - 500 ${errorMessage}`, errorStack)
 
-    response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
-      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-      message: '서버 내부 오류가 발생했습니다.',
-      error: 'Internal Server Error',
-      timestamp: new Date().toISOString(),
-      path: request.url,
-    })
+    const internalError = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, '서버 내부 오류가 발생했습니다.', 'Internal Server Error', request.url)
+    response.status(HttpStatus.INTERNAL_SERVER_ERROR).json(internalError)
   }
 }

--- a/backend/src/common/responses/error-response.ts
+++ b/backend/src/common/responses/error-response.ts
@@ -1,0 +1,17 @@
+export class ErrorResponse {
+  public readonly statusCode: number
+  public readonly message: string
+  public readonly error: string
+  public readonly path: string
+  public readonly timestamp: string
+  public readonly details?: string[]
+
+  constructor(statusCode: number, message: string, error: string, path: string, details?: string[]) {
+    this.statusCode = statusCode
+    this.message = message
+    this.error = error
+    this.path = path
+    this.timestamp = new Date().toISOString()
+    this.details = details
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core'
 import { AppModule } from './app.module'
 import { ValidationPipe } from '@nestjs/common'
 import cookieParser from 'cookie-parser'
+import { CustomGlobalExceptionFilter } from './common/filters/custom-global-exception.filter'
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
@@ -18,6 +19,7 @@ async function bootstrap() {
       forbidNonWhitelisted: true,
     }),
   )
+  app.useGlobalFilters(new CustomGlobalExceptionFilter())
   app.use(cookieParser())
   await app.listen(process.env.PORT ?? 3000)
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #340

## ✅ 작업 내용

### 💡개선 사항

**CustomGlobalExceptionFilter 구현**

- `backend/src/common/filters/custom-global-exception.filter.ts` 생성
- `backend/src/common/responses/error-response.ts` 생성 (에러 응답 공통 클래스)
- `main.ts`에 글로벌 필터 등록
- 중복 에러 처리 코드 제거 (`battles.controller.ts`)

**에러 응답 표준화**

| 항목 | 이전 | 이후 |
|------|------|------|
| timestamp | ❌ 없음 | ✅ 모든 응답에 포함 |
| path | ❌ 없음 | ✅ 모든 응답에 포함 |
| 에러 로깅 | ❌ 없음 | ✅ 4xx warn, 5xx error 로깅 |
| 스택 트레이스 | ⚠️ 노출 위험 | ✅ 로그에만 기록 |
| Validation 에러 | ⚠️ message에 배열 혼합 | ✅ details 필드 분리 |
| 응답 생성 | 필터 내 직접 객체 생성 | ✅ ErrorResponse 클래스로 공통화 |

**에러 응답 형식 예시**

    {
      "statusCode": 400,
      "message": "입력 값이 올바르지 않습니다.",
      "error": "BAD_REQUEST",
      "path": "/battles",
      "timestamp": "2026-02-02T12:00:00.000Z",
      "details": ["title must be a string"]
    }

**로그 출력 예시**

    [WARN] [GET] /battles/123/result - 404 배틀이 존재하지 않습니다.
    [ERROR] [POST] /battles - 500 서버 내부 오류가 발생했습니다.

<br />

## 📸 참고 사항

https://github.com/user-attachments/assets/7d41b070-e967-4498-999c-73e89f18fac6

**변경된 파일**

- `backend/src/common/filters/custom-global-exception.filter.ts` - 새로 생성 (글로벌 예외 필터)
- `backend/src/common/responses/error-response.ts` - 새로 생성 (에러 응답 공통 클래스)
- `backend/src/main.ts` - 필터 등록 추가
- `backend/src/battles/adapters/in/battles.controller.ts` - 중복 try-catch 제거

**글로벌 필터 동작 범위**

- HTTP 요청만 처리 (WebSocket은 기존 `battles.gateway.ts` 에러 처리 유지)
- 기존 `throw new NotFoundException()` 등 코드 변경 없이 그대로 작동

<br />

## 💬 질문사항 (고민했던 부분)

### WebSocket 에러 처리 통합 여부
WebSocket 에러 처리를 글로벌 필터로 통합하는 방안을 검토했으나, 현재 방식을 유지하기로 결정했습니다.

**현재 방식 유지 이유:**
- 메트릭 연동: `stopTimer()` 호출로 응답 시간 측정이 에러 처리와 결합되어 있음
- 세분화된 에러 이벤트: `error:submit`, `error:vote` 등 상황별 이벤트명 사용 중
- 변경 시 영향: 에러 이벤트명 통일 시 클라이언트 코드 수정 필요