### PR TITLE
[Fix] /tutorial/battle 페이지가 로딩되지 않는 문제 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,7 +38,7 @@ const router = createBrowserRouter([
         element: <TutorialTeamSelectPage />,
         loader: () => TUTORIAL_BATTLE_INFO
       },
-      { path: 'tutorial/battle', element: <TutorialBattlePage /> },
+      { path: 'tutorial/battle', element: <TutorialBattlePage />, loader: () => TUTORIAL_BATTLE_INFO },
       { path: 'battles/:inviteCode', element: <InvitePage /> },
       { path: 'battles/:id/result', element: <BattleResultPage /> }
     ]

--- a/frontend/src/pages/tutorialBattlePage/hooks/usePracticeFlow.ts
+++ b/frontend/src/pages/tutorialBattlePage/hooks/usePracticeFlow.ts
@@ -297,15 +297,15 @@ export function usePracticeFlow({ currentStep, onOpenTeamChangeModal }: Practice
       const trimmed = content.trim();
       const currentUser = useAuthStore.getState().user;
       const team = useBattleStore.getState().selectedTeam;
-
-      if (!trimmed || !currentUser || team === 'NONE') return;
+      console.log('Submitting discussion:', { trimmed, currentUser, team });
+      if (!trimmed || team === 'NONE') return;
 
       const state = useBattleStore.getState();
       const totalVotes = state.discussions.reduce((sum, discussion) => sum + discussion.votes, 0);
 
       state.addDiscussion({
         id: Date.now(),
-        user: currentUser.nickname,
+        user: currentUser?.nickname ? currentUser.nickname : 'You',
         team: team as 'A' | 'B',
         content: trimmed,
         votes: 0,

--- a/frontend/src/pages/tutorialBattlePage/hooks/useTutorialBattleSetup.ts
+++ b/frontend/src/pages/tutorialBattlePage/hooks/useTutorialBattleSetup.ts
@@ -30,7 +30,7 @@ export function useTutorialBattleSetup({ battleInfo, selectedTeamFromState }: Tu
 
     const store = useBattleStore.getState();
     store.initializeBattle({ userId: activeUser.id, battleId: TUTORIAL_BATTLE_ID });
-    store.setSelectedTeam(selectedTeamFromState ?? 'NONE');
+    store.setSelectedTeam(selectedTeamFromState ?? 'A');
     store.setBattleProgress(TUTORIAL_BATTLE_PROGRESS);
     store.setCurrentStage(TUTORIAL_BATTLE_PROGRESS.phase);
     store.setTeamCounts(TUTORIAL_TEAM_COUNTS);

--- a/frontend/src/pages/tutorialBattlePage/index.tsx
+++ b/frontend/src/pages/tutorialBattlePage/index.tsx
@@ -101,17 +101,6 @@ export default function TutorialBattlePage() {
   const phase = battleProgress?.phase;
   const shouldShowInput = !isInputDisabled(selectedTeam, phase);
 
-  // 🔍 디버깅용 콘솔 로그
-  console.log('=== TutorialBattlePage State ===');
-  console.log('selectedTeam:', selectedTeam);
-  console.log('selectedTeamFromState:', selectedTeamFromState);
-  console.log('phase:', phase);
-  console.log('battleProgress:', battleProgress);
-  console.log('isInputDisabled result:', isInputDisabled(selectedTeam, phase));
-  console.log('shouldShowInput:', shouldShowInput);
-  console.log('practicePhase:', practicePhase);
-  console.log('================================');
-
   const handleAutoExit = useCallback(() => {
     navigate('/');
   }, [navigate]);

--- a/frontend/src/pages/tutorialBattlePage/index.tsx
+++ b/frontend/src/pages/tutorialBattlePage/index.tsx
@@ -101,6 +101,17 @@ export default function TutorialBattlePage() {
   const phase = battleProgress?.phase;
   const shouldShowInput = !isInputDisabled(selectedTeam, phase);
 
+  // 🔍 디버깅용 콘솔 로그
+  console.log('=== TutorialBattlePage State ===');
+  console.log('selectedTeam:', selectedTeam);
+  console.log('selectedTeamFromState:', selectedTeamFromState);
+  console.log('phase:', phase);
+  console.log('battleProgress:', battleProgress);
+  console.log('isInputDisabled result:', isInputDisabled(selectedTeam, phase));
+  console.log('shouldShowInput:', shouldShowInput);
+  console.log('practicePhase:', practicePhase);
+  console.log('================================');
+
   const handleAutoExit = useCallback(() => {
     navigate('/');
   }, [navigate]);


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->


closes #351 

## ✅ 작업 내용

배포서버에서는 /tutorial/battle 페이지로 라우팅이 성공하는데 CDN에서는 404 페이지 에러가 발생한다.

TutorialBattlePage에서 useLoaderData를 사용하여 데이터를 가져오려는데, App.tsx에서 loader가 존재하지 않아, CDN에서는 데이터를 가져오지 못한 에러가 발생

- [x]  App.tsx에 loader 추가

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

https://5yii1ap713732.edge.naverncp.com/tutorial/battle
<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
