### PR TITLE
[Feature] HTTPS 적용 및 보안 설정 정리

### DIFF
--- a/backend/src/battles/adapters/in/battles.controller.spec.ts
+++ b/backend/src/battles/adapters/in/battles.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { ConfigService } from '@nestjs/config'
 import { NotFoundException, BadRequestException } from '@nestjs/common'
 import type { Response } from 'express'
 import type { BattleLanguage, BattleCategory } from '../../domains/models/types/battle.types'
@@ -31,6 +32,12 @@ describe('BattlesController', () => {
             getBattleByInviteCode: jest.fn(),
             getJoinBattleInfo: jest.fn(),
             getBattleResult: jest.fn(),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn().mockReturnValue(undefined),
           },
         },
         {

--- a/backend/src/battles/adapters/in/battles.controller.ts
+++ b/backend/src/battles/adapters/in/battles.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Post, Get, Query, Param, HttpCode, InternalServerErrorException, HttpException, Res, UseGuards } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
 import type { Response } from 'express'
 import { BattleResultResponseDto } from '../../dto/battleResult.dto'
 import { BattleCreateQueryDto } from '../../dto/battleCreateQuery.dto'
@@ -17,6 +18,7 @@ export class BattlesController {
   constructor(
     private readonly creationUseCase: BattleCreationUseCase,
     private readonly queryUseCase: BattleQueryUseCase,
+    private readonly configService: ConfigService,
   ) {}
 
   @Post()
@@ -78,7 +80,7 @@ export class BattlesController {
   private setInviteAccessCookie(battleId: string, res: Response) {
     res.cookie(`inviteAccess_${battleId}`, 'true', {
       httpOnly: true,
-      secure: false,
+      secure: this.configService.get<string>('NODE_ENV') === 'production',
       sameSite: 'lax',
       path: '/',
       maxAge: 60 * 60 * 1000, // 1시간

--- a/backend/src/oauth/service/token.service.ts
+++ b/backend/src/oauth/service/token.service.ts
@@ -70,8 +70,7 @@ export class TokenService {
    * 쿠키에 토큰 설정
    */
   setTokensInCookie(res: Response, accessToken: string, refreshToken: string): void {
-    // const isSecure = this.config.get<string>('NODE_ENV') === 'production'
-    const isSecure = false
+    const isSecure = this.config.get<string>('NODE_ENV') === 'production'
 
     // Access Token 쿠키 설정
     res.cookie('access_token', accessToken, {
@@ -172,8 +171,7 @@ export class TokenService {
   }
 
   clearAuthCookies(res: Response): void {
-    // const isSecure = this.config.get<string>('NODE_ENV') === 'production'
-    const isSecure = false
+    const isSecure = this.config.get<string>('NODE_ENV') === 'production'
 
     res.clearCookie('access_token', {
       httpOnly: true,

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -59,12 +59,35 @@ services:
     privileged: true
     restart: unless-stopped
 
-  frontend:
-    image: ghcr.io/boostcampwm2025/web02-cmc-frontend-prod:${VERSION_TAG:-latest}
+  nginx:
+    image: nginx:1.27-alpine
     ports:
       - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - letsencrypt:/etc/letsencrypt:ro
+      - certbot-webroot:/var/www/certbot:ro
+    depends_on:
+      - frontend
+      - backend
+    restart: unless-stopped
+    command: "/bin/sh -c 'while :; do sleep 12h; nginx -s reload; done & nginx -g \"daemon off;\"'"
+
+  frontend:
+    image: ghcr.io/boostcampwm2025/web02-cmc-frontend-prod:${VERSION_TAG:-latest}
     depends_on:
       - backend
+    restart: unless-stopped
+
+  certbot:
+    image: certbot/certbot:latest
+    volumes:
+      - letsencrypt:/etc/letsencrypt
+      - certbot-webroot:/var/www/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+    depends_on:
+      - nginx
     restart: unless-stopped
 
   redis:
@@ -82,4 +105,6 @@ services:
     restart: unless-stopped
 
 volumes:
+  letsencrypt:
+  certbot-webroot:
   redis-data:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -7,25 +7,4 @@ server {
     location / {
         try_files $uri $uri/ /index.html;
     }
-
-# Proxy API to backend container
-    location /api/ {
-        proxy_pass http://backend:3000/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-# WebSocket (Socket.IO) proxy
-    location /socket.io/ {
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-        proxy_set_header Host $host;
-        proxy_pass http://backend:3000;
-        proxy_http_version 1.1;
-        proxy_read_timeout 600s;
-        proxy_send_timeout 600s;
-    }
-    
 }

--- a/frontend/src/pages/battleCreatePage/components/InviteLinkButton.tsx
+++ b/frontend/src/pages/battleCreatePage/components/InviteLinkButton.tsx
@@ -11,30 +11,9 @@ export default function InviteLinkButton({ inviteCode }: InviteLinkProps) {
 
   const inviteLink = `${window.location.origin}/battles/${inviteCode}`;
 
-  // HTTPS 환경
-  const copyWithNavigator = async (text: string) => {
-    await navigator.clipboard.writeText(text);
-  };
-
-  // HTTP 환경
-  const copyWithExecCommand = (text: string) => {
-    const textarea = document.createElement('textarea');
-    textarea.value = text;
-    textarea.style.position = 'fixed';
-    textarea.style.opacity = '0';
-    document.body.appendChild(textarea);
-    textarea.select();
-    document.execCommand('copy');
-    document.body.removeChild(textarea);
-  };
-
   const handleCopy = async () => {
     try {
-      if (navigator.clipboard && window.isSecureContext) {
-        await copyWithNavigator(inviteLink);
-      } else {
-        copyWithExecCommand(inviteLink);
-      }
+      await navigator.clipboard.writeText(inviteLink);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (error) {

--- a/frontend/src/pages/battleCreatePage/components/test/InviteLinkButton.test.tsx
+++ b/frontend/src/pages/battleCreatePage/components/test/InviteLinkButton.test.tsx
@@ -9,12 +9,6 @@ Object.assign(navigator, {
   }
 });
 
-// window.isSecureContext를 true로 설정
-Object.defineProperty(window, 'isSecureContext', {
-  value: true,
-  writable: true
-});
-
 describe('InviteLinkButton', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,55 @@
+# HTTP → HTTPS 리다이렉트
+server {
+    listen 80;
+    server_name _;
+
+    # certbot 인증서 발급/갱신용
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS 서버
+server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate /etc/letsencrypt/live/cmctv.kro.kr/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/cmctv.kro.kr/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    # 프론트엔드 정적 파일
+    location / {
+        proxy_pass http://frontend:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # 백엔드 API
+    location /api/ {
+        proxy_pass http://backend:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # WebSocket (Socket.IO)
+    location /socket.io/ {
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,7 +1,7 @@
 # HTTP → HTTPS 리다이렉트
 server {
     listen 80;
-    server_name _;
+    server_name cmctv.kro.kr;
 
     # certbot 인증서 발급/갱신용
     location /.well-known/acme-challenge/ {
@@ -16,7 +16,7 @@ server {
 # HTTPS 서버
 server {
     listen 443 ssl;
-    server_name _;
+    server_name cmctv.kro.kr;
 
     ssl_certificate /etc/letsencrypt/live/cmctv.kro.kr/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/cmctv.kro.kr/privkey.pem;


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #346

## ✅ 작업 내용

### 💡개선 사항

**1. 독립 nginx 리버스 프록시 컨테이너로 HTTPS 적용**
- `docker-compose-prod.yml`에 독립 nginx 컨테이너 추가 (SSL 종료 + 리버스 프록시)
- certbot 컨테이너 추가 (Let's Encrypt 인증서 자동 발급/갱신)
- `nginx/nginx.conf` 신규 생성: HTTP→HTTPS 리다이렉트, `/api/` 백엔드 프록시, `/socket.io/` WebSocket 프록시, 프론트엔드 정적 파일 프록시
- `server_name`을 `cmctv.kro.kr`로 명시
- 인증서 12시간 주기 자동 갱신 및 nginx reload 설정

**2. 쿠키 secure 옵션을 환경변수 기반으로 변경**
- `token.service.ts`: `secure: false` 하드코딩 → `NODE_ENV === 'production'` 기반 분기 (setTokensInCookie, clearAuthCookies 2곳)
- `battles.controller.ts`: ConfigService 주입 후 `setInviteAccessCookie`에 동일 로직 적용

**3. execCommand 클립보드 폴백 제거**
- `InviteLinkButton.tsx`: `document.execCommand('copy')` 폴백 함수 제거, `navigator.clipboard.writeText`만 사용
- HTTPS(Secure Context) 환경에서는 Clipboard API가 항상 동작하므로 폴백 불필요

<br />

## 📸 참고 사항

https://github.com/user-attachments/assets/4c1d86c7-8d14-47de-91db-518b9a5b49ff

- HTTPS가 선행되어야 쿠키 `secure: true`와 `navigator.clipboard` API가 정상 동작하므로, 3가지 작업을 하나의 PR로 통합
- 프론트엔드 컨테이너는 현재 유지하되, 추후 CDN 전환 시 제거 예정
- 프로덕션 배포 시 필요한 추가 작업:
  - `.env`의 URL들을 `https://cmctv.kro.kr`로 변경
  - GitHub/Kakao OAuth 앱 설정에서 콜백 URL을 `https`로 업데이트
  - certbot 초기 인증서 발급: `docker compose -f docker-compose-prod.yml run --rm certbot certonly --webroot -w /var/www/certbot -d cmctv.kro.kr`

### 주요 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `nginx/nginx.conf` | 신규 — SSL 종료 + 리버스 프록시 설정 |
| `docker-compose-prod.yml` | nginx, certbot 컨테이너 추가 + SSL 볼륨 |
| `backend/src/oauth/service/token.service.ts` | `secure: false` → 환경변수 기반 |
| `backend/src/battles/controller/battles.controller.ts` | ConfigService 주입 + secure 환경변수 기반 |
| `backend/src/battles/controller/battles.controller.spec.ts` | ConfigService mock 추가 |
| `frontend/src/.../InviteLinkButton.tsx` | execCommand 폴백 제거 |
| `frontend/src/.../InviteLinkButton.test.tsx` | 테스트 업데이트 |

<br />

## 💬 질문사항 (고민했던 부분)

- 프론트엔드를 CDN으로 전환할 때 nginx에서 `location /` 프록시와 docker-compose의 frontend 서비스를 제거하면 됩니다. 현재는 기존 구조를 유지한 상태입니다.
- `sameSite: 'lax'` 설정은 CDN(다른 도메인)에서 프론트를 서빙할 경우 쿠키 전달에 영향을 줄 수 있어, CDN 전환 시 CORS + sameSite 설정 검토가 필요합니다.