### PR TITLE
[Fix] 초대 코드 Navigate 에러 수정

### DIFF
--- a/frontend/src/pages/invitePage/index.tsx
+++ b/frontend/src/pages/invitePage/index.tsx
@@ -8,7 +8,7 @@ export default function InvitePage() {
     if (!inviteCode) {
       return;
     }
-    window.location.href = `/api/battles/${inviteCode}`;
+    window.location.href = `${import.meta.env.VITE_API_URL}/api/battles/${inviteCode}`;
   }, [inviteCode]);
 
   return (


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #372 

## ✅ 작업 내용

Invite Code를 통해 접근 시 다음과 같이 라우팅 된다.

1. `/battles/:id` 로 URL 진입
2.  FE에서 `/api/battles/:id`로 라우팅 
3.  BE에서 GET으로 받아서 `${frontendUrl}/battle/${battleId}/team-select` 로 redirect

Nginx에서 `/api` 를 BE 서버로 바로 보내주었지만 이제는 아니다...

- [x] `/api/battles/:id` -> `${VITE_API_URL}/api/battles/:id` 로 변경

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
