### PR TITLE
[Refactor] Redis로 세션/캐싱/상태 관리

### DIFF
--- a/backend/src/battles/adapters/out/state/battleStateRepository.adapter.ts
+++ b/backend/src/battles/adapters/out/state/battleStateRepository.adapter.ts
@@ -73,7 +73,6 @@ interface SerializedBattleState {
 @Injectable()
 export class BattleStateRepositoryAdapter implements BattleStatePort {
   private readonly cachePrefix = 'battle:state:'
-
   constructor(
     private readonly prisma: PrismaService,
     private readonly redis: RedisRepository,

--- a/backend/src/battles/adapters/out/state/battleStateRepository.adapter.ts
+++ b/backend/src/battles/adapters/out/state/battleStateRepository.adapter.ts
@@ -139,6 +139,10 @@ export class BattleStateRepositoryAdapter implements BattleStatePort {
     await this.patchSkipCache(battleId, skipList)
   }
 
+  async clearCache(battleId: string): Promise<void> {
+    await this.redis.del(this.getCacheKey(battleId))
+  }
+
   parseMvpsState(value: unknown): Mvp[] {
     if (!Array.isArray(value)) return []
     return value

--- a/backend/src/battles/adapters/out/state/battleStateRepository.adapter.ts
+++ b/backend/src/battles/adapters/out/state/battleStateRepository.adapter.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common'
 import { Prisma } from 'generated/prisma/client'
 import { type Battle as PrismaBattle } from 'generated/prisma/client'
 import { PrismaService } from '../../../../prisma/prisma.service'
+import { RedisRepository } from '../../../../redis/redis.repository'
 import {
   ActiveBattleState,
   BattleTeam,
@@ -33,64 +34,64 @@ interface BattleChatSnapshot extends Omit<BattleChat, 'createdAt'> {
   createdAt: string
 }
 
+interface SerializedBattleState {
+  battleId: string
+  all: {
+    roomId: string
+    chats: BattleChatSnapshot[]
+    attacks: (BattleDiscussion | null)[]
+    defenses: (BattleDefense | null)[]
+  }
+  teamA: {
+    roomId: string
+    chats: BattleChatSnapshot[]
+    attacks: (BattleDiscussion | null)[]
+    defenses: (BattleDefense | null)[]
+    users: string[]
+  }
+  teamB: {
+    roomId: string
+    chats: BattleChatSnapshot[]
+    attacks: (BattleDiscussion | null)[]
+    defenses: (BattleDefense | null)[]
+    users: string[]
+  }
+  participants: [string, BattleTeam][]
+  teamVotes: [string, BattleTeam][]
+  userInfoMap: [string, string][]
+  opinionHistory: BattleDiscussion[]
+  skipState: string[]
+  round: number
+  topics: string[]
+  totalRounds: number
+  phase: BattlePhaseName
+  phaseCount: number
+  startedAt: number | null
+  expiredAt: number | null
+}
+
 @Injectable()
 export class BattleStateRepositoryAdapter implements BattleStatePort {
-  constructor(private readonly prisma: PrismaService) {}
+  private readonly cachePrefix = 'battle:state:'
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly redis: RedisRepository,
+  ) {}
 
   async loadBattleState(battleId: string): Promise<{ battle: PrismaBattle; state: ActiveBattleState }> {
+    const cachedState = await this.loadStateFromCache(battleId)
+
     const battle = await this.prisma.battle.findUnique({ where: { id: battleId } })
     if (!battle) throw new NotFoundException('배틀이 존재하지 않습니다.')
 
-    const participants = this.parseParticipantsState(battle.participantsState)
-    const teamVotes = this.parseTeamVotesState(battle.teamVotesState)
-    const userInfoMap = this.parseUserInfoState(battle.userInfoState)
-    const attackState = this.parseAttackState(battle.attacksState)
-    const defenseState = this.parseDefenseState(battle.defensesState)
-    const opinionHistory = this.parseOpinionHistoryState(battle.opinionHistoryState)
-    const skipState = new Set<string>(Array.isArray(battle.skipState) ? battle.skipState : [])
-
-    const playTime = BATTLE_PLAYTIME[battle.playTime as keyof typeof BATTLE_PLAYTIME]
-    if (!playTime) {
-      throw new NotFoundException('올바르지 않은 배틀 진행 시간입니다.')
+    //캐시에서 가져온 데이터가 있으면 바로 반환
+    if (cachedState) {
+      return { battle, state: cachedState }
     }
 
-    const state: ActiveBattleState = {
-      battleId,
-      all: {
-        roomId: this.getBattleRoomId(battleId),
-        chats: this.parseChatState(battle.chatsAllState),
-        attacks: attackState.all,
-        defenses: defenseState.all,
-      },
-      teamA: {
-        roomId: this.getBattleRoomId(battleId, BATTLE_TEAM.A),
-        users: [],
-        chats: this.parseChatState(battle.chatsTeamAState),
-        attacks: attackState.teamA,
-        defenses: defenseState.teamA,
-      },
-      teamB: {
-        roomId: this.getBattleRoomId(battleId, BATTLE_TEAM.B),
-        users: [],
-        chats: this.parseChatState(battle.chatsTeamBState),
-        attacks: attackState.teamB,
-        defenses: defenseState.teamB,
-      },
-      participants,
-      teamVotes,
-      userInfoMap,
-      opinionHistory,
-      skipState,
-      round: battle.currentRound ?? 1,
-      topics: battle.topics,
-      totalRounds: playTime.rounds,
-      phase: (battle.currentPhase ?? BATTLE_PHASE.PENDING.name) as BattlePhaseName,
-      phaseCount: battle.phaseCount ?? 1,
-      startedAt: battle.startedAt ? battle.startedAt.getTime() : null,
-      expiredAt: battle.expiredAt ? battle.expiredAt.getTime() : null,
-    }
-
-    this.rebuildTeamUsers(state)
+    const state = this.buildStateFromBattle(battle)
+    await this.persistStateCache(state)
     return { battle, state }
   }
 
@@ -124,6 +125,7 @@ export class BattleStateRepositoryAdapter implements BattleStatePort {
         updatedAt: new Date(),
       },
     })
+    await this.persistStateCache(state)
   }
 
   async updateSkipState(battleId: string, skipList: Set<string>): Promise<void> {
@@ -134,6 +136,7 @@ export class BattleStateRepositoryAdapter implements BattleStatePort {
         updatedAt: new Date(),
       },
     })
+    await this.patchSkipCache(battleId, skipList)
   }
 
   parseMvpsState(value: unknown): Mvp[] {
@@ -257,6 +260,171 @@ export class BattleStateRepositoryAdapter implements BattleStatePort {
     return value.filter(item => item && typeof item === 'object') as BattleDiscussion[]
   }
 
+  //캐시에서 가져오기
+  private async loadStateFromCache(battleId: string): Promise<ActiveBattleState | null> {
+    try {
+      const payload = await this.redis.get(this.getCacheKey(battleId))
+      if (!payload) return null
+      return this.deserializeState(JSON.parse(payload) as SerializedBattleState)
+    } catch {
+      return null
+    }
+  }
+
+  //캐시에 저장하기
+  private async persistStateCache(state: ActiveBattleState): Promise<void> {
+    const payload = this.serializeState(state)
+    await this.redis.set(this.getCacheKey(state.battleId), JSON.stringify(payload))
+  }
+
+  //skipState 업데이트 시 캐시 업데이트
+  private async patchSkipCache(battleId: string, skipList: Set<string>): Promise<void> {
+    const cachedState = await this.loadStateFromCache(battleId)
+    if (!cachedState) return
+    cachedState.skipState = new Set(skipList)
+    await this.persistStateCache(cachedState)
+  }
+
+  //캐시에 저장할 데이터 직렬화
+  private serializeState(state: ActiveBattleState): SerializedBattleState {
+    return {
+      battleId: state.battleId,
+      all: {
+        roomId: state.all.roomId,
+        chats: this.serializeChatState(state.all.chats),
+        attacks: state.all.attacks,
+        defenses: state.all.defenses,
+      },
+      teamA: {
+        roomId: state.teamA.roomId,
+        chats: this.serializeChatState(state.teamA.chats),
+        attacks: state.teamA.attacks,
+        defenses: state.teamA.defenses,
+        users: [...state.teamA.users],
+      },
+      teamB: {
+        roomId: state.teamB.roomId,
+        chats: this.serializeChatState(state.teamB.chats),
+        attacks: state.teamB.attacks,
+        defenses: state.teamB.defenses,
+        users: [...state.teamB.users],
+      },
+      participants: [...state.participants.entries()],
+      teamVotes: [...state.teamVotes.entries()],
+      userInfoMap: [...state.userInfoMap.entries()],
+      opinionHistory: state.opinionHistory,
+      skipState: Array.from(state.skipState),
+      round: state.round,
+      topics: state.topics,
+      totalRounds: state.totalRounds,
+      phase: state.phase,
+      phaseCount: state.phaseCount,
+      startedAt: state.startedAt,
+      expiredAt: state.expiredAt,
+    }
+  }
+
+  //캐시에서 가져온 데이터 역직렬화
+  private deserializeState(payload: SerializedBattleState): ActiveBattleState {
+    const participants = new Map<string, BattleTeam>(payload.participants ?? [])
+    const teamVotes = new Map<string, BattleTeam>(payload.teamVotes ?? [])
+    const userInfoMap = new Map<string, string>(payload.userInfoMap ?? [])
+
+    const state: ActiveBattleState = {
+      battleId: payload.battleId,
+      all: {
+        roomId: payload.all.roomId,
+        chats: this.parseChatState(payload.all.chats),
+        attacks: payload.all.attacks ?? [],
+        defenses: payload.all.defenses ?? [],
+      },
+      teamA: {
+        roomId: payload.teamA.roomId,
+        chats: this.parseChatState(payload.teamA.chats),
+        attacks: payload.teamA.attacks ?? [],
+        defenses: payload.teamA.defenses ?? [],
+        users: payload.teamA.users ?? [],
+      },
+      teamB: {
+        roomId: payload.teamB.roomId,
+        chats: this.parseChatState(payload.teamB.chats),
+        attacks: payload.teamB.attacks ?? [],
+        defenses: payload.teamB.defenses ?? [],
+        users: payload.teamB.users ?? [],
+      },
+      participants,
+      teamVotes,
+      userInfoMap,
+      opinionHistory: payload.opinionHistory ?? [],
+      skipState: new Set(payload.skipState ?? []),
+      round: payload.round,
+      topics: payload.topics,
+      totalRounds: payload.totalRounds,
+      phase: payload.phase,
+      phaseCount: payload.phaseCount,
+      startedAt: payload.startedAt,
+      expiredAt: payload.expiredAt,
+    }
+
+    this.rebuildTeamUsers(state)
+    return state
+  }
+
+  //데이터베이스에서 가져온 데이터 빌드
+  private buildStateFromBattle(battle: PrismaBattle): ActiveBattleState {
+    const participants = this.parseParticipantsState(battle.participantsState)
+    const teamVotes = this.parseTeamVotesState(battle.teamVotesState)
+    const userInfoMap = this.parseUserInfoState(battle.userInfoState)
+    const attackState = this.parseAttackState(battle.attacksState)
+    const defenseState = this.parseDefenseState(battle.defensesState)
+    const opinionHistory = this.parseOpinionHistoryState(battle.opinionHistoryState)
+    const skipState = new Set<string>(Array.isArray(battle.skipState) ? battle.skipState : [])
+
+    const playTime = BATTLE_PLAYTIME[battle.playTime as keyof typeof BATTLE_PLAYTIME]
+    if (!playTime) {
+      throw new NotFoundException('올바르지 않은 배틀 진행 시간입니다.')
+    }
+
+    const state: ActiveBattleState = {
+      battleId: battle.id,
+      all: {
+        roomId: this.getBattleRoomId(battle.id),
+        chats: this.parseChatState(battle.chatsAllState),
+        attacks: attackState.all,
+        defenses: defenseState.all,
+      },
+      teamA: {
+        roomId: this.getBattleRoomId(battle.id, BATTLE_TEAM.A),
+        users: [],
+        chats: this.parseChatState(battle.chatsTeamAState),
+        attacks: attackState.teamA,
+        defenses: defenseState.teamA,
+      },
+      teamB: {
+        roomId: this.getBattleRoomId(battle.id, BATTLE_TEAM.B),
+        users: [],
+        chats: this.parseChatState(battle.chatsTeamBState),
+        attacks: attackState.teamB,
+        defenses: defenseState.teamB,
+      },
+      participants,
+      teamVotes,
+      userInfoMap,
+      opinionHistory,
+      skipState,
+      round: battle.currentRound ?? 1,
+      topics: battle.topics,
+      totalRounds: playTime.rounds,
+      phase: (battle.currentPhase ?? BATTLE_PHASE.PENDING.name) as BattlePhaseName,
+      phaseCount: battle.phaseCount ?? 1,
+      startedAt: battle.startedAt ? battle.startedAt.getTime() : null,
+      expiredAt: battle.expiredAt ? battle.expiredAt.getTime() : null,
+    }
+
+    this.rebuildTeamUsers(state)
+    return state
+  }
+
   private rebuildTeamUsers(state: ActiveBattleState): void {
     state.teamA.users = []
     state.teamB.users = []
@@ -265,6 +433,10 @@ export class BattleStateRepositoryAdapter implements BattleStatePort {
       if (team === BATTLE_TEAM.A) state.teamA.users.push(userId)
       if (team === BATTLE_TEAM.B) state.teamB.users.push(userId)
     }
+  }
+
+  private getCacheKey(battleId: string): string {
+    return `${this.cachePrefix}${battleId}`
   }
 
   private getBattleRoomId(battleId: string, team?: BattleTeam): string {

--- a/backend/src/battles/adapters/out/timer/battleTimer.adapter.ts
+++ b/backend/src/battles/adapters/out/timer/battleTimer.adapter.ts
@@ -13,15 +13,7 @@ export class BattleTimerAdapter implements BattleTimerPort {
   schedule(battleId: string, state: ActiveBattleState): void {
     if (!state.expiredAt) return
 
-    const now = Date.now()
-    const remaining = Math.ceil((state.expiredAt - now) / 1000)
-
-    console.log(`📝 [타이머 등록] battleId=${battleId}`)
-    console.log(`   - 현재 시간: ${now} (${new Date(now).toLocaleString('ko-KR')})`)
-    console.log(`   - 만료 시간: ${state.expiredAt} (${new Date(state.expiredAt).toLocaleString('ko-KR')})`)
-    console.log(`   - 남은 시간: ${remaining}초`)
-
-    // Redis Sorted Set에 저장 (score = expiredAt, member = battleId)
+    // Redis Sorted Set에 저장
     void this.redisRepository.zadd(this.TIMERS_KEY, state.expiredAt, battleId)
   }
 
@@ -35,19 +27,7 @@ export class BattleTimerAdapter implements BattleTimerPort {
     const now = Date.now()
 
     // 현재 시간보다 작은 score를 가진 모든 member 조회
-    const expiredBattles = await this.redisRepository.zrangebyscore(this.TIMERS_KEY, '-inf', now)
-
-    // 디버그: 실제 score 값 확인
-    if (expiredBattles.length > 0) {
-      console.log(`🔍 [만료 조회] 현재=${now}`)
-      for (const battleId of expiredBattles) {
-        const score = await this.redisRepository.zscore(this.TIMERS_KEY, battleId)
-        const diff = score ? Number(score) - now : 0
-        console.log(`   - ${battleId}: score=${score}, 차이=${Math.ceil(diff / 1000)}초`)
-      }
-    }
-
-    return expiredBattles
+    return await this.redisRepository.zrangebyscore(this.TIMERS_KEY, '-inf', now)
   }
 
   //만료된 배틀 제거

--- a/backend/src/battles/adapters/out/timer/battleTimer.adapter.ts
+++ b/backend/src/battles/adapters/out/timer/battleTimer.adapter.ts
@@ -1,39 +1,64 @@
 import { Injectable } from '@nestjs/common'
 import { ActiveBattleState } from '../../../domains/models/types/battle.types'
 import { BattleTimerPort } from '../../../application/ports/out/battleTimer.port'
+import { RedisRepository } from '../../../../redis/redis.repository'
 
 @Injectable()
 export class BattleTimerAdapter implements BattleTimerPort {
-  private battleTimers: Map<string, NodeJS.Timeout> = new Map()
+  private readonly TIMERS_KEY = 'battle:timers'
+
+  constructor(private readonly redisRepository: RedisRepository) {}
 
   //배틀 타이머 스케줄러
-  schedule(battleId: string, state: ActiveBattleState, updatePhase: (battleId: string) => Promise<void>): void {
+  schedule(battleId: string, state: ActiveBattleState): void {
     if (!state.expiredAt) return
 
-    const prevTimer = this.battleTimers.get(battleId)
-    if (prevTimer) clearTimeout(prevTimer)
+    const now = Date.now()
+    const remaining = Math.ceil((state.expiredAt - now) / 1000)
 
-    const remaining = Math.max(state.expiredAt - Date.now(), 0)
+    console.log(`📝 [타이머 등록] battleId=${battleId}`)
+    console.log(`   - 현재 시간: ${now} (${new Date(now).toLocaleString('ko-KR')})`)
+    console.log(`   - 만료 시간: ${state.expiredAt} (${new Date(state.expiredAt).toLocaleString('ko-KR')})`)
+    console.log(`   - 남은 시간: ${remaining}초`)
 
-    const battleTimer = setTimeout(() => {
-      void updatePhase(battleId)
-    }, remaining)
-
-    this.battleTimers.set(battleId, battleTimer)
+    // Redis Sorted Set에 저장 (score = expiredAt, member = battleId)
+    void this.redisRepository.zadd(this.TIMERS_KEY, state.expiredAt, battleId)
   }
 
   //배틀 타이머 취소
   cancel(battleId: string): void {
-    const battleTimer = this.battleTimers.get(battleId)
-    if (battleTimer) {
-      clearTimeout(battleTimer)
-      this.battleTimers.delete(battleId)
+    void this.redisRepository.zrem(this.TIMERS_KEY, battleId)
+  }
+
+  //만료된 배틀 ID 목록 조회
+  async getExpiredBattles(): Promise<string[]> {
+    const now = Date.now()
+
+    // 현재 시간보다 작은 score를 가진 모든 member 조회
+    const expiredBattles = await this.redisRepository.zrangebyscore(this.TIMERS_KEY, '-inf', now)
+
+    // 디버그: 실제 score 값 확인
+    if (expiredBattles.length > 0) {
+      console.log(`🔍 [만료 조회] 현재=${now}`)
+      for (const battleId of expiredBattles) {
+        const score = await this.redisRepository.zscore(this.TIMERS_KEY, battleId)
+        const diff = score ? Number(score) - now : 0
+        console.log(`   - ${battleId}: score=${score}, 차이=${Math.ceil(diff / 1000)}초`)
+      }
     }
+
+    return expiredBattles
+  }
+
+  //만료된 배틀 제거
+  async removeExpiredBattles(battleIds: string[]): Promise<void> {
+    if (battleIds.length === 0) return
+
+    await this.redisRepository.zrem(this.TIMERS_KEY, ...battleIds)
   }
 
   //모든 배틀 타이머 취소 (테스트용)
   clear(): void {
-    this.battleTimers.forEach(timer => clearTimeout(timer))
-    this.battleTimers.clear()
+    void this.redisRepository.del(this.TIMERS_KEY)
   }
 }

--- a/backend/src/battles/application/ports/out/battleState.port.ts
+++ b/backend/src/battles/application/ports/out/battleState.port.ts
@@ -7,6 +7,8 @@ export interface BattleStatePort {
   loadBattleState(battleId: string): Promise<{ battle: PrismaBattle; state: ActiveBattleState }>
   //배틀 상태 저장
   saveBattleState(battleId: string, state: ActiveBattleState): Promise<void>
+  //캐시 삭제
+  clearCache(battleId: string): Promise<void>
   //페이즈 스킵 상태 업데이트
   updateSkipState(battleId: string, skipList: Set<string>): Promise<void>
   //MVP 상태 파싱

--- a/backend/src/battles/application/ports/out/battleTimer.port.ts
+++ b/backend/src/battles/application/ports/out/battleTimer.port.ts
@@ -2,7 +2,11 @@ import { ActiveBattleState } from '../../../domains/models/types/battle.types'
 
 export interface BattleTimerPort {
   //배틀 타이머 스케줄러
-  schedule(battleId: string, state: ActiveBattleState, updatePhase: (battleId: string) => Promise<void>): void
+  schedule(battleId: string, state: ActiveBattleState): void
   //배틀 타이머 취소
   cancel(battleId: string): void
+  //만료된 배틀 ID 목록 조회
+  getExpiredBattles(): Promise<string[]>
+  //만료된 배틀 제거
+  removeExpiredBattles(battleIds: string[]): Promise<void>
 }

--- a/backend/src/battles/application/usecases/battleCreation.usecase.ts
+++ b/backend/src/battles/application/usecases/battleCreation.usecase.ts
@@ -5,18 +5,10 @@ import { Battle, ActiveBattleState } from '../../domains/models/types/battle.typ
 import type { BattleReferenceData } from '../../domains/models/types/ai.types'
 import type { BattleCreateQueryDto } from '../../dto/battleCreateQuery.dto'
 import { BattlePhaseResponseDto, BattleRoundResponseDto } from '../../dto/battleTurnResponse.dto'
-import {
-  BATTLE_REPO_PORT,
-  BATTLE_STATE_PORT,
-  BATTLE_BROADCASTER_PORT,
-  BATTLE_TIMER_PORT,
-  BATTLE_REFERENCE_PORT,
-  BATTLE_IDENTIFIER_PORT,
-} from '../ports/tokens'
+import { BATTLE_REPO_PORT, BATTLE_STATE_PORT, BATTLE_BROADCASTER_PORT, BATTLE_REFERENCE_PORT, BATTLE_IDENTIFIER_PORT } from '../ports/tokens'
 import type { BattleRepoPort } from '../ports/out/battleRepository.port'
 import type { BattleStatePort } from '../ports/out/battleState.port'
 import type { BattleBroadcasterPort } from '../ports/out/battleBroadcaster.port'
-import type { BattleTimerPort } from '../ports/out/battleTimer.port'
 import type { BattleReferencePort } from '../ports/out/battleReference.port'
 import type { BattleIdentifierPort } from '../ports/out/battleIdentifier.port'
 
@@ -30,7 +22,6 @@ export class BattleCreationUseCase {
     @Inject(BATTLE_REPO_PORT) private readonly repo: BattleRepoPort,
     @Inject(BATTLE_STATE_PORT) private readonly stateRepo: BattleStatePort,
     @Inject(BATTLE_BROADCASTER_PORT) private readonly broadcaster: BattleBroadcasterPort,
-    @Inject(BATTLE_TIMER_PORT) private readonly timer: BattleTimerPort,
     @Inject(BATTLE_REFERENCE_PORT) private readonly referencePort: BattleReferencePort,
     @Inject(BATTLE_IDENTIFIER_PORT) private readonly identifierPort: BattleIdentifierPort,
     private readonly phaseTransitionUseCase: BattlePhaseTransitionUseCase,
@@ -137,16 +128,8 @@ export class BattleCreationUseCase {
 
     this.broadcaster.emitPhaseUpdated(phaseRes)
     this.broadcaster.emitRoundUpdated(roundRes)
-    void this.scheduleNextTick(battleId, state)
-  }
 
-  // 다음 타이머 스케줄링
-  private scheduleNextTick(battleId: string, state: ActiveBattleState): void {
-    try {
-      if (!state.expiredAt) return
-      this.timer.schedule(battleId, state, async (battleId: string) => await this.phaseTransitionUseCase.advancePhase(battleId))
-    } catch {
-      // ignore if battle not found or closed
-    }
+    // 배틀 시작 시 첫 페이즈로 전환 (PENDING → OPINION_SHARE)
+    await this.phaseTransitionUseCase.advancePhase(battleId)
   }
 }

--- a/backend/src/battles/application/usecases/battlePhaseTransition.usecase.ts
+++ b/backend/src/battles/application/usecases/battlePhaseTransition.usecase.ts
@@ -122,8 +122,10 @@ export class BattlePhaseTransitionUseCase {
     try {
       const { state } = await this.stateRepo.loadBattleState(battleId)
       if (!state.expiredAt) return
+      // PENDING 상태에서는 타이머 등록하지 않음
+      if (state.phase === 'PENDING') return
 
-      this.timer.schedule(battleId, state, async battleId => await this.advancePhase(battleId))
+      this.timer.schedule(battleId, state)
     } catch {
       // ignore if battle not found or closed
     }

--- a/backend/src/battles/application/usecases/battleTermination.usecase.ts
+++ b/backend/src/battles/application/usecases/battleTermination.usecase.ts
@@ -67,6 +67,8 @@ export class BattleTerminationUseCase {
       chatsTeamBState: Prisma.DbNull as unknown as Prisma.InputJsonValue,
     })
 
+    await this.stateRepo.clearCache(battleId)
+
     await this.applyRatingChanges(state, winningTeam, calculatedMvps)
     this.broadcaster.emitBattleClosed(BattleClosedResponseDto.of({ battleId }))
   }

--- a/backend/src/battles/application/usecases/battleTimerWorker.usecase.ts
+++ b/backend/src/battles/application/usecases/battleTimerWorker.usecase.ts
@@ -1,0 +1,78 @@
+import { Injectable, OnModuleInit, OnModuleDestroy, Inject, Logger } from '@nestjs/common'
+import { BATTLE_TIMER_PORT } from '../ports/tokens'
+import type { BattleTimerPort } from '../ports/out/battleTimer.port'
+import { BattlePhaseTransitionUseCase } from './battlePhaseTransition.usecase'
+
+/**
+ * 배틀 타이머 폴링 워커
+ * 1초마다 Redis Sorted Set에서 만료된 배틀을 조회하고 페이즈 전환 처리
+ */
+@Injectable()
+export class BattleTimerWorkerUseCase implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(BattleTimerWorkerUseCase.name)
+  private intervalId: NodeJS.Timeout | null = null
+  private readonly POLL_INTERVAL_MS = 1000 // 1초
+
+  constructor(
+    @Inject(BATTLE_TIMER_PORT) private readonly timer: BattleTimerPort,
+    private readonly phaseTransitionUseCase: BattlePhaseTransitionUseCase,
+  ) {}
+
+  onModuleInit() {
+    this.startPolling()
+    this.logger.log('⏰ 배틀 타이머 폴링 워커 시작 (1초 간격)')
+  }
+
+  onModuleDestroy() {
+    this.stopPolling()
+    this.logger.log('⏹️ 배틀 타이머 폴링 워커 종료')
+  }
+
+  private startPolling(): void {
+    this.intervalId = setInterval(() => {
+      void this.checkExpiredBattles()
+    }, this.POLL_INTERVAL_MS)
+  }
+
+  private stopPolling(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId)
+      this.intervalId = null
+    }
+  }
+
+  private async checkExpiredBattles(): Promise<void> {
+    try {
+      const now = Date.now()
+
+      // 만료된 배틀 조회
+      const expiredBattleIds = await this.timer.getExpiredBattles()
+
+      if (expiredBattleIds.length === 0) return
+
+      console.log(`⏰ [만료 감지] 현재=${now} (${new Date(now).toLocaleString('ko-KR')})`)
+      console.log(`   - 발견된 배틀 ${expiredBattleIds.length}개: ${expiredBattleIds.join(', ')}`)
+
+      this.logger.debug(`⏰ 만료된 배틀 ${expiredBattleIds.length}개 발견`)
+
+      // 각 배틀의 페이즈 전환 처리
+      const results = await Promise.allSettled(expiredBattleIds.map(battleId => this.phaseTransitionUseCase.advancePhase(battleId)))
+
+      // 성공한 배틀만 Redis에서 제거
+      const successBattleIds = expiredBattleIds.filter((_, index) => results[index].status === 'fulfilled')
+
+      if (successBattleIds.length > 0) {
+        await this.timer.removeExpiredBattles(successBattleIds)
+        this.logger.debug(`✅ ${successBattleIds.length}개 배틀 페이즈 전환 완료`)
+      }
+
+      // 실패한 배틀 로깅
+      const failedCount = expiredBattleIds.length - successBattleIds.length
+      if (failedCount > 0) {
+        this.logger.warn(`⚠️ ${failedCount}개 배틀 페이즈 전환 실패 (다음 폴링에서 재시도)`)
+      }
+    } catch (error) {
+      this.logger.error('❌ 배틀 타이머 폴링 중 오류 발생', error)
+    }
+  }
+}

--- a/backend/src/battles/application/usecases/battleTimerWorker.usecase.ts
+++ b/backend/src/battles/application/usecases/battleTimerWorker.usecase.ts
@@ -3,10 +3,6 @@ import { BATTLE_TIMER_PORT } from '../ports/tokens'
 import type { BattleTimerPort } from '../ports/out/battleTimer.port'
 import { BattlePhaseTransitionUseCase } from './battlePhaseTransition.usecase'
 
-/**
- * 배틀 타이머 폴링 워커
- * 1초마다 Redis Sorted Set에서 만료된 배틀을 조회하고 페이즈 전환 처리
- */
 @Injectable()
 export class BattleTimerWorkerUseCase implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(BattleTimerWorkerUseCase.name)
@@ -20,12 +16,10 @@ export class BattleTimerWorkerUseCase implements OnModuleInit, OnModuleDestroy {
 
   onModuleInit() {
     this.startPolling()
-    this.logger.log('⏰ 배틀 타이머 폴링 워커 시작 (1초 간격)')
   }
 
   onModuleDestroy() {
     this.stopPolling()
-    this.logger.log('⏹️ 배틀 타이머 폴링 워커 종료')
   }
 
   private startPolling(): void {
@@ -43,18 +37,10 @@ export class BattleTimerWorkerUseCase implements OnModuleInit, OnModuleDestroy {
 
   private async checkExpiredBattles(): Promise<void> {
     try {
-      const now = Date.now()
-
       // 만료된 배틀 조회
       const expiredBattleIds = await this.timer.getExpiredBattles()
 
       if (expiredBattleIds.length === 0) return
-
-      console.log(`⏰ [만료 감지] 현재=${now} (${new Date(now).toLocaleString('ko-KR')})`)
-      console.log(`   - 발견된 배틀 ${expiredBattleIds.length}개: ${expiredBattleIds.join(', ')}`)
-
-      this.logger.debug(`⏰ 만료된 배틀 ${expiredBattleIds.length}개 발견`)
-
       // 각 배틀의 페이즈 전환 처리
       const results = await Promise.allSettled(expiredBattleIds.map(battleId => this.phaseTransitionUseCase.advancePhase(battleId)))
 
@@ -63,16 +49,9 @@ export class BattleTimerWorkerUseCase implements OnModuleInit, OnModuleDestroy {
 
       if (successBattleIds.length > 0) {
         await this.timer.removeExpiredBattles(successBattleIds)
-        this.logger.debug(`✅ ${successBattleIds.length}개 배틀 페이즈 전환 완료`)
-      }
-
-      // 실패한 배틀 로깅
-      const failedCount = expiredBattleIds.length - successBattleIds.length
-      if (failedCount > 0) {
-        this.logger.warn(`⚠️ ${failedCount}개 배틀 페이즈 전환 실패 (다음 폴링에서 재시도)`)
       }
     } catch (error) {
-      this.logger.error('❌ 배틀 타이머 폴링 중 오류 발생', error)
+      this.logger.error('Error occurred while polling battles', error)
     }
   }
 }

--- a/backend/src/battles/battles.module.ts
+++ b/backend/src/battles/battles.module.ts
@@ -30,6 +30,7 @@ import { BattleTerminationUseCase } from './application/usecases/battleTerminati
 import { BattleInteractionUseCase } from './application/usecases/battleInteraction.usecase'
 import { CreateGuestUseCase } from './application/usecases/createGuest.usecase'
 import { BattleQueryUseCase } from './application/usecases/battleQuery.usecase'
+import { BattleTimerWorkerUseCase } from './application/usecases/battleTimerWorker.usecase'
 
 // Adapters (Out)
 import { BattleRepositoryAdapter } from './adapters/out/persistence/battleRepository.adapter'
@@ -83,6 +84,7 @@ import {
     BattleInteractionUseCase,
     CreateGuestUseCase,
     BattleQueryUseCase,
+    BattleTimerWorkerUseCase,
 
     // Adapters (Out)
     BattleRepositoryAdapter,

--- a/backend/src/gemini/gemini.service.ts
+++ b/backend/src/gemini/gemini.service.ts
@@ -1,16 +1,7 @@
 import { Injectable, OnModuleInit, Logger, InternalServerErrorException } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { GoogleGenerativeAI, GenerativeModel, Schema } from '@google/generative-ai'
-
-interface KeyUsageStats {
-  apiKey: string
-  minuteRequests: number[]
-  dailyRequests: number[]
-  lastUsed: number
-  isDisabled: boolean
-  disabledUntil: number | null
-  consecutiveFailures: number
-}
+import { RedisRepository } from '../redis/redis.repository'
 
 export interface GeminiGenerationConfig {
   responseMimeType?: string
@@ -20,16 +11,16 @@ export interface GeminiGenerationConfig {
 @Injectable()
 export class GeminiService implements OnModuleInit {
   private readonly logger = new Logger(GeminiService.name)
-  private keyStats: Map<string, KeyUsageStats> = new Map()
   private keys: string[] = []
 
   private rateLimitPerMinute: number = 5
   private rateLimitPerDay: number = 20
-  private readonly MINUTE_MS = 60 * 1000
-  private readonly DAY_MS = 24 * 60 * 60 * 1000
   private readonly BACKOFF_BASE_MS = 1000
 
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly redisRepository: RedisRepository,
+  ) {}
 
   onModuleInit() {
     const keysString = this.configService.get<string>('GEMINI_API_KEYS')
@@ -50,18 +41,6 @@ export class GeminiService implements OnModuleInit {
     this.rateLimitPerMinute = this.configService.get<number>('GEMINI_RATE_LIMIT_PER_MINUTE') ?? 5
     this.rateLimitPerDay = this.configService.get<number>('GEMINI_RATE_LIMIT_PER_DAY') ?? 20
 
-    for (const key of this.keys) {
-      this.keyStats.set(key, {
-        apiKey: key,
-        minuteRequests: [],
-        dailyRequests: [],
-        lastUsed: 0,
-        isDisabled: false,
-        disabledUntil: null,
-        consecutiveFailures: 0,
-      })
-    }
-
     this.logger.log(`Gemini 서비스 초기화 완료: ${this.keys.length}개 키 등록`)
   }
 
@@ -76,7 +55,7 @@ export class GeminiService implements OnModuleInit {
     const maxAttempts = this.keys.length
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const apiKey = this.getBestAvailableKey(triedKeys)
+      const apiKey = await this.getBestAvailableKey(triedKeys)
 
       if (!apiKey) {
         this.logger.warn('사용 가능한 API 키가 없습니다.')
@@ -84,10 +63,9 @@ export class GeminiService implements OnModuleInit {
       }
 
       triedKeys.add(apiKey)
-      const stats = this.keyStats.get(apiKey)!
 
       try {
-        this.recordUsage(apiKey)
+        await this.recordUsage(apiKey)
 
         const genAI = new GoogleGenerativeAI(apiKey)
         const model = genAI.getGenerativeModel({
@@ -97,17 +75,18 @@ export class GeminiService implements OnModuleInit {
 
         const result = await executor(model)
 
-        stats.consecutiveFailures = 0
+        await this.redisRepository.del(`gemini:failures:${apiKey}`)
+
+        this.logger.debug(`[Gemini] success key=${apiKey.substring(6, 14)}... model=${modelName}`)
 
         return result
       } catch (error) {
         lastError = error as Error
-        stats.consecutiveFailures++
 
         const errorType = this.classifyError(error)
         this.logger.warn(`Gemini API 호출 실패 (시도 ${attempt + 1}/${maxAttempts}, 키: ${apiKey.substring(6, 14)}...): ${errorType}`)
 
-        this.handleKeyFailure(apiKey, errorType)
+        await this.handleKeyFailure(apiKey, errorType)
 
         if (attempt < maxAttempts - 1) {
           const backoffMs = this.BACKOFF_BASE_MS * Math.pow(2, attempt)
@@ -119,78 +98,93 @@ export class GeminiService implements OnModuleInit {
     throw lastError ?? new InternalServerErrorException('Gemini API 호출에 실패했습니다.')
   }
 
-  private getBestAvailableKey(excludeKeys: Set<string> = new Set()): string | null {
-    const now = Date.now()
+  private static readonly METRICS_PER_KEY = 4
+  private static readonly MetricIdx = {
+    DISABLED: 0,
+    FAILURES: 1,
+    MIN_USAGE: 2,
+    DAY_USAGE: 3,
+  } as const
+
+  private async getBestAvailableKey(excludeKeys: Set<string> = new Set()): Promise<string | null> {
+    const redis = this.redisRepository.getRedisClient()
+    const pipeline = redis.pipeline()
+
+    const availableKeys = this.keys.filter(k => !excludeKeys.has(k))
+
+    for (const key of availableKeys) {
+      pipeline.exists(`gemini:disabled:${key}`)
+      pipeline.get(`gemini:failures:${key}`)
+      pipeline.get(`gemini:usage:min:${key}`)
+      pipeline.get(`gemini:usage:day:${key}`)
+    }
+
+    const results = await pipeline.exec()
+    if (!results) return null
+
     let bestKey: string | null = null
     let maxAvailability = -1
 
-    for (const [key, stats] of this.keyStats.entries()) {
-      if (excludeKeys.has(key)) continue
+    for (let i = 0; i < availableKeys.length; i++) {
+      const key = availableKeys[i]
+      const base = i * GeminiService.METRICS_PER_KEY
 
-      if (stats.isDisabled) {
-        if (stats.disabledUntil && now > stats.disabledUntil) {
-          stats.isDisabled = false
-          stats.disabledUntil = null
-          stats.consecutiveFailures = 0
-        } else {
-          continue
-        }
-      }
+      const isDisabled = results[base + GeminiService.MetricIdx.DISABLED]?.[1] === 1
+      const consecutiveFailures = Number(results[base + GeminiService.MetricIdx.FAILURES]?.[1] ?? 0)
+      const minUsage = Number(results[base + GeminiService.MetricIdx.MIN_USAGE]?.[1] ?? 0)
+      const dayUsage = Number(results[base + GeminiService.MetricIdx.DAY_USAGE]?.[1] ?? 0)
 
-      this.cleanupOldRequests(stats, now)
+      if (isDisabled) continue
 
-      const minuteAvailable = this.rateLimitPerMinute - stats.minuteRequests.length
-      const dailyAvailable = this.rateLimitPerDay - stats.dailyRequests.length
+      const minuteAvailable = this.rateLimitPerMinute - minUsage
+      const dailyAvailable = this.rateLimitPerDay - dayUsage
 
-      if (minuteAvailable <= 0 || dailyAvailable <= 0) {
-        continue
-      }
+      if (minuteAvailable <= 0 || dailyAvailable <= 0) continue
 
-      const availability = minuteAvailable * (1 - stats.consecutiveFailures * 0.1)
+      const failureWeight = Math.max(0, 1 - consecutiveFailures * 0.1)
+      const availability = minuteAvailable * failureWeight
+
+      this.logger.debug(
+        `[GeminiKeyPick] ${key.substring(6, 14)}... disabled=${isDisabled} min=${minUsage}/${this.rateLimitPerMinute} day=${dayUsage}/${this.rateLimitPerDay} failures=${consecutiveFailures} avail=${availability.toFixed(2)}`,
+      )
 
       if (availability > maxAvailability) {
         maxAvailability = availability
         bestKey = key
       }
     }
-
     return bestKey
   }
 
-  private recordUsage(apiKey: string): void {
-    const stats = this.keyStats.get(apiKey)
-    if (!stats) return
+  private async recordUsage(apiKey: string): Promise<void> {
+    const minKey = `gemini:usage:min:${apiKey}`
+    const dayKey = `gemini:usage:day:${apiKey}`
 
-    const now = Date.now()
-    stats.minuteRequests.push(now)
-    stats.dailyRequests.push(now)
-    stats.lastUsed = now
+    await Promise.all([this.redisRepository.incr(minKey, 60), this.redisRepository.incr(dayKey, 86400)])
   }
 
-  private handleKeyFailure(apiKey: string, errorType: string): void {
-    const stats = this.keyStats.get(apiKey)
-    if (!stats) return
+  private async handleKeyFailure(apiKey: string, errorType: string): Promise<void> {
+    const failureKey = `gemini:failures:${apiKey}`
+    const disabledKey = `gemini:disabled:${apiKey}`
+
+    const consecutiveFailures = await this.redisRepository.incr(failureKey, 86400)
 
     let disableDuration: number
-
     switch (errorType) {
       case 'RATE_LIMIT':
-        disableDuration = this.MINUTE_MS
+        disableDuration = 60
         break
       case 'QUOTA_EXCEEDED':
-        disableDuration = this.DAY_MS
-        break
       case 'AUTH_ERROR':
-        disableDuration = this.DAY_MS
+        disableDuration = 86400
         break
       default:
-        disableDuration = 5 * this.MINUTE_MS
+        disableDuration = 300
     }
 
-    if (stats.consecutiveFailures >= 3) {
-      stats.isDisabled = true
-      stats.disabledUntil = Date.now() + disableDuration
-      this.logger.warn(`API 키 비활성화: ${apiKey.substring(6, 14)}... (${errorType})`)
+    if (consecutiveFailures >= 3) {
+      await this.redisRepository.set(disabledKey, 'true', disableDuration)
+      this.logger.warn(`API 키 비활성화: ${apiKey.substring(6, 14)}... (${errorType}, 연속 실패: ${consecutiveFailures})`)
     }
   }
 
@@ -215,19 +209,11 @@ export class GeminiService implements OnModuleInit {
     return 'UNKNOWN'
   }
 
-  private cleanupOldRequests(stats: KeyUsageStats, now: number): void {
-    const minuteAgo = now - this.MINUTE_MS
-    const dayAgo = now - this.DAY_MS
-
-    stats.minuteRequests = stats.minuteRequests.filter(ts => ts > minuteAgo)
-    stats.dailyRequests = stats.dailyRequests.filter(ts => ts > dayAgo)
-  }
-
   private sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms))
   }
 
-  getHealthStatus(): {
+  async getHealthStatus(): Promise<{
     totalKeys: number
     activeKeys: number
     keyStatuses: Array<{
@@ -237,16 +223,30 @@ export class GeminiService implements OnModuleInit {
       isDisabled: boolean
       consecutiveFailures: number
     }>
-  } {
-    const now = Date.now()
-    const keyStatuses = Array.from(this.keyStats.entries()).map(([key, stats]) => {
-      this.cleanupOldRequests(stats, now)
+  }> {
+    const redis = this.redisRepository.getRedisClient()
+    const pipeline = redis.pipeline()
+
+    for (const key of this.keys) {
+      pipeline.exists(`gemini:disabled:${key}`)
+      pipeline.get(`gemini:failures:${key}`)
+      pipeline.get(`gemini:usage:min:${key}`)
+      pipeline.get(`gemini:usage:day:${key}`)
+    }
+
+    const results = await pipeline.exec()
+    if (!results) {
+      return { totalKeys: this.keys.length, activeKeys: 0, keyStatuses: [] }
+    }
+
+    const keyStatuses = this.keys.map((key, i) => {
+      const base = i * GeminiService.METRICS_PER_KEY
       return {
         keyPrefix: key.substring(6, 14) + '...',
-        minuteUsage: stats.minuteRequests.length,
-        dailyUsage: stats.dailyRequests.length,
-        isDisabled: stats.isDisabled,
-        consecutiveFailures: stats.consecutiveFailures,
+        isDisabled: results[base + GeminiService.MetricIdx.DISABLED]?.[1] === 1,
+        consecutiveFailures: Number(results[base + GeminiService.MetricIdx.FAILURES]?.[1] ?? 0),
+        minuteUsage: Number(results[base + GeminiService.MetricIdx.MIN_USAGE]?.[1] ?? 0),
+        dailyUsage: Number(results[base + GeminiService.MetricIdx.DAY_USAGE]?.[1] ?? 0),
       }
     })
 

--- a/backend/src/oauth/controller/oauth.controller.spec.ts
+++ b/backend/src/oauth/controller/oauth.controller.spec.ts
@@ -76,7 +76,7 @@ describe('OauthController', () => {
 
       const mockTokens = {
         accessToken: 'mock-access-token',
-        refreshToken: 'mock-refresh-token',
+        sessionId: 'mock-session-id',
         user: mockUser,
       }
 
@@ -95,7 +95,7 @@ describe('OauthController', () => {
       await controller.githubCallback(mockReq, mockRes)
 
       expect(mockOauthService.loginWithGithub).toHaveBeenCalledWith(mockProfile)
-      expect(mockTokenService.setTokensInCookie).toHaveBeenCalledWith(mockRes, mockTokens.accessToken, mockTokens.refreshToken)
+      expect(mockTokenService.setTokensInCookie).toHaveBeenCalledWith(mockRes, mockTokens.accessToken, mockTokens.sessionId)
       expect(mockRedirect).toHaveBeenCalledWith('http://localhost:5173/main')
     })
   })
@@ -118,7 +118,7 @@ describe('OauthController', () => {
 
       const mockTokens = {
         accessToken: 'mock-access-token',
-        refreshToken: 'mock-refresh-token',
+        sessionId: 'mock-session-id',
         user: mockUser,
       }
 
@@ -137,21 +137,21 @@ describe('OauthController', () => {
       await controller.kakaoCallback(mockReq, mockRes)
 
       expect(mockOauthService.loginWithKakao).toHaveBeenCalledWith(mockProfile)
-      expect(mockTokenService.setTokensInCookie).toHaveBeenCalledWith(mockRes, mockTokens.accessToken, mockTokens.refreshToken)
+      expect(mockTokenService.setTokensInCookie).toHaveBeenCalledWith(mockRes, mockTokens.accessToken, mockTokens.sessionId)
       expect(mockRedirect).toHaveBeenCalledWith('http://localhost:5173/main')
     })
   })
 
   describe('refresh', () => {
-    it('Refresh Token으로 새로운 토큰을 발급하고 쿠키에 설정한다', () => {
+    it('Refresh Token으로 새로운 토큰을 발급하고 쿠키에 설정한다', async () => {
       const mockUser = {
         userId: 'user-123',
-        refreshToken: 'old-refresh-token',
+        sessionId: 'old-session-id',
       }
 
       const mockNewTokens = {
         accessToken: 'new-access-token',
-        refreshToken: 'new-refresh-token',
+        sessionId: 'new-session-id',
       }
 
       const mockReq = {
@@ -164,22 +164,21 @@ describe('OauthController', () => {
         json: mockJson,
       } as unknown as expressRes
 
-      mockOauthService.refreshToken.mockReturnValue(mockNewTokens)
+      mockOauthService.refreshToken.mockResolvedValue(mockNewTokens)
 
-      const result = controller.refresh(mockReq, mockRes)
+      await controller.refresh(mockReq, mockRes)
 
-      expect(mockOauthService.refreshToken).toHaveBeenCalledWith(mockUser.refreshToken)
-      expect(mockTokenService.setTokensInCookie).toHaveBeenCalledWith(mockRes, mockNewTokens.accessToken, mockNewTokens.refreshToken)
+      expect(mockOauthService.refreshToken).toHaveBeenCalledWith(mockUser.sessionId)
+      expect(mockTokenService.setTokensInCookie).toHaveBeenCalledWith(mockRes, mockNewTokens.accessToken, mockNewTokens.sessionId)
       expect(mockJson).toHaveBeenCalledWith({ success: true })
-      expect(result).toEqual({ success: true })
     })
   })
 
   describe('logout', () => {
-    it('Refresh Token이 있으면 무효화하고 쿠키를 삭제한다', () => {
+    it('Session ID가 있으면 무효화하고 쿠키를 삭제한다', async () => {
       const mockReq = {
         cookies: {
-          refresh_token: 'refresh-token-to-revoke',
+          session_id: 'session-id-to-revoke',
         },
       } as unknown as expressReq
 
@@ -188,14 +187,14 @@ describe('OauthController', () => {
         json: jest.fn(),
       } as unknown as expressRes
 
-      controller.logout(mockReq, mockRes)
+      await controller.logout(mockReq, mockRes)
 
-      expect(mockTokenService.revokeRefreshToken).toHaveBeenCalledWith('refresh-token-to-revoke')
+      expect(mockTokenService.revokeRefreshToken).toHaveBeenCalledWith('session-id-to-revoke')
       expect(mockTokenService.clearAuthCookies).toHaveBeenCalledWith(mockRes)
       expect(mockRes.json).toHaveBeenCalledWith({ success: true })
     })
 
-    it('Refresh Token이 없어도 쿠키를 삭제한다', () => {
+    it('Session ID가 없어도 쿠키를 삭제한다', async () => {
       const mockReq = {
         cookies: {},
       } as unknown as expressReq
@@ -205,7 +204,7 @@ describe('OauthController', () => {
         json: jest.fn(),
       } as unknown as expressRes
 
-      controller.logout(mockReq, mockRes)
+      await controller.logout(mockReq, mockRes)
 
       expect(mockTokenService.revokeRefreshToken).not.toHaveBeenCalled()
       expect(mockTokenService.clearAuthCookies).toHaveBeenCalledWith(mockRes)

--- a/backend/src/oauth/controller/oauth.controller.ts
+++ b/backend/src/oauth/controller/oauth.controller.ts
@@ -6,6 +6,7 @@ import { OauthService } from '../service/oauth.service'
 import { TokenService } from '../service/token.service'
 import type { OAuthProfile } from '../types/oauth.types'
 import { JwtAuthGuard } from '../guard/jwt-auth.guard'
+import { RefreshGuard } from '../strategy/jwt-refresh.strategy'
 import { UpdateNicknameDto } from '../dto/updateNickname.dto'
 import { OAuthUserResponseDto } from '../dto/oauthUserResponse.dto'
 
@@ -26,12 +27,10 @@ export class OauthController {
   @HttpCode(302)
   async githubCallback(@Req() req: expressReq, @Res() res: expressRes) {
     const profile = req.user as OAuthProfile
-    const { accessToken, refreshToken } = await this.oauthService.loginWithGithub(profile)
+    const { accessToken, sessionId } = await this.oauthService.loginWithGithub(profile)
 
-    // 쿠키에 토큰 저장
-    this.tokenService.setTokensInCookie(res, accessToken, refreshToken)
+    this.tokenService.setTokensInCookie(res, accessToken, sessionId)
 
-    // 프론트엔드로 직접 리다이렉트
     const frontendUrl = this.config.get<string>('FRONTEND_URL') || 'http://localhost:5173'
     res.redirect(`${frontendUrl}/main`)
   }
@@ -45,34 +44,32 @@ export class OauthController {
   @HttpCode(302)
   async kakaoCallback(@Req() req: expressReq, @Res() res: expressRes) {
     const profile = req.user as OAuthProfile
-    const { accessToken, refreshToken } = await this.oauthService.loginWithKakao(profile)
+    const { accessToken, sessionId } = await this.oauthService.loginWithKakao(profile)
 
-    this.tokenService.setTokensInCookie(res, accessToken, refreshToken)
+    this.tokenService.setTokensInCookie(res, accessToken, sessionId)
 
     const frontendUrl = this.config.get<string>('FRONTEND_URL') || 'http://localhost:5173'
     res.redirect(`${frontendUrl}/main`)
   }
 
   @Post('refresh')
-  @UseGuards(AuthGuard('jwt-refresh'))
+  @UseGuards(RefreshGuard)
   @HttpCode(200)
-  refresh(@Req() req: expressReq, @Res() res: expressRes) {
-    const user = req.user as { userId: string; refreshToken: string }
-    const { accessToken, refreshToken: newRefreshToken } = this.oauthService.refreshToken(user.refreshToken)
-    // 새로운 토큰을 쿠키에 설정
-    this.tokenService.setTokensInCookie(res, accessToken, newRefreshToken)
+  async refresh(@Req() req: expressReq, @Res() res: expressRes) {
+    const user = req.user as { userId: string; sessionId: string }
+    const { accessToken, sessionId: newSessionId } = await this.oauthService.refreshToken(user.sessionId)
+    this.tokenService.setTokensInCookie(res, accessToken, newSessionId)
     return res.json({ success: true })
   }
 
   @Post('logout')
   @UseGuards(JwtAuthGuard)
   @HttpCode(200)
-  logout(@Req() req: expressReq, @Res() res: expressRes): void {
-    const refreshToken = req.cookies?.refresh_token as string | undefined
+  async logout(@Req() req: expressReq, @Res() res: expressRes): Promise<void> {
+    const sessionId = req.cookies?.session_id as string | undefined
 
-    // refreshToken이 있으면 무효화
-    if (refreshToken) {
-      this.tokenService.revokeRefreshToken(refreshToken)
+    if (sessionId) {
+      await this.tokenService.revokeRefreshToken(sessionId)
     }
 
     this.tokenService.clearAuthCookies(res)

--- a/backend/src/oauth/oauth.module.ts
+++ b/backend/src/oauth/oauth.module.ts
@@ -9,8 +9,9 @@ import { GithubStrategy } from './strategy/github.strategy'
 import { KakaoStrategy } from './strategy/kakao.strategy'
 import { TokenService } from './service/token.service'
 import { JwtStrategy } from './strategy/jwt.strategy'
-import { RefreshStrategy } from './strategy/jwt-refresh.strategy'
+import { RefreshGuard } from './strategy/jwt-refresh.strategy'
 import { PrismaService } from 'src/prisma/prisma.service'
+import { RedisModule } from 'src/redis/redis.module'
 
 @Module({
   imports: [
@@ -28,9 +29,10 @@ import { PrismaService } from 'src/prisma/prisma.service'
         }
       },
     }),
+    RedisModule,
   ],
   controllers: [OauthController],
-  providers: [OauthService, GithubStrategy, KakaoStrategy, JwtStrategy, RefreshStrategy, TokenService, PrismaService],
+  providers: [OauthService, GithubStrategy, KakaoStrategy, JwtStrategy, RefreshGuard, TokenService, PrismaService],
   exports: [OauthService],
 })
 export class OauthModule {}

--- a/backend/src/oauth/service/oauth.service.spec.ts
+++ b/backend/src/oauth/service/oauth.service.spec.ts
@@ -173,9 +173,10 @@ describe('OauthService', () => {
       const mockTokens = {
         accessToken: 'mock-access-token',
         refreshToken: 'mock-refresh-token',
+        sessionId: 'mock-session-id',
       }
 
-      mockTokenService.generateTokens.mockReturnValue(mockTokens)
+      mockTokenService.generateTokens.mockResolvedValue(mockTokens)
       mockPrisma.oAuth.findFirst.mockResolvedValue(null as never)
       mockPrisma.user.create.mockResolvedValue({
         id: 'user-id',
@@ -217,14 +218,16 @@ describe('OauthService', () => {
       const mockTokens1 = {
         accessToken: 'mock-access-token-1',
         refreshToken: 'mock-refresh-token-1',
+        sessionId: 'mock-session-id-1',
       }
 
       const mockTokens2 = {
         accessToken: 'mock-access-token-2',
         refreshToken: 'mock-refresh-token-2',
+        sessionId: 'mock-session-id-2',
       }
 
-      mockTokenService.generateTokens.mockReturnValueOnce(mockTokens1).mockReturnValueOnce(mockTokens2)
+      mockTokenService.generateTokens.mockResolvedValueOnce(mockTokens1).mockResolvedValueOnce(mockTokens2)
       mockPrisma.oAuth.findFirst.mockResolvedValue({
         id: 'oauth-id',
         userId: 'user-id',
@@ -275,9 +278,10 @@ describe('OauthService', () => {
       const mockTokens = {
         accessToken: 'mock-access-token',
         refreshToken: 'mock-refresh-token',
+        sessionId: 'mock-session-id',
       }
 
-      mockTokenService.generateTokens.mockReturnValue(mockTokens)
+      mockTokenService.generateTokens.mockResolvedValue(mockTokens)
       mockPrisma.oAuth.findFirst.mockResolvedValue(null as never)
       mockPrisma.user.create.mockResolvedValue({
         id: 'user-id',
@@ -303,19 +307,20 @@ describe('OauthService', () => {
   })
 
   describe('refreshToken', () => {
-    it('Refresh Token으로 새로운 토큰 쌍을 발급한다', () => {
-      const refreshToken = 'old-refresh-token'
+    it('세션 ID로 새로운 토큰 쌍을 발급한다', async () => {
+      const sessionId = 'old-session-id'
       const mockNewTokens = {
         accessToken: 'new-access-token',
         refreshToken: 'new-refresh-token',
+        sessionId: 'new-session-id',
       }
 
-      mockTokenService.refresh.mockReturnValue(mockNewTokens)
+      mockTokenService.refresh.mockResolvedValue(mockNewTokens)
 
-      const result = service.refreshToken(refreshToken)
+      const result = await service.refreshToken(sessionId)
 
       expect(result).toEqual(mockNewTokens)
-      expect(mockTokenService.refresh).toHaveBeenCalledWith(refreshToken)
+      expect(mockTokenService.refresh).toHaveBeenCalledWith(sessionId)
     })
   })
 
@@ -327,9 +332,10 @@ describe('OauthService', () => {
         avatarUrl: 'https://example.com/avatar.jpg',
       }
 
-      mockTokenService.generateTokens.mockReturnValue({
+      mockTokenService.generateTokens.mockResolvedValue({
         accessToken: 'token',
         refreshToken: 'refresh',
+        sessionId: 'session',
       })
 
       await service.loginWithGithub(profile)
@@ -358,9 +364,10 @@ describe('OauthService', () => {
         avatarUrl: 'https://example.com/avatar2.jpg',
       }
 
-      mockTokenService.generateTokens.mockReturnValue({
+      mockTokenService.generateTokens.mockResolvedValue({
         accessToken: 'token',
         refreshToken: 'refresh',
+        sessionId: 'session',
       })
 
       await service.loginWithGithub(profile1)
@@ -386,9 +393,10 @@ describe('OauthService', () => {
         avatarUrl: 'https://example.com/avatar.jpg',
       }
 
-      mockTokenService.generateTokens.mockReturnValue({
+      mockTokenService.generateTokens.mockResolvedValue({
         accessToken: 'token',
         refreshToken: 'refresh',
+        sessionId: 'session',
       })
 
       await service.loginWithGithub(profile)

--- a/backend/src/oauth/service/oauth.service.ts
+++ b/backend/src/oauth/service/oauth.service.ts
@@ -57,14 +57,16 @@ export class OauthService {
   async loginWithGithub(profile: OAuthProfile): Promise<{
     accessToken: string
     refreshToken: string
+    sessionId: string
     user: User
   }> {
     const loginUser = await this.findOrCreateUser(profile)
-    const { accessToken, refreshToken } = this.tokenService.generateTokens(loginUser.id)
+    const { accessToken, refreshToken, sessionId } = await this.tokenService.generateTokens(loginUser.id)
 
     return {
       accessToken,
       refreshToken,
+      sessionId,
       user: loginUser,
     }
   }
@@ -72,22 +74,25 @@ export class OauthService {
   async loginWithKakao(profile: OAuthProfile): Promise<{
     accessToken: string
     refreshToken: string
+    sessionId: string
   }> {
     const loginUser = await this.findOrCreateUser(profile)
-    const { accessToken, refreshToken } = this.tokenService.generateTokens(loginUser.id)
+    const { accessToken, refreshToken, sessionId } = await this.tokenService.generateTokens(loginUser.id)
 
     return {
       accessToken,
       refreshToken,
+      sessionId,
     }
   }
 
-  refreshToken(refreshToken: string): {
+  async refreshToken(sessionId: string): Promise<{
     accessToken: string
     refreshToken: string
-  } {
-    const { accessToken, refreshToken: newRefreshToken } = this.tokenService.refresh(refreshToken)
-    return { accessToken, refreshToken: newRefreshToken }
+    sessionId: string
+  }> {
+    const { accessToken, refreshToken: newRefreshToken, sessionId: newSessionId } = await this.tokenService.refresh(sessionId)
+    return { accessToken, refreshToken: newRefreshToken, sessionId: newSessionId }
   }
 
   async updateUserNickname(userId: string, nickname: string): Promise<OAuthUserResponseDto> {

--- a/backend/src/oauth/service/token.service.spec.ts
+++ b/backend/src/oauth/service/token.service.spec.ts
@@ -4,6 +4,7 @@ import { JwtService } from '@nestjs/jwt'
 import { UnauthorizedException } from '@nestjs/common'
 import type { Response } from 'express'
 import { TokenService } from './token.service'
+import { RedisRepository } from '../../redis/redis.repository'
 
 describe('TokenService', () => {
   let service: TokenService
@@ -17,8 +18,14 @@ describe('TokenService', () => {
     get: jest.fn(),
   }
 
+  const mockRedisRepository = {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    keys: jest.fn(),
+  }
+
   beforeEach(async () => {
-    // 기본 설정값 모킹 (모듈 생성 전에 설정)
     mockConfigService.get.mockImplementation((key: string) => {
       const config: Record<string, string> = {
         JWT_ACCESS_EXPIRES_IN: '15m',
@@ -40,6 +47,10 @@ describe('TokenService', () => {
         {
           provide: ConfigService,
           useValue: mockConfigService,
+        },
+        {
+          provide: RedisRepository,
+          useValue: mockRedisRepository,
         },
       ],
     }).compile()
@@ -90,9 +101,10 @@ describe('TokenService', () => {
   describe('generateTokens', () => {
     beforeEach(() => {
       jest.clearAllMocks()
+      mockRedisRepository.set.mockResolvedValue('OK')
     })
 
-    it('userId로 Access Token과 Refresh Token을 발급하고 저장한다', () => {
+    it('userId로 Access Token과 Refresh Token을 발급하고 저장한다', async () => {
       const userId = 'user-123'
       const mockAccessToken = 'mock-access-token'
       const mockRefreshToken = 'mock-refresh-token'
@@ -104,19 +116,21 @@ describe('TokenService', () => {
         exp: Math.floor(Date.now() / 1000) + 14 * 24 * 60 * 60,
       })
 
-      const result = service.generateTokens(userId)
+      const result = await service.generateTokens(userId)
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         accessToken: mockAccessToken,
         refreshToken: mockRefreshToken,
+        sessionId: expect.any(String),
       })
       expect(mockJwtService.sign).toHaveBeenCalledTimes(2)
       expect(mockJwtService.verify).toHaveBeenCalledWith(mockRefreshToken, {
         secret: 'test_refresh_secret',
       })
+      expect(mockRedisRepository.set).toHaveBeenCalled()
     })
 
-    it('Refresh Token의 userId가 일치하지 않으면 UnauthorizedException을 던진다', () => {
+    it('Refresh Token의 userId가 일치하지 않으면 UnauthorizedException을 던진다', async () => {
       const userId = 'user-123'
       const mockRefreshToken = 'mock-refresh-token'
 
@@ -126,14 +140,19 @@ describe('TokenService', () => {
         exp: Math.floor(Date.now() / 1000) + 14 * 24 * 60 * 60,
       })
 
-      expect(() => service.generateTokens(userId)).toThrow(UnauthorizedException)
-      expect(() => service.generateTokens(userId)).toThrow('Refresh Token의 userId가 일치하지 않습니다')
+      await expect(service.generateTokens(userId)).rejects.toThrow(UnauthorizedException)
+      await expect(service.generateTokens(userId)).rejects.toThrow('Refresh Token의 userId가 일치하지 않습니다')
     })
   })
 
   describe('storeRefreshToken', () => {
-    it('Refresh Token을 저장한다', () => {
+    beforeEach(() => {
+      mockRedisRepository.set.mockResolvedValue('OK')
+    })
+
+    it('Refresh Token을 저장한다', async () => {
       const userId = 'user-123'
+      const sessionId = 'session-123'
       const mockRefreshToken = 'mock-refresh-token'
 
       mockJwtService.verify.mockReturnValue({
@@ -141,15 +160,17 @@ describe('TokenService', () => {
         exp: Math.floor(Date.now() / 1000) + 14 * 24 * 60 * 60,
       })
 
-      service.storeRefreshToken(mockRefreshToken, userId)
+      await service.storeRefreshToken(sessionId, mockRefreshToken, userId)
 
       expect(mockJwtService.verify).toHaveBeenCalledWith(mockRefreshToken, {
         secret: 'test_refresh_secret',
       })
+      expect(mockRedisRepository.set).toHaveBeenCalled()
     })
 
-    it('userId가 일치하지 않으면 UnauthorizedException을 던진다', () => {
+    it('userId가 일치하지 않으면 UnauthorizedException을 던진다', async () => {
       const userId = 'user-123'
+      const sessionId = 'session-123'
       const mockRefreshToken = 'mock-refresh-token'
 
       mockJwtService.verify.mockReturnValue({
@@ -157,162 +178,135 @@ describe('TokenService', () => {
         exp: Math.floor(Date.now() / 1000) + 14 * 24 * 60 * 60,
       })
 
-      expect(() => service.storeRefreshToken(mockRefreshToken, userId)).toThrow(UnauthorizedException)
-      expect(() => service.storeRefreshToken(mockRefreshToken, userId)).toThrow('Refresh Token의 userId가 일치하지 않습니다')
+      await expect(service.storeRefreshToken(sessionId, mockRefreshToken, userId)).rejects.toThrow(UnauthorizedException)
+      await expect(service.storeRefreshToken(sessionId, mockRefreshToken, userId)).rejects.toThrow('Refresh Token의 userId가 일치하지 않습니다')
     })
   })
 
   describe('refresh', () => {
     const userId = 'user-123'
-    const mockRefreshToken = 'valid-refresh-token'
+    const sessionId = 'session-123'
     const mockNewAccessToken = 'new-access-token'
     const mockNewRefreshToken = 'new-refresh-token'
 
     beforeEach(() => {
       jest.clearAllMocks()
-      // verify는 여러 번 호출될 수 있으므로 mockImplementation 사용
       mockJwtService.verify.mockImplementation(() => ({
         sub: userId,
         exp: Math.floor(Date.now() / 1000) + 14 * 24 * 60 * 60,
       }))
+      mockRedisRepository.set.mockResolvedValue('OK')
     })
 
-    it('유효한 Refresh Token으로 새로운 토큰 쌍을 발급한다', () => {
-      // 초기 토큰 생성
-      mockJwtService.sign.mockReturnValueOnce(mockRefreshToken).mockReturnValueOnce('initial-access-token')
+    it('유효한 세션 ID로 새로운 토큰 쌍을 발급한다', async () => {
+      const storedTokenData = JSON.stringify({
+        userId,
+        exp: Math.floor(Date.now() / 1000) + 14 * 24 * 60 * 60,
+        expiresAt: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+        isRevoked: false,
+      })
 
-      const tokens = service.generateTokens(userId)
-      const actualRefreshToken = tokens.refreshToken
-
-      // refresh 시 새로운 토큰 생성
+      mockRedisRepository.get.mockResolvedValue(storedTokenData)
       mockJwtService.sign.mockReturnValueOnce(mockNewRefreshToken).mockReturnValueOnce(mockNewAccessToken)
 
-      const result = service.refresh(actualRefreshToken)
+      const result = await service.refresh(sessionId)
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         accessToken: mockNewAccessToken,
         refreshToken: mockNewRefreshToken,
+        sessionId: expect.any(String),
       })
+      expect(mockRedisRepository.get).toHaveBeenCalledWith(`session:${sessionId}`)
+      expect(mockRedisRepository.set).toHaveBeenCalled()
     })
 
-    it('존재하지 않는 Refresh Token이면 UnauthorizedException을 던진다', () => {
-      expect(() => service.refresh('invalid-token')).toThrow(UnauthorizedException)
-      expect(() => service.refresh('invalid-token')).toThrow('유효하지 않은 Refresh Token입니다')
+    it('존재하지 않는 세션이면 UnauthorizedException을 던진다', async () => {
+      mockRedisRepository.get.mockResolvedValue(null)
+
+      await expect(service.refresh('invalid-session')).rejects.toThrow(UnauthorizedException)
+      await expect(service.refresh('invalid-session')).rejects.toThrow('유효하지 않은 Refresh Token입니다')
     })
 
-    it('이미 무효화된 Refresh Token이면 UnauthorizedException을 던진다', () => {
-      // 초기 토큰 생성
-      const initialRefreshToken = 'initial-refresh-token'
-      mockJwtService.sign.mockReturnValueOnce(initialRefreshToken).mockReturnValueOnce('initial-access-token')
-
-      mockJwtService.verify.mockImplementation(() => ({
-        sub: userId,
+    it('이미 무효화된 세션이면 UnauthorizedException을 던진다', async () => {
+      const storedTokenData = JSON.stringify({
+        userId,
         exp: Math.floor(Date.now() / 1000) + 14 * 24 * 60 * 60,
-      }))
-
-      const tokens = service.generateTokens(userId)
-      const actualRefreshToken = tokens.refreshToken
-      expect(actualRefreshToken).toBe(initialRefreshToken)
-
-      const newRefreshToken = 'new-refresh-token'
-      mockJwtService.sign.mockReturnValueOnce(newRefreshToken).mockReturnValueOnce('new-access-token')
-
-      const refreshResult = service.refresh(actualRefreshToken)
-
-      expect(refreshResult.refreshToken).toBe(newRefreshToken)
-      expect(() => service.refresh(actualRefreshToken)).toThrow(UnauthorizedException)
-      expect(() => service.refresh(actualRefreshToken)).toThrow('Refresh Token 재사용이 감지되었습니다')
-    })
-
-    it('만료된 Refresh Token이면 UnauthorizedException을 던진다', () => {
-      const expiredToken = 'expired-refresh-token'
-
-      // 토큰을 먼저 생성
-      mockJwtService.sign.mockReturnValueOnce(expiredToken).mockReturnValueOnce('access')
-      mockJwtService.verify.mockReturnValue({
-        sub: userId,
-        exp: Math.floor(Date.now() / 1000) + 14 * 24 * 60 * 60,
+        expiresAt: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+        isRevoked: true,
       })
 
-      const tokens = service.generateTokens(userId)
-      const actualRefreshToken = tokens.refreshToken
+      mockRedisRepository.get.mockResolvedValue(storedTokenData)
+      mockRedisRepository.keys.mockResolvedValue([])
 
-      const futureDate = new Date()
-      const expiresInMs = service.parseExpiresIn(service.REFRESH_TOKEN_EXPIRES_IN)
-      futureDate.setTime(futureDate.getTime() + expiresInMs + 1000)
+      await expect(service.refresh(sessionId)).rejects.toThrow(UnauthorizedException)
+      await expect(service.refresh(sessionId)).rejects.toThrow('Refresh Token 재사용이 감지되었습니다')
+    })
 
-      jest.useFakeTimers()
-      jest.setSystemTime(futureDate)
+    it('만료된 세션이면 UnauthorizedException을 던진다', async () => {
+      const pastDate = new Date(Date.now() - 1000)
+      const storedTokenData = JSON.stringify({
+        userId,
+        exp: Math.floor(Date.now() / 1000) - 1,
+        expiresAt: pastDate,
+        isRevoked: false,
+      })
 
-      expect(() => service.refresh(actualRefreshToken)).toThrow(UnauthorizedException)
-      expect(() => service.refresh(actualRefreshToken)).toThrow('만료된 Refresh Token입니다')
+      mockRedisRepository.get.mockResolvedValue(storedTokenData)
 
-      jest.useRealTimers()
+      await expect(service.refresh(sessionId)).rejects.toThrow(UnauthorizedException)
+      await expect(service.refresh(sessionId)).rejects.toThrow('만료된 Refresh Token입니다')
     })
   })
 
   describe('revokeRefreshToken', () => {
-    it('Refresh Token을 무효화한다', () => {
-      const userId = 'user-123'
-      const mockRefreshToken = 'mock-refresh-token'
+    it('세션을 삭제한다', async () => {
+      const sessionId = 'session-123'
+      mockRedisRepository.del.mockResolvedValue(1)
 
-      mockJwtService.sign.mockReturnValue(mockRefreshToken)
-      mockJwtService.verify.mockReturnValue({
-        sub: userId,
-        exp: Math.floor(Date.now() / 1000) + 14 * 24 * 60 * 60,
-      })
+      await service.revokeRefreshToken(sessionId)
 
-      service.generateTokens(userId)
-      service.revokeRefreshToken(mockRefreshToken)
-
-      expect(() => service.refresh(mockRefreshToken)).toThrow(UnauthorizedException)
+      expect(mockRedisRepository.del).toHaveBeenCalledWith(`session:${sessionId}`)
     })
   })
 
   describe('revokeAllRefreshTokensForUser', () => {
-    it('특정 사용자의 모든 Refresh Token을 무효화한다', () => {
+    it('특정 사용자의 모든 세션을 삭제한다', async () => {
       const userId1 = 'user-1'
       const userId2 = 'user-2'
-      const mockToken1 = 'token-1'
-      const mockToken2 = 'token-2'
-      const mockToken3 = 'token-3'
+      const session1 = 'session-1'
+      const session2 = 'session-2'
+      const session3 = 'session-3'
 
-      mockJwtService.sign
-        .mockReturnValueOnce(mockToken1)
-        .mockReturnValueOnce('access-1')
-        .mockReturnValueOnce(mockToken2)
-        .mockReturnValueOnce('access-2')
-        .mockReturnValueOnce(mockToken3)
-        .mockReturnValueOnce('access-3')
-
-      mockJwtService.verify.mockReturnValue({
-        sub: userId1,
+      const tokenData1 = JSON.stringify({
+        userId: userId1,
         exp: Math.floor(Date.now() / 1000) + 14 * 24 * 60 * 60,
+        expiresAt: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+        isRevoked: false,
       })
 
-      service.generateTokens(userId1)
-
-      mockJwtService.verify.mockReturnValue({
-        sub: userId2,
+      const tokenData2 = JSON.stringify({
+        userId: userId2,
         exp: Math.floor(Date.now() / 1000) + 14 * 24 * 60 * 60,
+        expiresAt: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+        isRevoked: false,
       })
 
-      service.generateTokens(userId2)
-
-      mockJwtService.verify.mockReturnValue({
-        sub: userId1,
+      const tokenData3 = JSON.stringify({
+        userId: userId1,
         exp: Math.floor(Date.now() / 1000) + 14 * 24 * 60 * 60,
+        expiresAt: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+        isRevoked: false,
       })
 
-      service.generateTokens(userId1)
+      mockRedisRepository.keys.mockResolvedValue([`session:${session1}`, `session:${session2}`, `session:${session3}`])
+      mockRedisRepository.get.mockResolvedValueOnce(tokenData1).mockResolvedValueOnce(tokenData2).mockResolvedValueOnce(tokenData3)
+      mockRedisRepository.del.mockResolvedValue(1)
 
-      service.revokeAllRefreshTokensForUser(userId1)
+      await service.revokeAllRefreshTokensForUser(userId1)
 
-      // revokeAllRefreshTokensForUser는 isRevoked = true로 설정하므로, refresh 시도 시 재사용 감지 에러가 발생해야 함
-      expect(() => service.refresh(mockToken1)).toThrow(UnauthorizedException)
-      expect(() => service.refresh(mockToken1)).toThrow('Refresh Token 재사용이 감지되었습니다')
-      expect(() => service.refresh(mockToken3)).toThrow(UnauthorizedException)
-      expect(() => service.refresh(mockToken3)).toThrow('Refresh Token 재사용이 감지되었습니다')
+      expect(mockRedisRepository.del).toHaveBeenCalledWith(`session:${session1}`)
+      expect(mockRedisRepository.del).toHaveBeenCalledWith(`session:${session3}`)
+      expect(mockRedisRepository.del).not.toHaveBeenCalledWith(`session:${session2}`)
     })
   })
 
@@ -343,16 +337,16 @@ describe('TokenService', () => {
   })
 
   describe('setTokensInCookie', () => {
-    it('쿠키에 Access Token과 Refresh Token을 설정한다', () => {
+    it('쿠키에 Access Token과 Session ID를 설정한다', () => {
       const mockCookie = jest.fn()
       const mockRes = {
         cookie: mockCookie,
       } as unknown as Response<Record<string, unknown>>
 
       const accessToken = 'access-token'
-      const refreshToken = 'refresh-token'
+      const sessionId = 'session-id'
 
-      service.setTokensInCookie(mockRes, accessToken, refreshToken)
+      service.setTokensInCookie(mockRes, accessToken, sessionId)
 
       expect(mockCookie).toHaveBeenCalledTimes(2)
       expect(mockCookie).toHaveBeenCalledWith(
@@ -366,8 +360,8 @@ describe('TokenService', () => {
         }),
       )
       expect(mockCookie).toHaveBeenCalledWith(
-        'refresh_token',
-        refreshToken,
+        'session_id',
+        sessionId,
         expect.objectContaining({
           httpOnly: true,
           secure: false,
@@ -433,7 +427,7 @@ describe('TokenService', () => {
         sameSite: 'lax',
         path: '/',
       })
-      expect(mockClearCookie).toHaveBeenCalledWith('refresh_token', {
+      expect(mockClearCookie).toHaveBeenCalledWith('session_id', {
         httpOnly: true,
         secure: false,
         sameSite: 'lax',

--- a/backend/src/oauth/service/token.service.ts
+++ b/backend/src/oauth/service/token.service.ts
@@ -2,6 +2,8 @@ import { Injectable, UnauthorizedException } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { JwtService } from '@nestjs/jwt'
 import type { Response } from 'express'
+import { v7 as uuidv7 } from 'uuid'
+import { RedisRepository } from '../../redis/redis.repository'
 
 type StoredRefreshToken = {
   userId: string
@@ -18,14 +20,11 @@ export class TokenService {
   private readonly ACCESS_TOKEN_SECRET: string
   private readonly REFRESH_TOKEN_SECRET: string
 
-  //TODO: Redis 사용
-  private readonly refreshTokenStore = new Map<string, StoredRefreshToken>()
-
   constructor(
     private readonly jwtService: JwtService,
     private readonly config: ConfigService,
+    private readonly redisRepository: RedisRepository,
   ) {
-    // 생성자에서 상수 초기화
     this.ACCESS_TOKEN_EXPIRES_IN = this.config.get<string>('JWT_ACCESS_EXPIRES_IN') || '15m'
     this.REFRESH_TOKEN_EXPIRES_IN = this.config.get<string>('JWT_REFRESH_EXPIRES_IN') || '14d'
     this.ACCESS_TOKEN_SECRET = this.config.get<string>('JWT_ACCESS_SECRET') || 'access_secret'
@@ -54,25 +53,26 @@ export class TokenService {
   /**
    * Access Token과 Refresh Token 발급 및 저장
    */
-  generateTokens(userId: string): { accessToken: string; refreshToken: string } {
+  async generateTokens(userId: string): Promise<{ accessToken: string; refreshToken: string; sessionId: string }> {
     const refreshToken = this.signRefresh(userId)
     const accessToken = this.signAccess(userId)
-    // Refresh Token만 저장 (RTR을 위해)
-    this.storeRefreshToken(refreshToken, userId)
+    const sessionId = uuidv7()
+
+    await this.storeRefreshToken(sessionId, refreshToken, userId)
 
     return {
       accessToken,
       refreshToken,
+      sessionId,
     }
   }
 
   /**
    * 쿠키에 토큰 설정
    */
-  setTokensInCookie(res: Response, accessToken: string, refreshToken: string): void {
+  setTokensInCookie(res: Response, accessToken: string, sessionId: string): void {
     const isSecure = this.config.get<string>('NODE_ENV') === 'production'
 
-    // Access Token 쿠키 설정
     res.cookie('access_token', accessToken, {
       httpOnly: true,
       secure: isSecure,
@@ -81,8 +81,7 @@ export class TokenService {
       maxAge: this.parseExpiresIn(this.ACCESS_TOKEN_EXPIRES_IN),
     })
 
-    // Refresh Token 쿠키 설정
-    res.cookie('refresh_token', refreshToken, {
+    res.cookie('session_id', sessionId, {
       httpOnly: true,
       secure: isSecure,
       sameSite: 'lax',
@@ -104,61 +103,66 @@ export class TokenService {
   /**
    * Refresh Token 저장
    */
-  storeRefreshToken(refreshToken: string, userId: string): void {
+  async storeRefreshToken(sessionId: string, refreshToken: string, userId: string): Promise<void> {
     const decoded = this.jwtService.verify<{ sub: string; exp: number }>(refreshToken, {
       secret: this.REFRESH_TOKEN_SECRET,
     })
 
-    // userId 검증 (토큰의 userId와 일치하는지 확인)
     if (decoded.sub !== userId) {
       throw new UnauthorizedException('Refresh Token의 userId가 일치하지 않습니다')
     }
 
-    this.refreshTokenStore.set(refreshToken, {
+    const tokenData: StoredRefreshToken = {
       userId: decoded.sub,
       exp: decoded.exp,
       expiresAt: this.calculateRefreshTokenExpiry(),
       isRevoked: false,
-    })
+    }
+
+    const ttlSeconds = Math.floor(this.parseExpiresIn(this.REFRESH_TOKEN_EXPIRES_IN) / 1000)
+    await this.redisRepository.set(`session:${sessionId}`, JSON.stringify(tokenData), ttlSeconds)
   }
 
   /**
    * 토큰 갱신 (RTR - Refresh Token Rotation 적용)
    * 기존 refresh token을 무효화하고 새로운 토큰 쌍을 발급
    */
-  refresh(refreshToken: string): { accessToken: string; refreshToken: string } {
-    // 토큰 조회
-    const storedToken = this.refreshTokenStore.get(refreshToken)
+  async refresh(sessionId: string): Promise<{ accessToken: string; refreshToken: string; sessionId: string }> {
+    const storedData = await this.redisRepository.get(`session:${sessionId}`)
 
-    if (!storedToken) {
+    if (!storedData) {
       throw new UnauthorizedException('유효하지 않은 Refresh Token입니다')
     }
 
-    // 이미 폐기된(Revoked) 토큰인지 확인
+    const storedToken = JSON.parse(storedData) as StoredRefreshToken
+
     if (storedToken.isRevoked) {
-      this.revokeAllRefreshTokensForUser(storedToken.userId)
+      await this.revokeAllRefreshTokensForUser(storedToken.userId)
       throw new UnauthorizedException('Refresh Token 재사용이 감지되었습니다. 다시 로그인해주세요.')
     }
 
-    // 만료 기간 확인
-    if (new Date() > storedToken.expiresAt) {
+    if (new Date() > new Date(storedToken.expiresAt)) {
       throw new UnauthorizedException('만료된 Refresh Token입니다')
     }
 
-    // 기존 토큰 무효화 처리
     storedToken.isRevoked = true
+    const shortTtl = 300
+    await this.redisRepository.set(`session:${sessionId}`, JSON.stringify(storedToken), shortTtl)
 
-    // 새로운 토큰 쌍 생성
-    const newTokens = this.generateTokens(storedToken.userId)
-
-    // 새로운 Refresh Token 저장
+    const newTokens = await this.generateTokens(storedToken.userId)
     return newTokens
   }
 
-  revokeAllRefreshTokensForUser(userId: string): void {
-    for (const meta of this.refreshTokenStore.values()) {
-      if (meta.userId === userId) {
-        meta.isRevoked = true
+  async revokeAllRefreshTokensForUser(userId: string): Promise<void> {
+    const keys = await this.redisRepository.keys('session:*')
+
+    for (const key of keys) {
+      const data = await this.redisRepository.get(key)
+      if (data) {
+        const token = JSON.parse(data) as StoredRefreshToken
+        if (token.userId === userId) {
+          await this.redisRepository.del(key)
+        }
       }
     }
   }
@@ -166,8 +170,8 @@ export class TokenService {
   /**
    * Refresh Token 무효화
    */
-  revokeRefreshToken(refreshToken: string): void {
-    this.refreshTokenStore.delete(refreshToken)
+  async revokeRefreshToken(sessionId: string): Promise<void> {
+    await this.redisRepository.del(`session:${sessionId}`)
   }
 
   clearAuthCookies(res: Response): void {
@@ -180,7 +184,7 @@ export class TokenService {
       path: '/',
     })
 
-    res.clearCookie('refresh_token', {
+    res.clearCookie('session_id', {
       httpOnly: true,
       secure: isSecure,
       sameSite: 'lax',

--- a/backend/src/oauth/strategy/jwt-refresh.strategy.ts
+++ b/backend/src/oauth/strategy/jwt-refresh.strategy.ts
@@ -1,42 +1,18 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common'
-import { PassportStrategy } from '@nestjs/passport'
-import { ExtractJwt, Strategy } from 'passport-jwt'
+import { Injectable, UnauthorizedException, CanActivate, ExecutionContext } from '@nestjs/common'
 import type { Request } from 'express'
-import { ConfigService } from '@nestjs/config'
-
-interface JwtRefreshPayload {
-  sub: string
-  iat?: number
-  exp?: number
-}
-
-interface RefreshUser {
-  userId: string
-  refreshToken: string
-}
 
 @Injectable()
-export class RefreshStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
-  constructor(private readonly config: ConfigService) {
-    super({
-      jwtFromRequest: ExtractJwt.fromExtractors([
-        (req: Request) => {
-          const cookies = req.cookies as Record<string, string> | undefined
-          return cookies?.refresh_token || null
-        },
-      ]),
-      secretOrKey: config.getOrThrow<string>('JWT_REFRESH_SECRET'),
-      passReqToCallback: true,
-    })
-  }
+export class RefreshGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>()
+    const cookies = request.cookies as Record<string, string> | undefined
+    const sessionId = cookies?.session_id
 
-  validate(req: Request, payload: JwtRefreshPayload): RefreshUser {
-    if (!payload?.sub) throw new UnauthorizedException('유효하지 않은 Refresh Token입니다.')
+    if (!sessionId) {
+      throw new UnauthorizedException('세션이 없습니다.')
+    }
 
-    const cookies = req.cookies as Record<string, string> | undefined
-    const refreshToken = cookies?.refresh_token
-    if (!refreshToken) throw new UnauthorizedException('Refresh Token이 없습니다.')
-
-    return { userId: payload.sub, refreshToken }
+    request.user = { userId: '', sessionId }
+    return true
   }
 }

--- a/backend/src/redis/redis.repository.ts
+++ b/backend/src/redis/redis.repository.ts
@@ -46,6 +46,17 @@ export class RedisRepository implements OnModuleDestroy {
     return this.redisClient.del(key)
   }
 
+  async incr(key: string, ttl?: number): Promise<number> {
+    if (ttl) {
+      const pipeline = this.redisClient.pipeline()
+      pipeline.incr(key)
+      pipeline.expire(key, ttl, 'NX')
+      const results = await pipeline.exec()
+      return Number(results?.[0][1] ?? 0)
+    }
+    return this.redisClient.incr(key)
+  }
+
   async exists(key: string): Promise<boolean> {
     const result = await this.redisClient.exists(key)
     return result === 1

--- a/backend/src/redis/redis.repository.ts
+++ b/backend/src/redis/redis.repository.ts
@@ -86,6 +86,23 @@ export class RedisRepository implements OnModuleDestroy {
     return this.redisClient.keys(pattern)
   }
 
+  // Redis Sorted Set 메서드
+  async zadd(key: string, score: number, member: string): Promise<number> {
+    return this.redisClient.zadd(key, score, member)
+  }
+
+  async zrem(key: string, ...members: string[]): Promise<number> {
+    return this.redisClient.zrem(key, ...members)
+  }
+
+  async zrangebyscore(key: string, min: number | string, max: number | string): Promise<string[]> {
+    return this.redisClient.zrangebyscore(key, min, max)
+  }
+
+  async zscore(key: string, member: string): Promise<string | null> {
+    return this.redisClient.zscore(key, member)
+  }
+
   getRedisClient(): Redis {
     return this.redisClient
   }

--- a/backend/src/redis/redis.repository.ts
+++ b/backend/src/redis/redis.repository.ts
@@ -71,6 +71,10 @@ export class RedisRepository implements OnModuleDestroy {
     return this.redisClient.lrange(key, start, stop)
   }
 
+  async keys(pattern: string): Promise<string[]> {
+    return this.redisClient.keys(pattern)
+  }
+
   getRedisClient(): Redis {
     return this.redisClient
   }


### PR DESCRIPTION
## 🔗 관련 이슈
resolve #353 


## ✅ 작업 내용

### 💡개선 사항

#### 1️⃣ 배틀 상태 캐싱 (Cache Hit/Miss)
- Redis 도입으로 배틀 상태 조회 성능 최적화
- Cache Miss 시 DB 로드 후 Redis 동기화 (Lazy Loading)
- 상태 변경 및 skip 시 캐시 정합성 유지 로직 추가

#### 2️⃣ Redis 기반 Gemini API 키 가용성 관리
- 기존 Ricky가 작업한 기능에서 map으로 관리되고 있던 사용량 부분을 레디스로 전환

#### 3️⃣ Redis 기반 세션 관리
- 인메모리 저장소 제거 후 Redis 기반 세션 관리
- `session_id`로 쿠키 발급 및 Refresh Token Rotation(RTR) 로직 redis로 전환

#### 4️⃣ 타이머
- Redis Sorted Set 기반 타이머로 전환 및 Polling 방식 도입 (1초마다 만료된 배틀 확인)
  - Score: 만료 시간(timestamp)
  - Member: 배틀 ID
- `BattleTimerWorkerUseCase`에서 1초마다  만료된 배틀 확인, 자동 페이즈 전환 처리

```mermaid
flowchart LR
    A[서버 실행<br/>OPINION_SHARE<br/>14:32:00 전환 예정] --> B[Redis 저장<br/>expiredAt: 14:32:00]
    B --> C[💥 서버 중단<br/>14:30:30]
    C --> D[⏰ 14:32:00<br/>전환 시간 도래<br/>❌ 전환 못함]
    D --> E[Redis 데이터 유지<br/>expiredAt: 14:32:00<br/>⚠️ 전환 대기 중]
    E --> F[🔄 서버 재시작<br/>14:33:00]
    F --> G[워커 체크<br/>14:33:01]
    G --> H{expiredAt 지났나?<br/>14:32:00 < 14:33:01}
    H -->|Yes 만료됨!| I[놓친 페이즈 전환 실행<br/>OPINION_SHARE → ATTACK<br/>배틀 정상화 ✅]
    
    style C fill:#ffe1e1
    style D fill:#fff4e1
    style E fill:#fff4e1
    style I fill:#e1ffe1
```
<br />

## 📸 참고 사항
| 배틀 상태 저장 | 타이머 |
|--|--|
|  <img width="1049" height="262" alt="image" src="https://github.com/user-attachments/assets/d37aef3a-43b4-420a-a7d7-728e486fb097" /> | <img width="1133" height="301" alt="image" src="https://github.com/user-attachments/assets/09f6136f-e065-4887-be87-0c69a0748d64" /> |


| 세션 관리 |  Gemini 사용량 관리 |
|--|--|
|  <img width="1652" height="229" alt="image" src="https://github.com/user-attachments/assets/e4206588-18c0-4c23-bd82-de7f0c40fd89" /> |  <img width="953" height="188" alt="image" src="https://github.com/user-attachments/assets/17a9c63c-d632-44c6-bbda-4b1467bbe5d0" />

<br />

## 💬 질문사항 (고민했던 부분)
