### PR TITLE
[Fix] Sentry.setUser() 메서드 에러 코드 주석처리

### DIFF
--- a/frontend/src/commons/stores/authStore.ts
+++ b/frontend/src/commons/stores/authStore.ts
@@ -69,12 +69,12 @@ export const useAuthStore = create<AuthStore>((set, get) => {
           isLoggingIn: false
         });
 
-        const { default: Sentry } = await import('@sentry/react');
-        Sentry.setUser({
-          id: user.id,
-          username: user.nickname,
-          type: 'guest'
-        });
+        // const { default: Sentry } = await import('@sentry/react');
+        // Sentry.setUser({
+        //   id: user.id,
+        //   username: user.nickname,
+        //   type: 'guest'
+        // });
 
         return user;
       } catch (e) {
@@ -108,13 +108,13 @@ export const useAuthStore = create<AuthStore>((set, get) => {
 
         set({ user: oauthUser });
 
-        const { default: Sentry } = await import('@sentry/react');
-        Sentry.setUser({
-          id: oauthUser.id,
-          username: oauthUser.nickname,
-          provider: oauthUser.provider,
-          type: 'oauth'
-        });
+        // const { default: Sentry } = await import('@sentry/react');
+        // Sentry.setUser({
+        //   id: oauthUser.id,
+        //   username: oauthUser.nickname,
+        //   provider: oauthUser.provider,
+        //   type: 'oauth'
+        // });
 
         localStorage.setItem(
           OAUTH_KEY,
@@ -140,8 +140,8 @@ export const useAuthStore = create<AuthStore>((set, get) => {
         get().clearAuth();
 
         // Sentry 사용자 정보 제거
-        const { default: Sentry } = await import('@sentry/react');
-        Sentry.setUser(null);
+        // const { default: Sentry } = await import('@sentry/react');
+        // Sentry.setUser(null);
       } catch {
         throw new Error('로그아웃 실패');
       }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #365 

## ✅ 작업 내용

`Sentry.setUser()` 코드를 거치는 로직들에서 에러가 발생하여 임시적으로 주석처리를 해둡니다.

**인지된 에러 발생 범위**
- 로그인 유지
- 비회원으로 배틀 진입

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->


- [x] `authStore.ts` 파일 `Sentry.setUser()` 관련 코드 주석
<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->

- 일단 주석처리를 해두었는데, 버그 수정이 가능하면 머지하지 않아도 될 것 같습니다!