### PR TITLE
[Fix] 배포 환경에서 채팅 시간이 9시간 빠르게 표시되는 문제 수정 

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,6 +27,10 @@ RUN pnpm -C backend build
 FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+
+RUN apk add --no-cache tzdata
+ENV TZ=Asia/Seoul
+
 RUN corepack enable
 
 # Copy workspace files


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #356

## ✅ 작업 내용
### Docker 컨테이너의 타임존을 UTC에서 Asia/Seoul(KST)로 변경
Docker 컨테이너는 기본적으로 UTC(UTC+0) 타임존을 사용하기에  한국 시간과 9시간 차이 발생 합니다. 그래서 타임존을 Asia/Seoul로 설정했습니다

```docker
...
# -------- Runtime image --------
FROM node:20-alpine AS runner
WORKDIR /app
ENV NODE_ENV=production

# 타임존 설정 추가
RUN apk add --no-cache tzdata
ENV TZ=Asia/Seoul

...
```