### PR TITLE
[Feature] NCP Object Storage 생성 및 빌드 파일 업로드

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -93,7 +93,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ steps.image_names.outputs.frontend_image }}:latest
             ${{ env.REGISTRY }}/${{ steps.image_names.outputs.frontend_image }}:${{ steps.set_version.outputs.version_tag }}
 
-  cd:
+  cd-backend:
     needs: ci
     runs-on: ubuntu-latest
     steps:
@@ -141,3 +141,64 @@ jobs:
             docker compose -f docker-compose.yml up -d
 
             echo "[SUCCESS] Deployment completed successfully ✅"
+
+  cd-frontend:
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        env:
+          HUSKY: 0
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend
+        env:
+          VITE_API_URL: ${{ secrets.VITE_API_URL }}
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          VITE_ENABLE_SENTRY: ${{ secrets.VITE_ENABLE_SENTRY }}
+        run: pnpm -C frontend build
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+
+      - name: Install AWS CLI (NCP compatible)
+        run: pip install awscli==1.15.85
+
+      - name: Upload to NCP Object Storage
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.NCP_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.NCP_SECRET_KEY }}
+        run: |
+          aws s3 sync frontend/dist/ s3://${{ secrets.NCP_BUCKET }}/${{ secrets.NCP_BUCKET_ROOT }} \
+            --endpoint-url ${{ secrets.NCP_ENDPOINT }} \
+            --exclude "index.html" \
+            --delete \
+            --acl public-read \
+            --cache-control "public max-age=31536000, immutable"
+
+          aws s3 sync frontend/dist/ s3://${{ secrets.NCP_BUCKET }}/${{ secrets.NCP_BUCKET_ROOT }} \
+            --endpoint-url ${{ secrets.NCP_ENDPOINT }} \
+            --exclude "*" \
+            --include "index.html" \
+            --acl public-read \
+            --cache-control "no-cache, no-store, must-revalidate"
+
+      - name: Deployment summary
+        run: |
+          echo "✅ Frontend deployed to Object Storage successfully!"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -191,7 +191,7 @@ jobs:
             --exclude "index.html" \
             --delete \
             --acl public-read \
-            --cache-control "public max-age=31536000, immutable"
+            --cache-control "public, max-age=31536000, immutable"
 
           aws s3 sync frontend/dist/ s3://${{ secrets.NCP_BUCKET }}/${{ secrets.NCP_BUCKET_ROOT }} \
             --endpoint-url ${{ secrets.NCP_ENDPOINT }} \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -168,6 +168,7 @@ jobs:
       - name: Build frontend
         env:
           VITE_API_URL: ${{ secrets.VITE_API_URL }}
+          VITE_SOCKET_URL: ${{ secrets.VITE_SOCKET_URL }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           VITE_ENABLE_SENTRY: ${{ secrets.VITE_ENABLE_SENTRY }}
         run: pnpm -C frontend build


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #334 

## ✅ 작업 내용

- [x] Deploy 단계에서 Frontend 빌드 파일을 Object Storage에 저장한다.
- [x] 각 파일 캐싱 설정

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

#### **캐싱 설정**
1. **index.html**
<img width="1464" height="642" alt="image" src="https://github.com/user-attachments/assets/91b1150d-246c-4580-a596-6bbb02e30b3f" />

파일을 빌드하면 `index.html` 는 진입점이기 때문에 항상 동일한 파일명을 갖는다. 

CDN 입장에서는 파일명이 동일하기 때문에 파일 내용의 변경 여부를 파악하기 어려우며 최신 파일이 아닌 과거에 캐싱된 파일을 계속 서빙될 수 있는 문제가 존재한다.

그렇기 때문에 캐싱하지 않는다는 옵션을 추가하여 파일을 저장한다.

- `no-cache`: 캐시된 복사본을 사용자에게 보여주기 이전에, 재검증을 위한 요청을 원 서버로 보내도록 강제합니다.
- `no-store`:캐시는 클라이언트 요청 혹은 서버 응답에 관해서 어떤 것도 저장해서는 안됩니다.
- `must-revalidate` :캐시는 사용하기 이전에 기존 리소스의 상태를 반드시 확인해야 하며 만료된 리소스는 사용되어서는 안됩니다.

2. **그 외 Assets + Scripts** 
<img width="1434" height="644" alt="image" src="https://github.com/user-attachments/assets/c4d00dd8-f1db-4a6e-8974-023a077a4f64" />

반면, `assets` , `script`와 같은 파일은 오랜 기간동안 변화하지 않거나 변화된 파일에 대해서는 파일명이 해싱되어 저장된다. 그렇기 때문에, 오랜 기간 변화하지 않는 파일은 그대로 캐싱을, 변화된  파일은 감지하여 원본으로 요청을 바로 보낼 수 있다.

- `public` :응답이 어떤 캐시에 의해서든 캐시된다는 것을 나타냅니다
- `max-age` : 리소스가 최신 상태라고 판단할 최대 시간을 지정합니다. `Expires`에 반해, 이 디렉티브는 요청 시간과 관련이 있습니다.
- `immutable`: 해당 리소스는 변하지 않는다고 명시하며 새로고침 시에도 기존의 데이터를 사용한다.

다만 Chrome은 immutable을 지원하지 않으며 Firefox나 Safari에서는 지원한다.


자세한 내용은 [노션 팀위키](https://lovely-sunstone-c80.notion.site/Object-Storage-CDN-2fbd7ffb4ba480888797ef6bacaefc6b?source=copy_link)에 있습니다.

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
