### PR TITLE
[Test] 테스트 커버리지 향상

### DIFF
--- a/backend/src/battles/adapters/in/battles.gateway.spec.ts
+++ b/backend/src/battles/adapters/in/battles.gateway.spec.ts
@@ -346,4 +346,349 @@ describe('BattlesGateway - Discussion Events', () => {
       expect(mockServer.emit).toHaveBeenCalledWith('battle:all:updated', payload)
     })
   })
+
+  describe('handleConnection', () => {
+    it('소켓 연결 시 userId를 저장한다', () => {
+      const mockClientNew = {
+        id: 'client-new',
+        emit: jest.fn(),
+        data: {},
+        handshake: {
+          auth: {
+            userId: 'new-user',
+          },
+        },
+        disconnect: jest.fn(),
+      }
+
+      gateway.handleConnection(mockClientNew as any)
+
+      expect(mockClientNew.data.userId).toBe('new-user')
+    })
+
+    it('userId가 없으면 연결을 끊는다', () => {
+      const mockClientNoAuth = {
+        id: 'client-no-auth',
+        emit: jest.fn(),
+        data: {},
+        handshake: {
+          auth: {},
+        },
+        disconnect: jest.fn(),
+      }
+
+      gateway.handleConnection(mockClientNoAuth as any)
+
+      expect(mockClientNoAuth.disconnect).toHaveBeenCalled()
+    })
+  })
+
+  describe('handleDisconnect', () => {
+    let participationUseCase: jest.Mocked<BattleParticipationUseCase>
+
+    beforeEach(() => {
+      participationUseCase = gateway['participationUseCase'] as jest.Mocked<BattleParticipationUseCase>
+    })
+
+    it('배틀에 참여 중이면 leave를 호출한다', async () => {
+      const mockClientWithBattle = {
+        id: 'client-with-battle',
+        emit: jest.fn(),
+        data: {
+          userId: 'user-in-battle',
+          battleId: 'battle-1',
+        },
+        disconnect: jest.fn(),
+      }
+
+      participationUseCase.leave.mockResolvedValue({} as any)
+      gateway['userIdToSocketMap'].set('user-in-battle', mockClientWithBattle as any)
+
+      await gateway.handleDisconnect(mockClientWithBattle as any)
+
+      expect(participationUseCase.leave).toHaveBeenCalledWith('user-in-battle', 'battle-1')
+      expect(mockClientWithBattle.disconnect).toHaveBeenCalled()
+    })
+
+    it('userId만 있고 battleId가 없으면 leave를 호출하지 않는다', async () => {
+      const mockClientNoBattle = {
+        id: 'client-no-battle',
+        emit: jest.fn(),
+        data: {
+          userId: 'user-no-battle',
+        },
+        disconnect: jest.fn(),
+      }
+
+      gateway['userIdToSocketMap'].set('user-no-battle', mockClientNoBattle as any)
+
+      await gateway.handleDisconnect(mockClientNoBattle as any)
+
+      expect(participationUseCase.leave).not.toHaveBeenCalled()
+      expect(mockClientNoBattle.disconnect).toHaveBeenCalled()
+    })
+  })
+
+  describe('joinBattle', () => {
+    let participationUseCase: jest.Mocked<BattleParticipationUseCase>
+    let queryUseCase: jest.Mocked<BattleQueryUseCase>
+
+    beforeEach(() => {
+      participationUseCase = gateway['participationUseCase'] as jest.Mocked<BattleParticipationUseCase>
+      queryUseCase = gateway['queryUseCase'] as jest.Mocked<BattleQueryUseCase>
+    })
+
+    it('공개 배틀에 참가한다', async () => {
+      const dto = {
+        battleId: 'battle-1',
+        team: BATTLE_TEAM.A,
+        nickname: '테스터',
+      }
+
+      queryUseCase.isPrivateBattle.mockResolvedValue(false)
+      participationUseCase.join.mockResolvedValue({
+        battleState: {
+          battleId: 'battle-1',
+          round: 1,
+          phase: 'PENDING',
+          phaseCount: 1,
+          startedAt: null,
+          expiredAt: null,
+          topics: ['topic1'],
+          totalRounds: 1,
+          participants: new Map([['user-1', BATTLE_TEAM.A]]),
+          userInfoMap: new Map([['user-1', '테스터']]),
+          teamVotes: new Map(),
+          skipState: new Set(),
+          teamA: { roomId: 'battle:battle-1:A', users: ['user-1'], chats: [], attacks: [], defenses: [] },
+          teamB: { roomId: 'battle:battle-1:B', users: [], chats: [], attacks: [], defenses: [] },
+          all: { roomId: 'battle:battle-1', chats: [], attacks: [], defenses: [] },
+          opinionHistory: [],
+        } as any,
+        team: BATTLE_TEAM.A,
+      })
+
+      const joinMockClient = {
+        ...mockClient,
+        join: jest.fn().mockResolvedValue(undefined),
+      }
+
+      await gateway.joinBattle(dto as any, joinMockClient)
+
+      expect(queryUseCase.isPrivateBattle).toHaveBeenCalledWith('battle-1')
+      expect(participationUseCase.join).toHaveBeenCalled()
+      expect(joinMockClient.emit).toHaveBeenCalledWith('battle:joined', expect.any(Object))
+    })
+
+    it('비공개 배틀에 초대 코드 없이 접근하면 에러를 emit한다', async () => {
+      const dto = {
+        battleId: 'battle-private',
+        team: BATTLE_TEAM.A,
+        nickname: '테스터',
+      }
+
+      queryUseCase.isPrivateBattle.mockResolvedValue(true)
+
+      const joinMockClient = {
+        ...mockClient,
+        handshake: {
+          auth: { userId: 'user-1' },
+          headers: { cookie: '' },
+        },
+        join: jest.fn().mockResolvedValue(undefined),
+      }
+
+      await gateway.joinBattle(dto as any, joinMockClient)
+
+      expect(joinMockClient.emit).toHaveBeenCalledWith('battle:join:error', {
+        message: '비공개 배틀에 접근하려면 초대 코드가 필요합니다.',
+      })
+    })
+  })
+
+  describe('handleLeave', () => {
+    let participationUseCase: jest.Mocked<BattleParticipationUseCase>
+
+    beforeEach(() => {
+      participationUseCase = gateway['participationUseCase'] as jest.Mocked<BattleParticipationUseCase>
+    })
+
+    it('배틀에서 나간다', async () => {
+      const dto = { battleId: 'battle-1' }
+      participationUseCase.leave.mockResolvedValue({} as any)
+
+      await gateway.handleLeave(dto, mockClient)
+
+      expect(participationUseCase.leave).toHaveBeenCalledWith('user-1', 'battle-1')
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockServer.emit).toHaveBeenCalledWith('battle:leaved', expect.any(Object))
+    })
+  })
+
+  describe('handleStart', () => {
+    let creationUseCase: jest.Mocked<BattleCreationUseCase>
+
+    beforeEach(() => {
+      creationUseCase = gateway['creationUseCase'] as jest.Mocked<BattleCreationUseCase>
+    })
+
+    it('배틀을 시작한다', async () => {
+      const dto = { battleId: 'battle-1' }
+      creationUseCase.start.mockResolvedValue(undefined)
+
+      await gateway.handleStart(dto as any)
+
+      expect(creationUseCase.start).toHaveBeenCalledWith('battle-1')
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockServer.emit).toHaveBeenCalledWith('battle:started')
+    })
+  })
+
+  describe('handlePhaseSkip', () => {
+    let phaseTransitionUseCase: jest.Mocked<BattlePhaseTransitionUseCase>
+
+    beforeEach(() => {
+      phaseTransitionUseCase = gateway['phaseTransitionUseCase'] as jest.Mocked<BattlePhaseTransitionUseCase>
+    })
+
+    it('스킵 요청을 처리한다', async () => {
+      const dto = { skip: true, battleId: 'battle-1' }
+      phaseTransitionUseCase.handlePhaseSkip.mockResolvedValue(3)
+
+      await gateway.handlePhaseSkip(dto, mockClient)
+
+      expect(phaseTransitionUseCase.handlePhaseSkip).toHaveBeenCalledWith('battle-1', 'user-1', true)
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockServer.emit).toHaveBeenCalledWith('battle:user:skipped', { totalSkips: 3 })
+    })
+  })
+
+  describe('handleChat', () => {
+    it('채팅을 전송한다', async () => {
+      const dto = {
+        battleId: 'battle-1',
+        scope: 'all',
+        team: BATTLE_TEAM.A,
+        text: '안녕하세요',
+      }
+
+      interactionUseCase.sendChat.mockResolvedValue({
+        battleId: 'battle-1',
+        scope: 'all',
+        messageId: 'msg-1',
+        team: BATTLE_TEAM.A,
+        sender: { userId: 'user-1', nickname: '테스터' },
+        text: '안녕하세요',
+        createdAt: new Date(),
+      })
+
+      const chatMockServer = {
+        to: jest.fn().mockReturnValue({
+          except: jest.fn().mockReturnValue({
+            emit: jest.fn(),
+          }),
+        }),
+        emit: jest.fn(),
+      }
+      gateway.server = chatMockServer as any
+
+      await gateway.handleChat(dto as any, mockClient)
+
+      expect(interactionUseCase.sendChat).toHaveBeenCalled()
+    })
+  })
+
+  describe('handleTeamVote', () => {
+    it('팀 투표를 처리한다', async () => {
+      const dto = {
+        battleId: 'battle-1',
+        team: BATTLE_TEAM.B,
+      }
+
+      interactionUseCase.switchTeam.mockResolvedValue(undefined)
+
+      await gateway.handleTeamVote(dto as any, mockClient)
+
+      expect(interactionUseCase.switchTeam).toHaveBeenCalledWith('battle-1', 'user-1', BATTLE_TEAM.B)
+    })
+  })
+
+  describe('phaseUpdate', () => {
+    it('페이즈 업데이트를 브로드캐스트한다', () => {
+      const payload = { battleId: 'battle-1', phase: 'ATTACK', phaseCount: 1, startedAt: Date.now(), expiredAt: Date.now() + 60000 }
+
+      gateway.phaseUpdate(payload as any)
+
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockServer.emit).toHaveBeenCalledWith('battle:phase:updated', payload)
+    })
+  })
+
+  describe('roundUpdate', () => {
+    it('라운드 업데이트를 브로드캐스트한다', () => {
+      const payload = { battleId: 'battle-1', round: 2, topic: 'topic2' }
+
+      gateway.roundUpdate(payload as any)
+
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockServer.emit).toHaveBeenCalledWith('battle:round:updated', payload)
+    })
+  })
+
+  describe('onAttacked', () => {
+    it('공격 결과를 브로드캐스트한다', () => {
+      const payload = { battleId: 'battle-1', aTeam: null, bTeam: null }
+
+      gateway.onAttacked(payload as any)
+
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockServer.emit).toHaveBeenCalledWith('battle:attacked', payload)
+    })
+  })
+
+  describe('onDefensed', () => {
+    it('반론 결과를 브로드캐스트한다', () => {
+      const payload = { battleId: 'battle-1', aTeam: null, bTeam: null }
+
+      gateway.onDefensed(payload as any)
+
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockServer.emit).toHaveBeenCalledWith('battle:defensed', payload)
+    })
+  })
+
+  describe('closeBattle', () => {
+    it('배틀 종료를 브로드캐스트하고 소켓을 끊는다', () => {
+      const payload = { battleId: 'battle-1' }
+      const mockIn = jest.fn().mockReturnValue({ disconnectSockets: jest.fn() })
+      gateway.server = { ...mockServer, in: mockIn }
+
+      gateway.closeBattle(payload as any)
+
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockServer.emit).toHaveBeenCalledWith('battle:closed', payload)
+      expect(mockIn).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('skipPhase', () => {
+    it('스킵 이벤트를 브로드캐스트한다', () => {
+      const payload = { battleId: 'battle-1' }
+
+      gateway.skipPhase(payload)
+
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockServer.emit).toHaveBeenCalledWith('battle:phase:skipped')
+    })
+  })
+
+  describe('afterInit', () => {
+    it('broadcaster에 서버를 설정한다', () => {
+      const broadcasterAdapter = gateway['broadcaster'] as jest.Mocked<BattleBroadcasterAdapter>
+
+      gateway.afterInit(mockServer)
+
+      expect(broadcasterAdapter.setServer).toHaveBeenCalledWith(mockServer)
+    })
+  })
 })

--- a/backend/src/battles/adapters/out/battleIdentifier/battleIdentifier.adapter.spec.ts
+++ b/backend/src/battles/adapters/out/battleIdentifier/battleIdentifier.adapter.spec.ts
@@ -1,0 +1,37 @@
+import { BattleIdentifierAdapter } from './battleIdentifier.adapter'
+
+describe('BattleIdentifierAdapter', () => {
+  let adapter: BattleIdentifierAdapter
+
+  beforeEach(() => {
+    adapter = new BattleIdentifierAdapter()
+  })
+
+  describe('generateId', () => {
+    it('UUID v7 문자열을 반환한다', () => {
+      const id = adapter.generateId()
+      expect(typeof id).toBe('string')
+      expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    })
+
+    it('호출마다 고유한 ID를 생성한다', () => {
+      const ids = new Set(Array.from({ length: 100 }, () => adapter.generateId()))
+      expect(ids.size).toBe(100)
+    })
+  })
+
+  describe('generateInviteCode', () => {
+    it('문자열을 반환한다', () => {
+      const code = adapter.generateInviteCode()
+      expect(typeof code).toBe('string')
+      expect(code.length).toBeGreaterThan(0)
+    })
+
+    it('타임스탬프 기반 코드를 반환한다', () => {
+      const code = adapter.generateInviteCode()
+      const parsed = Number(code)
+      expect(Number.isNaN(parsed)).toBe(false)
+      expect(parsed).toBeGreaterThan(0)
+    })
+  })
+})

--- a/backend/src/battles/adapters/out/battlePrivacyCheck/battlePrivacyCheck.adapter.spec.ts
+++ b/backend/src/battles/adapters/out/battlePrivacyCheck/battlePrivacyCheck.adapter.spec.ts
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { BattlePrivacyCheckAdapter } from './battlePrivacyCheck.adapter'
+import type { PrismaService } from '../../../../prisma/prisma.service'
+
+describe('BattlePrivacyCheckAdapter', () => {
+  let adapter: BattlePrivacyCheckAdapter
+  let prisma: jest.Mocked<PrismaService>
+
+  beforeEach(() => {
+    prisma = {
+      battle: {
+        findUnique: jest.fn(),
+      },
+    } as unknown as jest.Mocked<PrismaService>
+    adapter = new BattlePrivacyCheckAdapter(prisma)
+  })
+
+  describe('isPrivateBattle', () => {
+    it('비공개 배틀이면 true를 반환한다', async () => {
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue({ isPrivate: true })
+      const result = await adapter.isPrivateBattle('battle-1')
+      expect(result).toBe(true)
+      expect(prisma.battle.findUnique).toHaveBeenCalledWith({
+        where: { id: 'battle-1' },
+        select: { isPrivate: true },
+      })
+    })
+
+    it('공개 배틀이면 false를 반환한다', async () => {
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue({ isPrivate: false })
+      const result = await adapter.isPrivateBattle('battle-1')
+      expect(result).toBe(false)
+    })
+
+    it('배틀이 없으면 false를 반환한다', async () => {
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(null)
+      const result = await adapter.isPrivateBattle('nonexistent')
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.spec.ts
+++ b/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.spec.ts
@@ -1,0 +1,120 @@
+import type { Server } from 'socket.io'
+import { BattleBroadcasterAdapter } from './battleBroadcaster.adapter'
+import type { BattlePhaseResponseDto, BattleRoundResponseDto } from '../../../dto/battleTurnResponse.dto'
+import type { BattleUserUpdateResponseDto } from '../../../dto/battleUserUpdateResponse.dto'
+import type { BattleTeamUpdateAllResponseDto } from '../../../dto/battleTeamUpdateAllResponse.dto'
+import type { BattleClosedResponseDto } from '../../../dto/battleClosedResponse.dto'
+import type { DiscussionVoteResultDto } from '../../../dto/discussionVoteResult.dto'
+
+describe('BattleBroadcasterAdapter', () => {
+  let adapter: BattleBroadcasterAdapter
+  let mockServer: { to: jest.Mock; in: jest.Mock }
+  let mockRoom: { emit: jest.Mock; disconnectSockets: jest.Mock }
+
+  beforeEach(() => {
+    mockRoom = {
+      emit: jest.fn(),
+      disconnectSockets: jest.fn(),
+    }
+    mockServer = {
+      to: jest.fn().mockReturnValue(mockRoom),
+      in: jest.fn().mockReturnValue(mockRoom),
+    }
+    adapter = new BattleBroadcasterAdapter()
+    adapter.setServer(mockServer as unknown as Server)
+  })
+
+  describe('서버 미설정 시', () => {
+    it('서버 없이 emit하면 에러가 발생한다', () => {
+      const noServerAdapter = new BattleBroadcasterAdapter()
+      const dto = { battleId: 'b1' } as BattlePhaseResponseDto
+      expect(() => noServerAdapter.emitPhaseUpdated(dto)).toThrow('Socket server not initialized')
+    })
+  })
+
+  describe('emitPhaseUpdated', () => {
+    it('battle room에 phase:updated 이벤트를 전송한다', () => {
+      const dto = { battleId: 'battle-1' } as BattlePhaseResponseDto
+      const listener = jest.fn()
+      adapter.on('battle:phase:updated', listener)
+
+      adapter.emitPhaseUpdated(dto)
+
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockRoom.emit).toHaveBeenCalledWith('battle:phase:updated', dto)
+      expect(listener).toHaveBeenCalledWith(dto)
+    })
+  })
+
+  describe('emitRoundUpdated', () => {
+    it('battle room에 round:updated 이벤트를 전송한다', () => {
+      const dto = { battleId: 'battle-1' } as BattleRoundResponseDto
+      adapter.emitRoundUpdated(dto)
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockRoom.emit).toHaveBeenCalledWith('battle:round:updated', dto)
+    })
+  })
+
+  describe('emitUserUpdated', () => {
+    it('battle room에 user:updated 이벤트를 전송한다', () => {
+      const dto = { battleId: 'battle-1' } as BattleUserUpdateResponseDto
+      adapter.emitUserUpdated(dto)
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockRoom.emit).toHaveBeenCalledWith('battle:user:updated', dto)
+    })
+  })
+
+  describe('emitTeamUpdated', () => {
+    it('battle room에 team:updated 이벤트를 전송한다', () => {
+      const dto = { battleId: 'battle-1' } as BattleTeamUpdateAllResponseDto
+      adapter.emitTeamUpdated(dto)
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockRoom.emit).toHaveBeenCalledWith('battle:team:updated', dto)
+    })
+  })
+
+  describe('emitBattleClosed', () => {
+    it('battle room에 closed 이벤트를 전송하고 소켓을 끊는다', () => {
+      const dto = { battleId: 'battle-1' } as BattleClosedResponseDto
+      adapter.emitBattleClosed(dto)
+
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockRoom.emit).toHaveBeenCalledWith('battle:closed', dto)
+      expect(mockServer.in).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockServer.in).toHaveBeenCalledWith('battle:battle-1:A')
+      expect(mockServer.in).toHaveBeenCalledWith('battle:battle-1:B')
+      expect(mockRoom.disconnectSockets).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('emitPhaseSkipped', () => {
+    it('battle room에 phase:skipped 이벤트를 전송한다', () => {
+      const listener = jest.fn()
+      adapter.on('battle:phase:skipped', listener)
+
+      adapter.emitPhaseSkipped('battle-1')
+
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockRoom.emit).toHaveBeenCalledWith('battle:phase:skipped')
+      expect(listener).toHaveBeenCalledWith({ battleId: 'battle-1' })
+    })
+  })
+
+  describe('emitAttacked', () => {
+    it('battle room에 attacked 이벤트를 전송한다', () => {
+      const dto = { battleId: 'battle-1' } as DiscussionVoteResultDto
+      adapter.emitAttacked(dto)
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockRoom.emit).toHaveBeenCalledWith('battle:attacked', dto)
+    })
+  })
+
+  describe('emitDefensed', () => {
+    it('battle room에 defensed 이벤트를 전송한다', () => {
+      const dto = { battleId: 'battle-1' } as DiscussionVoteResultDto
+      adapter.emitDefensed(dto)
+      expect(mockServer.to).toHaveBeenCalledWith('battle:battle-1')
+      expect(mockRoom.emit).toHaveBeenCalledWith('battle:defensed', dto)
+    })
+  })
+})

--- a/backend/src/battles/adapters/out/guestCheck/guestCheck.adapter.spec.ts
+++ b/backend/src/battles/adapters/out/guestCheck/guestCheck.adapter.spec.ts
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { GuestCheckAdapter } from './guestCheck.adapter'
+import type { OauthService } from '../../../../oauth/service/oauth.service'
+
+describe('GuestCheckAdapter', () => {
+  let adapter: GuestCheckAdapter
+  let oauthService: jest.Mocked<OauthService>
+
+  beforeEach(() => {
+    oauthService = {
+      isNicknameExists: jest.fn(),
+    } as unknown as jest.Mocked<OauthService>
+    adapter = new GuestCheckAdapter(oauthService)
+  })
+
+  describe('isNicknameExists', () => {
+    it('닉네임이 존재하면 true를 반환한다', async () => {
+      oauthService.isNicknameExists.mockResolvedValue(true)
+      const result = await adapter.isNicknameExists('테스터')
+      expect(result).toBe(true)
+      expect(oauthService.isNicknameExists).toHaveBeenCalledWith('테스터')
+    })
+
+    it('닉네임이 없으면 false를 반환한다', async () => {
+      oauthService.isNicknameExists.mockResolvedValue(false)
+      const result = await adapter.isNicknameExists('새닉네임')
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/backend/src/battles/adapters/out/persistence/battleRepository.adapter.spec.ts
+++ b/backend/src/battles/adapters/out/persistence/battleRepository.adapter.spec.ts
@@ -1,0 +1,329 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { NotFoundException } from '@nestjs/common'
+import { BattleRepositoryAdapter } from './battleRepository.adapter'
+import type { PrismaService } from '../../../../prisma/prisma.service'
+
+describe('BattleRepositoryAdapter', () => {
+  let adapter: BattleRepositoryAdapter
+  let prisma: jest.Mocked<PrismaService>
+
+  beforeEach(() => {
+    prisma = {
+      battle: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        count: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+      },
+      user: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        update: jest.fn(),
+      },
+      battleParticipant: {
+        upsert: jest.fn(),
+        updateMany: jest.fn(),
+      },
+      $transaction: jest.fn(),
+    } as unknown as jest.Mocked<PrismaService>
+    adapter = new BattleRepositoryAdapter(prisma)
+  })
+
+  describe('findUnique', () => {
+    it('배틀을 찾아 반환한다', async () => {
+      const mockBattle = { id: 'battle-1', title: '테스트 배틀' }
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(mockBattle)
+
+      const result = await adapter.findUnique('battle-1')
+
+      expect(result).toEqual(mockBattle)
+      expect(prisma.battle.findUnique).toHaveBeenCalledWith({ where: { id: 'battle-1' } })
+    })
+
+    it('배틀이 없으면 NotFoundException을 던진다', async () => {
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(null)
+
+      await expect(adapter.findUnique('nonexistent')).rejects.toThrow(NotFoundException)
+    })
+  })
+
+  describe('findBattleList', () => {
+    it('배틀 목록을 조회한다', async () => {
+      const mockBattles = [{ id: 'battle-1' }, { id: 'battle-2' }]
+      ;(prisma.battle.findMany as jest.Mock).mockResolvedValue(mockBattles)
+
+      const result = await adapter.findBattleList({ limit: 10, offset: 0 })
+
+      expect(result).toEqual(mockBattles)
+    })
+
+    it('공개 배틀만 조회한다', async () => {
+      ;(prisma.battle.findMany as jest.Mock).mockResolvedValue([])
+
+      await adapter.findBattleList({ onlyPublic: true, limit: 10, offset: 0 })
+
+      expect(prisma.battle.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { isPrivate: false },
+        }),
+      )
+    })
+
+    it('상태로 필터링한다 (문자열)', async () => {
+      ;(prisma.battle.findMany as jest.Mock).mockResolvedValue([])
+
+      await adapter.findBattleList({ status: 'OPEN', limit: 10, offset: 0 })
+
+      expect(prisma.battle.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { status: 'OPEN' },
+        }),
+      )
+    })
+
+    it('상태로 필터링한다 (배열)', async () => {
+      ;(prisma.battle.findMany as jest.Mock).mockResolvedValue([])
+
+      await adapter.findBattleList({ status: { in: ['OPEN', 'CLOSED'] }, limit: 10, offset: 0 })
+
+      expect(prisma.battle.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { status: { in: ['OPEN', 'CLOSED'] } },
+        }),
+      )
+    })
+
+    it('정렬 옵션을 적용한다', async () => {
+      ;(prisma.battle.findMany as jest.Mock).mockResolvedValue([])
+
+      await adapter.findBattleList({ limit: 10, offset: 0, orderBy: { finishedAt: 'desc' } })
+
+      expect(prisma.battle.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { finishedAt: 'desc' },
+        }),
+      )
+    })
+  })
+
+  describe('countBattleList', () => {
+    it('배틀 수를 반환한다', async () => {
+      ;(prisma.battle.count as jest.Mock).mockResolvedValue(5)
+
+      const result = await adapter.countBattleList({})
+
+      expect(result).toBe(5)
+    })
+
+    it('상태 필터로 카운트한다', async () => {
+      ;(prisma.battle.count as jest.Mock).mockResolvedValue(3)
+
+      await adapter.countBattleList({ status: 'OPEN' })
+
+      expect(prisma.battle.count).toHaveBeenCalledWith({ where: { status: 'OPEN' } })
+    })
+
+    it('상태 배열 필터로 카운트한다', async () => {
+      ;(prisma.battle.count as jest.Mock).mockResolvedValue(3)
+
+      await adapter.countBattleList({ status: { in: ['OPEN', 'CLOSED'] } })
+
+      expect(prisma.battle.count).toHaveBeenCalledWith({ where: { status: { in: ['OPEN', 'CLOSED'] } } })
+    })
+  })
+
+  describe('findUniqueByInviteCode', () => {
+    it('초대 코드로 배틀을 찾는다', async () => {
+      const mockBattle = { id: 'battle-1', inviteCode: 'ABC123' }
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(mockBattle)
+
+      const result = await adapter.findUniqueByInviteCode('ABC123')
+
+      expect(result).toEqual(mockBattle)
+      expect(prisma.battle.findUnique).toHaveBeenCalledWith({ where: { inviteCode: 'ABC123' } })
+    })
+
+    it('없으면 null을 반환한다', async () => {
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(null)
+
+      const result = await adapter.findUniqueByInviteCode('INVALID')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('create', () => {
+    it('배틀을 생성한다', async () => {
+      const createData = {
+        id: 'battle-1',
+        userId: 'user-1',
+        title: '테스트',
+        description: '설명',
+        codeA: 'code A',
+        codeB: 'code B',
+        language: 'javascript',
+        category: 'ALGORITHM',
+        playTime: 'FIFTEEN_MIN',
+        topics: ['topic1'],
+        inviteCode: null,
+        isPrivate: false,
+        status: 'PENDING',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        currentRound: 1,
+        currentPhase: 'PENDING',
+        phaseCount: 1,
+        startedAt: null,
+        expiredAt: null,
+        participantsState: [],
+        teamVotesState: [],
+        userInfoState: [],
+        attacksState: {},
+        defensesState: {},
+        opinionHistoryState: [],
+        chatsAllState: [],
+        chatsTeamAState: [],
+        chatsTeamBState: [],
+      }
+      const mockBattle = { ...createData }
+      ;(prisma.battle.create as jest.Mock).mockResolvedValue(mockBattle)
+
+      const result = await adapter.create(createData)
+
+      expect(result).toEqual(mockBattle)
+      expect(prisma.battle.create).toHaveBeenCalledWith({ data: createData })
+    })
+  })
+
+  describe('update', () => {
+    it('배틀을 업데이트한다', async () => {
+      const mockBattle = { id: 'battle-1', status: 'OPEN' }
+      ;(prisma.battle.update as jest.Mock).mockResolvedValue(mockBattle)
+
+      const result = await adapter.update('battle-1', { status: 'OPEN' })
+
+      expect(result).toEqual(mockBattle)
+      expect(prisma.battle.update).toHaveBeenCalledWith({
+        where: { id: 'battle-1' },
+        data: { status: 'OPEN' },
+      })
+    })
+  })
+
+  describe('findUniqueUser', () => {
+    it('사용자를 찾아 반환한다', async () => {
+      const mockUser = { id: 'user-1', rating: 1500, tier: 'SILVER' }
+      ;(prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser)
+
+      const result = await adapter.findUniqueUser('user-1', { id: true, rating: true, tier: true })
+
+      expect(result).toEqual(mockUser)
+    })
+
+    it('select 옵션 없이 조회한다', async () => {
+      const mockUser = { id: 'user-1' }
+      ;(prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser)
+
+      const result = await adapter.findUniqueUser('user-1')
+
+      expect(result).toEqual(mockUser)
+    })
+  })
+
+  describe('findManyUsers', () => {
+    it('여러 사용자를 조회한다', async () => {
+      const mockUsers = [
+        { id: 'user-1', rating: 1500, tier: 'SILVER' },
+        { id: 'user-2', rating: 1600, tier: 'GOLD' },
+      ]
+      ;(prisma.user.findMany as jest.Mock).mockResolvedValue(mockUsers)
+
+      const result = await adapter.findManyUsers({
+        where: { id: { in: ['user-1', 'user-2'] } },
+        select: { id: true, rating: true, tier: true },
+      })
+
+      expect(result).toEqual(mockUsers)
+    })
+  })
+
+  describe('updateUser', () => {
+    it('사용자 정보를 업데이트한다', async () => {
+      ;(prisma.user.update as jest.Mock).mockResolvedValue({})
+
+      await adapter.updateUser('user-1', { rating: 1600, tier: 'GOLD' })
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        data: { rating: 1600, tier: 'GOLD' },
+      })
+    })
+  })
+
+  describe('upsertBattleParticipant', () => {
+    it('참가자를 upsert한다', async () => {
+      ;(prisma.battleParticipant.upsert as jest.Mock).mockResolvedValue({})
+
+      await adapter.upsertBattleParticipant({
+        userId: 'user-1',
+        battleId: 'battle-1',
+        team: 'A',
+        isMvp: false,
+      })
+
+      expect(prisma.battleParticipant.upsert).toHaveBeenCalledWith({
+        where: { userId_battleId: { userId: 'user-1', battleId: 'battle-1' } },
+        create: { userId: 'user-1', battleId: 'battle-1', team: 'A', isMvp: false },
+        update: { team: 'A', isMvp: false },
+      })
+    })
+  })
+
+  describe('updateManyBattleParticipants', () => {
+    it('여러 참가자를 업데이트한다', async () => {
+      ;(prisma.battleParticipant.updateMany as jest.Mock).mockResolvedValue({})
+
+      await adapter.updateManyBattleParticipants({
+        where: { battleId: 'battle-1', userId: { in: ['user-1', 'user-2'] } },
+        data: { isMvp: true },
+      })
+
+      expect(prisma.battleParticipant.updateMany).toHaveBeenCalledWith({
+        where: { battleId: 'battle-1', userId: { in: ['user-1', 'user-2'] } },
+        data: { isMvp: true },
+      })
+    })
+
+    it('userId 필터 없이 업데이트한다', async () => {
+      ;(prisma.battleParticipant.updateMany as jest.Mock).mockResolvedValue({})
+
+      await adapter.updateManyBattleParticipants({
+        where: { battleId: 'battle-1' },
+        data: { isMvp: false },
+      })
+
+      expect(prisma.battleParticipant.updateMany).toHaveBeenCalledWith({
+        where: { battleId: 'battle-1' },
+        data: { isMvp: false },
+      })
+    })
+  })
+
+  describe('transaction', () => {
+    it('트랜잭션을 실행한다', async () => {
+      const mockResult = { success: true }
+      ;(prisma.$transaction as jest.Mock).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const txMock = {
+          battle: { findUnique: jest.fn() },
+        }
+        return fn(txMock)
+      })
+
+      const result = await adapter.transaction(() => Promise.resolve(mockResult))
+
+      expect(prisma.$transaction).toHaveBeenCalled()
+      expect(result).toEqual(mockResult)
+    })
+  })
+})

--- a/backend/src/battles/adapters/out/reference/battleReferenceGenerator.adapter.spec.ts
+++ b/backend/src/battles/adapters/out/reference/battleReferenceGenerator.adapter.spec.ts
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { InternalServerErrorException } from '@nestjs/common'
+import { BattleReferenceGeneratorAdapter } from './battleReferenceGenerator.adapter'
+import type { GeminiService } from '../../../../gemini/gemini.service'
+import type { GenerateReferenceRequest } from '../../../application/ports/out/battleReference.port'
+
+describe('BattleReferenceGeneratorAdapter', () => {
+  let adapter: BattleReferenceGeneratorAdapter
+  let geminiService: jest.Mocked<GeminiService>
+
+  beforeEach(() => {
+    geminiService = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<GeminiService>
+    adapter = new BattleReferenceGeneratorAdapter(geminiService)
+  })
+
+  const mockRequest: GenerateReferenceRequest = {
+    title: '테스트 배틀',
+    description: '설명',
+    codeA: 'console.log("A")',
+    codeB: 'console.log("B")',
+    language: 'javascript',
+    category: 'clean-code',
+    topics: ['가독성', '성능'],
+  }
+
+  const mockReferenceData = {
+    summary: 'AI 분석 결과',
+    codeAAnalysis: '코드 A 분석',
+    codeBAnalysis: '코드 B 분석',
+  }
+
+  describe('generate', () => {
+    it('AI 참고 자료를 정상적으로 생성한다', async () => {
+      geminiService.execute.mockResolvedValue(mockReferenceData)
+      const result = await adapter.generate(mockRequest)
+      expect(result).toEqual(mockReferenceData)
+      expect(geminiService.execute).toHaveBeenCalledTimes(1)
+    })
+
+    it('InternalServerErrorException은 그대로 전파한다', async () => {
+      const error = new InternalServerErrorException('Gemini 실패')
+      geminiService.execute.mockRejectedValue(error)
+      await expect(adapter.generate(mockRequest)).rejects.toThrow(InternalServerErrorException)
+      await expect(adapter.generate(mockRequest)).rejects.toThrow('Gemini 실패')
+    })
+
+    it('일반 에러는 InternalServerErrorException으로 래핑한다', async () => {
+      geminiService.execute.mockRejectedValue(new Error('네트워크 에러'))
+      await expect(adapter.generate(mockRequest)).rejects.toThrow(InternalServerErrorException)
+      await expect(adapter.generate(mockRequest)).rejects.toThrow('AI 참고 자료 생성에 실패했습니다.')
+    })
+
+    it('topics가 빈 배열이면 "없음"으로 처리된다', async () => {
+      geminiService.execute.mockResolvedValue(mockReferenceData)
+      const requestWithEmptyTopics: GenerateReferenceRequest = { ...mockRequest, topics: [] }
+      await adapter.generate(requestWithEmptyTopics)
+      expect(geminiService.execute).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/backend/src/battles/adapters/out/state/battleStateRepository.adapter.spec.ts
+++ b/backend/src/battles/adapters/out/state/battleStateRepository.adapter.spec.ts
@@ -1,0 +1,279 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { NotFoundException } from '@nestjs/common'
+import { BattleStateRepositoryAdapter } from './battleStateRepository.adapter'
+import type { PrismaService } from '../../../../prisma/prisma.service'
+import { BATTLE_TEAM } from '../../../domains/models/const/battles.const'
+
+describe('BattleStateRepositoryAdapter', () => {
+  let adapter: BattleStateRepositoryAdapter
+  let prisma: jest.Mocked<PrismaService>
+
+  const createMockBattle = (overrides = {}) => ({
+    id: 'battle-1',
+    playTime: 'FIFTEEN_MIN',
+    currentRound: 1,
+    currentPhase: 'PENDING',
+    phaseCount: 1,
+    startedAt: null,
+    expiredAt: null,
+    topics: ['topic1'],
+    participantsState: [],
+    teamVotesState: [],
+    userInfoState: [],
+    attacksState: { teamA: [], teamB: [], all: [] },
+    defensesState: { teamA: [], teamB: [], all: [] },
+    opinionHistoryState: [],
+    chatsAllState: [],
+    chatsTeamAState: [],
+    chatsTeamBState: [],
+    skipState: [],
+    ...overrides,
+  })
+
+  beforeEach(() => {
+    prisma = {
+      battle: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+    } as unknown as jest.Mocked<PrismaService>
+    adapter = new BattleStateRepositoryAdapter(prisma)
+  })
+
+  describe('loadBattleState', () => {
+    it('배틀 상태를 로드한다', async () => {
+      const mockBattle = createMockBattle()
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(mockBattle)
+
+      const result = await adapter.loadBattleState('battle-1')
+
+      expect(result.battle).toEqual(mockBattle)
+      expect(result.state.battleId).toBe('battle-1')
+      expect(result.state.round).toBe(1)
+      expect(result.state.phase).toBe('PENDING')
+    })
+
+    it('배틀이 없으면 NotFoundException을 던진다', async () => {
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(null)
+
+      await expect(adapter.loadBattleState('nonexistent')).rejects.toThrow(NotFoundException)
+    })
+
+    it('올바르지 않은 playTime이면 NotFoundException을 던진다', async () => {
+      const mockBattle = createMockBattle({ playTime: 'INVALID' })
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(mockBattle)
+
+      await expect(adapter.loadBattleState('battle-1')).rejects.toThrow(NotFoundException)
+    })
+
+    it('participants를 파싱한다', async () => {
+      const mockBattle = createMockBattle({
+        participantsState: [
+          { userId: 'user-1', team: 'A' },
+          { userId: 'user-2', team: 'B' },
+        ],
+      })
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(mockBattle)
+
+      const result = await adapter.loadBattleState('battle-1')
+
+      expect(result.state.participants.get('user-1')).toBe('A')
+      expect(result.state.participants.get('user-2')).toBe('B')
+      expect(result.state.teamA.users).toContain('user-1')
+      expect(result.state.teamB.users).toContain('user-2')
+    })
+
+    it('userInfoMap을 파싱한다', async () => {
+      const mockBattle = createMockBattle({
+        userInfoState: [{ userId: 'user-1', nickname: '테스터' }],
+      })
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(mockBattle)
+
+      const result = await adapter.loadBattleState('battle-1')
+
+      expect(result.state.userInfoMap.get('user-1')).toBe('테스터')
+    })
+
+    it('채팅 상태를 파싱한다', async () => {
+      const mockBattle = createMockBattle({
+        chatsAllState: [{ message: 'hello', createdAt: '2024-01-01T00:00:00.000Z' }],
+      })
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(mockBattle)
+
+      const result = await adapter.loadBattleState('battle-1')
+
+      expect(result.state.all.chats).toHaveLength(1)
+      expect(result.state.all.chats[0].message).toBe('hello')
+    })
+
+    it('skipState를 파싱한다', async () => {
+      const mockBattle = createMockBattle({
+        skipState: ['user-1', 'user-2'],
+      })
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(mockBattle)
+
+      const result = await adapter.loadBattleState('battle-1')
+
+      expect(result.state.skipState.has('user-1')).toBe(true)
+      expect(result.state.skipState.has('user-2')).toBe(true)
+    })
+
+    it('startedAt과 expiredAt이 있으면 타임스탬프로 변환한다', async () => {
+      const startedAt = new Date('2024-01-01T00:00:00.000Z')
+      const expiredAt = new Date('2024-01-01T00:15:00.000Z')
+      const mockBattle = createMockBattle({ startedAt, expiredAt })
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(mockBattle)
+
+      const result = await adapter.loadBattleState('battle-1')
+
+      expect(result.state.startedAt).toBe(startedAt.getTime())
+      expect(result.state.expiredAt).toBe(expiredAt.getTime())
+    })
+  })
+
+  describe('saveBattleState', () => {
+    it('배틀 상태를 저장한다', async () => {
+      ;(prisma.battle.update as jest.Mock).mockResolvedValue({})
+
+      const state = {
+        battleId: 'battle-1',
+        round: 2,
+        phase: 'ATTACK' as const,
+        phaseCount: 1,
+        startedAt: Date.now(),
+        expiredAt: Date.now() + 60000,
+        participants: new Map([['user-1', BATTLE_TEAM.A]]),
+        teamVotes: new Map(),
+        userInfoMap: new Map([['user-1', '테스터']]),
+        opinionHistory: [],
+        skipState: new Set<string>(),
+        all: { roomId: 'battle:battle-1', chats: [], attacks: [], defenses: [] },
+        teamA: { roomId: 'battle:battle-1:A', users: ['user-1'], chats: [], attacks: [], defenses: [] },
+        teamB: { roomId: 'battle:battle-1:B', users: [], chats: [], attacks: [], defenses: [] },
+        topics: ['topic1'],
+        totalRounds: 1,
+      }
+
+      await adapter.saveBattleState('battle-1', state)
+
+      expect(prisma.battle.update).toHaveBeenCalledWith({
+        where: { id: 'battle-1' },
+        data: expect.objectContaining({
+          currentRound: 2,
+          currentPhase: 'ATTACK',
+        }),
+      })
+    })
+  })
+
+  describe('updateSkipState', () => {
+    it('스킵 상태를 업데이트한다', async () => {
+      ;(prisma.battle.update as jest.Mock).mockResolvedValue({})
+
+      await adapter.updateSkipState('battle-1', new Set(['user-1', 'user-2']))
+
+      expect(prisma.battle.update).toHaveBeenCalledWith({
+        where: { id: 'battle-1' },
+        data: expect.objectContaining({
+          skipState: expect.arrayContaining(['user-1', 'user-2']),
+        }),
+      })
+    })
+  })
+
+  describe('parseMvpsState', () => {
+    it('MVP 상태를 파싱한다', () => {
+      const mvpsState = [
+        {
+          userId: 'user-1',
+          nickname: '테스터',
+          team: 'A',
+          score: 100,
+          totalVotes: 10,
+          opinionCount: 5,
+          selectedOpinionCount: 2,
+          joinedAt: 1234567890,
+        },
+      ]
+
+      const result = adapter.parseMvpsState(mvpsState)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].userId).toBe('user-1')
+      expect(result[0].nickname).toBe('테스터')
+      expect(result[0].team).toBe('A')
+    })
+
+    it('빈 배열이면 빈 배열을 반환한다', () => {
+      const result = adapter.parseMvpsState([])
+      expect(result).toEqual([])
+    })
+
+    it('배열이 아니면 빈 배열을 반환한다', () => {
+      const result = adapter.parseMvpsState(null)
+      expect(result).toEqual([])
+    })
+
+    it('닉네임이 없는 항목은 필터링한다', () => {
+      const mvpsState = [{ userId: 'user-1', team: 'A', score: 100 }]
+
+      const result = adapter.parseMvpsState(mvpsState)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('team이 A나 B가 아니면 NONE으로 처리한다', () => {
+      const mvpsState = [{ userId: 'user-1', nickname: '테스터', team: 'INVALID', score: 100 }]
+
+      const result = adapter.parseMvpsState(mvpsState)
+
+      expect(result[0].team).toBe('NONE')
+    })
+  })
+
+  describe('getNicknameByUserId', () => {
+    it('userId로 닉네임을 찾는다', () => {
+      const state = {
+        userInfoMap: new Map([['user-1', '테스터']]),
+      } as Parameters<typeof adapter.getNicknameByUserId>[0]
+
+      const result = adapter.getNicknameByUserId(state, 'user-1')
+
+      expect(result).toBe('테스터')
+    })
+
+    it('없으면 null을 반환한다', () => {
+      const state = {
+        userInfoMap: new Map(),
+      } as Parameters<typeof adapter.getNicknameByUserId>[0]
+
+      const result = adapter.getNicknameByUserId(state, 'nonexistent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('isNicknameDuplicate', () => {
+    it('닉네임이 중복되면 true를 반환한다', async () => {
+      const mockBattle = createMockBattle({
+        userInfoState: [{ userId: 'user-1', nickname: '테스터' }],
+      })
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(mockBattle)
+
+      const result = await adapter.isNicknameDuplicate('battle-1', '테스터')
+
+      expect(result).toBe(true)
+    })
+
+    it('닉네임이 중복되지 않으면 false를 반환한다', async () => {
+      const mockBattle = createMockBattle({
+        userInfoState: [{ userId: 'user-1', nickname: '테스터' }],
+      })
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(mockBattle)
+
+      const result = await adapter.isNicknameDuplicate('battle-1', '새닉네임')
+
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/backend/src/battles/adapters/out/state/battleStateRepository.adapter.spec.ts
+++ b/backend/src/battles/adapters/out/state/battleStateRepository.adapter.spec.ts
@@ -2,11 +2,13 @@
 import { NotFoundException } from '@nestjs/common'
 import { BattleStateRepositoryAdapter } from './battleStateRepository.adapter'
 import type { PrismaService } from '../../../../prisma/prisma.service'
+import type { RedisRepository } from '../../../../redis/redis.repository'
 import { BATTLE_TEAM } from '../../../domains/models/const/battles.const'
 
 describe('BattleStateRepositoryAdapter', () => {
   let adapter: BattleStateRepositoryAdapter
   let prisma: jest.Mocked<PrismaService>
+  let redis: jest.Mocked<RedisRepository>
 
   const createMockBattle = (overrides = {}) => ({
     id: 'battle-1',
@@ -37,7 +39,12 @@ describe('BattleStateRepositoryAdapter', () => {
         update: jest.fn(),
       },
     } as unknown as jest.Mocked<PrismaService>
-    adapter = new BattleStateRepositoryAdapter(prisma)
+    redis = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<RedisRepository>
+    adapter = new BattleStateRepositoryAdapter(prisma, redis)
   })
 
   describe('loadBattleState', () => {
@@ -96,14 +103,16 @@ describe('BattleStateRepositoryAdapter', () => {
 
     it('채팅 상태를 파싱한다', async () => {
       const mockBattle = createMockBattle({
-        chatsAllState: [{ message: 'hello', createdAt: '2024-01-01T00:00:00.000Z' }],
+        chatsAllState: [
+          { messageId: 'msg-1', team: 'A', sender: { userId: 'user-1', nickname: 'test' }, text: 'hello', createdAt: '2024-01-01T00:00:00.000Z' },
+        ],
       })
       ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(mockBattle)
 
       const result = await adapter.loadBattleState('battle-1')
 
       expect(result.state.all.chats).toHaveLength(1)
-      expect(result.state.all.chats[0].message).toBe('hello')
+      expect(result.state.all.chats[0].text).toBe('hello')
     })
 
     it('skipState를 파싱한다', async () => {

--- a/backend/src/battles/adapters/out/timer/battleTimer.adapter.spec.ts
+++ b/backend/src/battles/adapters/out/timer/battleTimer.adapter.spec.ts
@@ -1,0 +1,90 @@
+import { BattleTimerAdapter } from './battleTimer.adapter'
+import type { ActiveBattleState } from '../../../domains/models/types/battle.types'
+
+describe('BattleTimerAdapter', () => {
+  let adapter: BattleTimerAdapter
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    adapter = new BattleTimerAdapter()
+  })
+
+  afterEach(() => {
+    adapter.clear()
+    jest.useRealTimers()
+  })
+
+  const createState = (expiredAt: number | null): ActiveBattleState => ({ expiredAt }) as unknown as ActiveBattleState
+
+  describe('schedule', () => {
+    it('expiredAt이 null이면 타이머를 설정하지 않는다', () => {
+      const updatePhase = jest.fn()
+      adapter.schedule('battle-1', createState(null), updatePhase)
+      jest.advanceTimersByTime(10000)
+      expect(updatePhase).not.toHaveBeenCalled()
+    })
+
+    it('만료 시간 후 updatePhase를 호출한다', () => {
+      const updatePhase = jest.fn().mockResolvedValue(undefined)
+      const now = Date.now()
+      adapter.schedule('battle-1', createState(now + 5000), updatePhase)
+
+      jest.advanceTimersByTime(4999)
+      expect(updatePhase).not.toHaveBeenCalled()
+
+      jest.advanceTimersByTime(1)
+      expect(updatePhase).toHaveBeenCalledWith('battle-1')
+    })
+
+    it('이전 타이머를 취소하고 새 타이머를 설정한다', () => {
+      const updatePhase1 = jest.fn().mockResolvedValue(undefined)
+      const updatePhase2 = jest.fn().mockResolvedValue(undefined)
+      const now = Date.now()
+
+      adapter.schedule('battle-1', createState(now + 5000), updatePhase1)
+      adapter.schedule('battle-1', createState(now + 3000), updatePhase2)
+
+      jest.advanceTimersByTime(3000)
+      expect(updatePhase1).not.toHaveBeenCalled()
+      expect(updatePhase2).toHaveBeenCalledWith('battle-1')
+    })
+
+    it('이미 만료된 시간이면 즉시 실행한다', () => {
+      const updatePhase = jest.fn().mockResolvedValue(undefined)
+      const pastTime = Date.now() - 1000
+      adapter.schedule('battle-1', createState(pastTime), updatePhase)
+
+      jest.advanceTimersByTime(0)
+      expect(updatePhase).toHaveBeenCalledWith('battle-1')
+    })
+  })
+
+  describe('cancel', () => {
+    it('해당 배틀의 타이머를 취소한다', () => {
+      const updatePhase = jest.fn().mockResolvedValue(undefined)
+      const now = Date.now()
+      adapter.schedule('battle-1', createState(now + 5000), updatePhase)
+
+      adapter.cancel('battle-1')
+      jest.advanceTimersByTime(10000)
+      expect(updatePhase).not.toHaveBeenCalled()
+    })
+
+    it('존재하지 않는 배틀을 취소해도 에러가 발생하지 않는다', () => {
+      expect(() => adapter.cancel('nonexistent')).not.toThrow()
+    })
+  })
+
+  describe('clear', () => {
+    it('모든 타이머를 취소한다', () => {
+      const updatePhase = jest.fn().mockResolvedValue(undefined)
+      const now = Date.now()
+      adapter.schedule('battle-1', createState(now + 5000), updatePhase)
+      adapter.schedule('battle-2', createState(now + 5000), updatePhase)
+
+      adapter.clear()
+      jest.advanceTimersByTime(10000)
+      expect(updatePhase).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/backend/src/battles/adapters/out/timer/battleTimer.adapter.spec.ts
+++ b/backend/src/battles/adapters/out/timer/battleTimer.adapter.spec.ts
@@ -1,90 +1,70 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import { BattleTimerAdapter } from './battleTimer.adapter'
+import type { RedisRepository } from '../../../../redis/redis.repository'
 import type { ActiveBattleState } from '../../../domains/models/types/battle.types'
 
 describe('BattleTimerAdapter', () => {
   let adapter: BattleTimerAdapter
+  let redis: jest.Mocked<RedisRepository>
 
   beforeEach(() => {
-    jest.useFakeTimers()
-    adapter = new BattleTimerAdapter()
-  })
-
-  afterEach(() => {
-    adapter.clear()
-    jest.useRealTimers()
+    redis = {
+      zadd: jest.fn().mockResolvedValue(undefined),
+      zrem: jest.fn().mockResolvedValue(undefined),
+      zrangebyscore: jest.fn().mockResolvedValue([]),
+      del: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<RedisRepository>
+    adapter = new BattleTimerAdapter(redis)
   })
 
   const createState = (expiredAt: number | null): ActiveBattleState => ({ expiredAt }) as unknown as ActiveBattleState
 
   describe('schedule', () => {
-    it('expiredAt이 null이면 타이머를 설정하지 않는다', () => {
-      const updatePhase = jest.fn()
-      adapter.schedule('battle-1', createState(null), updatePhase)
-      jest.advanceTimersByTime(10000)
-      expect(updatePhase).not.toHaveBeenCalled()
+    it('expiredAt이 null이면 Redis에 저장하지 않는다', () => {
+      adapter.schedule('battle-1', createState(null))
+      expect(redis.zadd).not.toHaveBeenCalled()
     })
 
-    it('만료 시간 후 updatePhase를 호출한다', () => {
-      const updatePhase = jest.fn().mockResolvedValue(undefined)
-      const now = Date.now()
-      adapter.schedule('battle-1', createState(now + 5000), updatePhase)
+    it('expiredAt이 있으면 Redis Sorted Set에 저장한다', () => {
+      const expiredAt = Date.now() + 5000
+      adapter.schedule('battle-1', createState(expiredAt))
 
-      jest.advanceTimersByTime(4999)
-      expect(updatePhase).not.toHaveBeenCalled()
-
-      jest.advanceTimersByTime(1)
-      expect(updatePhase).toHaveBeenCalledWith('battle-1')
-    })
-
-    it('이전 타이머를 취소하고 새 타이머를 설정한다', () => {
-      const updatePhase1 = jest.fn().mockResolvedValue(undefined)
-      const updatePhase2 = jest.fn().mockResolvedValue(undefined)
-      const now = Date.now()
-
-      adapter.schedule('battle-1', createState(now + 5000), updatePhase1)
-      adapter.schedule('battle-1', createState(now + 3000), updatePhase2)
-
-      jest.advanceTimersByTime(3000)
-      expect(updatePhase1).not.toHaveBeenCalled()
-      expect(updatePhase2).toHaveBeenCalledWith('battle-1')
-    })
-
-    it('이미 만료된 시간이면 즉시 실행한다', () => {
-      const updatePhase = jest.fn().mockResolvedValue(undefined)
-      const pastTime = Date.now() - 1000
-      adapter.schedule('battle-1', createState(pastTime), updatePhase)
-
-      jest.advanceTimersByTime(0)
-      expect(updatePhase).toHaveBeenCalledWith('battle-1')
+      expect(redis.zadd).toHaveBeenCalledWith('battle:timers', expiredAt, 'battle-1')
     })
   })
 
   describe('cancel', () => {
-    it('해당 배틀의 타이머를 취소한다', () => {
-      const updatePhase = jest.fn().mockResolvedValue(undefined)
-      const now = Date.now()
-      adapter.schedule('battle-1', createState(now + 5000), updatePhase)
-
+    it('Redis Sorted Set에서 배틀을 제거한다', () => {
       adapter.cancel('battle-1')
-      jest.advanceTimersByTime(10000)
-      expect(updatePhase).not.toHaveBeenCalled()
+
+      expect(redis.zrem).toHaveBeenCalledWith('battle:timers', 'battle-1')
+    })
+  })
+
+  describe('getExpiredBattles', () => {
+    it('만료된 배틀 ID 목록을 반환한다', async () => {
+      redis.zrangebyscore.mockResolvedValue(['battle-1', 'battle-2'])
+
+      const result = await adapter.getExpiredBattles()
+
+      expect(redis.zrangebyscore).toHaveBeenCalledWith('battle:timers', '-inf', expect.any(Number))
+      expect(result).toEqual(['battle-1', 'battle-2'])
     })
 
-    it('존재하지 않는 배틀을 취소해도 에러가 발생하지 않는다', () => {
-      expect(() => adapter.cancel('nonexistent')).not.toThrow()
+    it('만료된 배틀이 없으면 빈 배열을 반환한다', async () => {
+      redis.zrangebyscore.mockResolvedValue([])
+
+      const result = await adapter.getExpiredBattles()
+
+      expect(result).toEqual([])
     })
   })
 
   describe('clear', () => {
-    it('모든 타이머를 취소한다', () => {
-      const updatePhase = jest.fn().mockResolvedValue(undefined)
-      const now = Date.now()
-      adapter.schedule('battle-1', createState(now + 5000), updatePhase)
-      adapter.schedule('battle-2', createState(now + 5000), updatePhase)
-
+    it('Redis에서 타이머 키를 삭제한다', () => {
       adapter.clear()
-      jest.advanceTimersByTime(10000)
-      expect(updatePhase).not.toHaveBeenCalled()
+
+      expect(redis.del).toHaveBeenCalledWith('battle:timers')
     })
   })
 })

--- a/backend/src/battles/application/mappers/battle.mapper.spec.ts
+++ b/backend/src/battles/application/mappers/battle.mapper.spec.ts
@@ -1,0 +1,121 @@
+import { BadRequestException } from '@nestjs/common'
+import { toBattleEntity } from './battle.mapper'
+import { BATTLE_TYPE, BATTLE_PHASE, BATTLE_PLAYTIME } from '../../domains/models/const/battles.const'
+
+describe('battle.mapper', () => {
+  const createMockRecord = (overrides = {}) => ({
+    id: 'battle-1',
+    userId: 'user-1',
+    title: '테스트 배틀',
+    description: '배틀 설명',
+    codeA: 'const a = 1;',
+    codeB: 'const b = 2;',
+    language: 'javascript',
+    category: 'algorithm',
+    playTime: 'FIFTEEN_MIN',
+    topics: ['topic1', 'topic2'],
+    inviteCode: null,
+    isPrivate: false,
+    status: 'OPEN',
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    referenceData: null,
+    ...overrides,
+  })
+
+  describe('toBattleEntity', () => {
+    it('Prisma 레코드를 Battle 엔티티로 변환한다', () => {
+      const record = createMockRecord()
+
+      const result = toBattleEntity(record, 5)
+
+      expect(result.id).toBe('battle-1')
+      expect(result.authorId).toBe('user-1')
+      expect(result.title).toBe('테스트 배틀')
+      expect(result.description).toBe('배틀 설명')
+      expect(result.aCode).toBe('const a = 1;')
+      expect(result.bCode).toBe('const b = 2;')
+      expect(result.language).toBe('javascript')
+      expect(result.category).toBe('algorithm')
+      expect(result.topics).toEqual(['topic1', 'topic2'])
+      expect(result.status).toBe('OPEN')
+      expect(result.participantCount).toBe(5)
+    })
+
+    it('공개 배틀인 경우 type이 PUBLIC이다', () => {
+      const record = createMockRecord({ isPrivate: false })
+
+      const result = toBattleEntity(record, 0)
+
+      expect(result.type).toBe(BATTLE_TYPE.PUBLIC)
+    })
+
+    it('비공개 배틀인 경우 type이 PRIVATE이다', () => {
+      const record = createMockRecord({ isPrivate: true, inviteCode: 'INVITE123' })
+
+      const result = toBattleEntity(record, 0)
+
+      expect(result.type).toBe(BATTLE_TYPE.PRIVATE)
+      expect(result.inviteCode).toBe('INVITE123')
+    })
+
+    it('inviteCode가 null이면 undefined로 변환한다', () => {
+      const record = createMockRecord({ inviteCode: null })
+
+      const result = toBattleEntity(record, 0)
+
+      expect(result.inviteCode).toBeUndefined()
+    })
+
+    it('playTime을 올바르게 매핑한다', () => {
+      const record = createMockRecord({ playTime: 'FIFTEEN_MIN' })
+
+      const result = toBattleEntity(record, 0)
+
+      expect(result.playTime).toBe(BATTLE_PLAYTIME.FIFTEEN_MIN)
+    })
+
+    it('THIRTY_MIN playTime을 올바르게 매핑한다', () => {
+      const record = createMockRecord({ playTime: 'THIRTY_MIN' })
+
+      const result = toBattleEntity(record, 0)
+
+      expect(result.playTime).toBe(BATTLE_PLAYTIME.THIRTY_MIN)
+    })
+
+    it('올바르지 않은 playTime이면 BadRequestException을 던진다', () => {
+      const record = createMockRecord({ playTime: 'INVALID_TIME' })
+
+      expect(() => toBattleEntity(record, 0)).toThrow(BadRequestException)
+      expect(() => toBattleEntity(record, 0)).toThrow('올바르지 않은 배틀 진행 시간입니다.')
+    })
+
+    it('initialState를 올바르게 설정한다', () => {
+      const record = createMockRecord()
+
+      const result = toBattleEntity(record, 0)
+
+      expect(result.initialState.round).toBe(1)
+      expect(result.initialState.phase).toBe(BATTLE_PHASE.OPINION_SHARE.name)
+      expect(result.initialState.phaseCount).toBe(1)
+    })
+
+    it('updatedAt이 null이면 createdAt을 사용한다', () => {
+      const createdAt = new Date('2024-01-01T00:00:00.000Z')
+      const record = createMockRecord({ createdAt, updatedAt: null })
+
+      const result = toBattleEntity(record, 0)
+
+      expect(result.updatedAt).toEqual(createdAt)
+    })
+
+    it('referenceData를 포함한다', () => {
+      const referenceData = { summary: 'AI 요약', keyPoints: ['point1'] }
+      const record = createMockRecord({ referenceData })
+
+      const result = toBattleEntity(record, 0)
+
+      expect(result.referenceData).toEqual(referenceData)
+    })
+  })
+})

--- a/backend/src/battles/application/usecases/battleCreation.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/battleCreation.usecase.spec.ts
@@ -1,10 +1,9 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { BattleCreationUseCase } from './battleCreation.usecase'
-import { BATTLE_STATUS, BATTLE_PHASE, BATTLE_TYPE } from '../../domains/models/const/battles.const'
+import { BATTLE_STATUS, BATTLE_TYPE } from '../../domains/models/const/battles.const'
 import type { BattleRepoPort } from '../ports/out/battleRepository.port'
 import type { BattleStatePort } from '../ports/out/battleState.port'
 import type { BattleBroadcasterPort } from '../ports/out/battleBroadcaster.port'
-import type { BattleTimerPort } from '../ports/out/battleTimer.port'
 import type { BattleReferencePort } from '../ports/out/battleReference.port'
 import type { BattleIdentifierPort } from '../ports/out/battleIdentifier.port'
 import type { BattlePhaseTransitionUseCase } from './battlePhaseTransition.usecase'
@@ -16,7 +15,6 @@ describe('BattleCreationUseCase', () => {
   let repo: jest.Mocked<BattleRepoPort>
   let stateRepo: jest.Mocked<BattleStatePort>
   let broadcaster: jest.Mocked<BattleBroadcasterPort>
-  let timer: jest.Mocked<BattleTimerPort>
   let referencePort: jest.Mocked<BattleReferencePort>
   let identifierPort: jest.Mocked<BattleIdentifierPort>
   let phaseTransitionUseCase: jest.Mocked<BattlePhaseTransitionUseCase>
@@ -86,10 +84,6 @@ describe('BattleCreationUseCase', () => {
       emitRoundUpdated: jest.fn(),
     } as unknown as jest.Mocked<BattleBroadcasterPort>
 
-    timer = {
-      schedule: jest.fn(),
-    } as unknown as jest.Mocked<BattleTimerPort>
-
     referencePort = {
       generate: jest.fn().mockResolvedValue({
         summary: 'AI 요약',
@@ -106,7 +100,7 @@ describe('BattleCreationUseCase', () => {
       advancePhase: jest.fn(),
     } as unknown as jest.Mocked<BattlePhaseTransitionUseCase>
 
-    useCase = new BattleCreationUseCase(repo, stateRepo, broadcaster, timer, referencePort, identifierPort, phaseTransitionUseCase)
+    useCase = new BattleCreationUseCase(repo, stateRepo, broadcaster, referencePort, identifierPort, phaseTransitionUseCase)
   })
 
   describe('create', () => {
@@ -196,9 +190,8 @@ describe('BattleCreationUseCase', () => {
       )
     })
 
-    it('타이머를 스케줄한다', async () => {
+    it('배틀 시작 시 첫 페이즈로 전환한다', async () => {
       const mockState = createMockState()
-      mockState.expiredAt = Date.now() + BATTLE_PHASE.PENDING.time
       stateRepo.loadBattleState.mockResolvedValue({
         battle: {},
         state: mockState,
@@ -206,7 +199,7 @@ describe('BattleCreationUseCase', () => {
 
       await useCase.start('battle-id-123')
 
-      expect(timer.schedule).toHaveBeenCalledWith('battle-id-123', expect.any(Object), expect.any(Function))
+      expect(phaseTransitionUseCase.advancePhase).toHaveBeenCalledWith('battle-id-123')
     })
   })
 })

--- a/backend/src/battles/application/usecases/battleCreation.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/battleCreation.usecase.spec.ts
@@ -1,0 +1,212 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { BattleCreationUseCase } from './battleCreation.usecase'
+import { BATTLE_STATUS, BATTLE_PHASE, BATTLE_TYPE } from '../../domains/models/const/battles.const'
+import type { BattleRepoPort } from '../ports/out/battleRepository.port'
+import type { BattleStatePort } from '../ports/out/battleState.port'
+import type { BattleBroadcasterPort } from '../ports/out/battleBroadcaster.port'
+import type { BattleTimerPort } from '../ports/out/battleTimer.port'
+import type { BattleReferencePort } from '../ports/out/battleReference.port'
+import type { BattleIdentifierPort } from '../ports/out/battleIdentifier.port'
+import type { BattlePhaseTransitionUseCase } from './battlePhaseTransition.usecase'
+import type { BattleCreateQueryDto } from '../../dto/battleCreateQuery.dto'
+import type { ActiveBattleState } from '../../domains/models/types/battle.types'
+
+describe('BattleCreationUseCase', () => {
+  let useCase: BattleCreationUseCase
+  let repo: jest.Mocked<BattleRepoPort>
+  let stateRepo: jest.Mocked<BattleStatePort>
+  let broadcaster: jest.Mocked<BattleBroadcasterPort>
+  let timer: jest.Mocked<BattleTimerPort>
+  let referencePort: jest.Mocked<BattleReferencePort>
+  let identifierPort: jest.Mocked<BattleIdentifierPort>
+  let phaseTransitionUseCase: jest.Mocked<BattlePhaseTransitionUseCase>
+
+  const createMockPayload = (overrides = {}): BattleCreateQueryDto =>
+    ({
+      authorId: 'user-1',
+      title: '테스트 배틀',
+      description: '설명',
+      aCode: 'code A',
+      bCode: 'code B',
+      language: 'javascript',
+      category: 'algorithm',
+      playTime: 'FIFTEEN_MIN',
+      topics: ['topic1'],
+      type: BATTLE_TYPE.PUBLIC,
+      ...overrides,
+    }) as unknown as BattleCreateQueryDto
+
+  const createMockState = (): ActiveBattleState =>
+    ({
+      battleId: 'battle-id-123',
+      round: 1,
+      phase: 'PENDING',
+      phaseCount: 1,
+      startedAt: null,
+      expiredAt: null,
+      topics: ['topic1'],
+      participants: new Map(),
+      userInfoMap: new Map(),
+      teamA: { users: [] },
+      teamB: { users: [] },
+    }) as unknown as ActiveBattleState
+
+  beforeEach(() => {
+    repo = {
+      create: jest.fn().mockResolvedValue({
+        id: 'battle-id-123',
+        userId: 'user-1',
+        title: '테스트 배틀',
+        description: '설명',
+        codeA: 'code A',
+        codeB: 'code B',
+        language: 'javascript',
+        category: 'algorithm',
+        playTime: 'FIFTEEN_MIN',
+        topics: ['topic1'],
+        inviteCode: null,
+        isPrivate: false,
+        status: BATTLE_STATUS.PENDING,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+      update: jest.fn().mockResolvedValue({}),
+    } as unknown as jest.Mocked<BattleRepoPort>
+
+    stateRepo = {
+      loadBattleState: jest.fn().mockResolvedValue({
+        battle: {},
+        state: createMockState(),
+      }),
+      saveBattleState: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<BattleStatePort>
+
+    broadcaster = {
+      emitPhaseUpdated: jest.fn(),
+      emitRoundUpdated: jest.fn(),
+    } as unknown as jest.Mocked<BattleBroadcasterPort>
+
+    timer = {
+      schedule: jest.fn(),
+    } as unknown as jest.Mocked<BattleTimerPort>
+
+    referencePort = {
+      generate: jest.fn().mockResolvedValue({
+        summary: 'AI 요약',
+        keyPoints: ['point1', 'point2'],
+      }),
+    } as unknown as jest.Mocked<BattleReferencePort>
+
+    identifierPort = {
+      generateId: jest.fn().mockReturnValue('battle-id-123'),
+      generateInviteCode: jest.fn().mockReturnValue('INVITE123'),
+    } as unknown as jest.Mocked<BattleIdentifierPort>
+
+    phaseTransitionUseCase = {
+      advancePhase: jest.fn(),
+    } as unknown as jest.Mocked<BattlePhaseTransitionUseCase>
+
+    useCase = new BattleCreationUseCase(repo, stateRepo, broadcaster, timer, referencePort, identifierPort, phaseTransitionUseCase)
+  })
+
+  describe('create', () => {
+    it('배틀을 생성하고 엔티티를 반환한다', async () => {
+      const payload = createMockPayload()
+
+      const result = await useCase.create(payload)
+
+      expect(identifierPort.generateId).toHaveBeenCalled()
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'battle-id-123',
+          userId: 'user-1',
+          title: '테스트 배틀',
+          status: BATTLE_STATUS.PENDING,
+        }),
+      )
+      expect(result.id).toBe('battle-id-123')
+    })
+
+    it('비공개 배틀 생성 시 초대 코드를 생성한다', async () => {
+      const payload = createMockPayload({ type: BATTLE_TYPE.PRIVATE })
+
+      await useCase.create(payload)
+
+      expect(identifierPort.generateInviteCode).toHaveBeenCalled()
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inviteCode: 'INVITE123',
+          isPrivate: true,
+        }),
+      )
+    })
+
+    it('공개 배틀 생성 시 초대 코드가 null이다', async () => {
+      const payload = createMockPayload({ type: BATTLE_TYPE.PUBLIC })
+
+      await useCase.create(payload)
+
+      expect(identifierPort.generateInviteCode).not.toHaveBeenCalled()
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inviteCode: null,
+          isPrivate: false,
+        }),
+      )
+    })
+
+    it('AI 참고 자료 생성에 실패해도 배틀 생성은 계속 진행된다', async () => {
+      referencePort.generate.mockRejectedValue(new Error('AI error'))
+      const payload = createMockPayload()
+
+      const result = await useCase.create(payload)
+
+      expect(result.id).toBe('battle-id-123')
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          referenceData: null,
+        }),
+      )
+    })
+  })
+
+  describe('start', () => {
+    it('배틀을 시작하고 상태를 업데이트한다', async () => {
+      await useCase.start('battle-id-123')
+
+      expect(stateRepo.loadBattleState).toHaveBeenCalledWith('battle-id-123')
+      expect(repo.update).toHaveBeenCalledWith('battle-id-123', expect.objectContaining({ status: BATTLE_STATUS.OPEN }))
+      expect(stateRepo.saveBattleState).toHaveBeenCalled()
+    })
+
+    it('phase와 round 업데이트를 브로드캐스트한다', async () => {
+      await useCase.start('battle-id-123')
+
+      expect(broadcaster.emitPhaseUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          battleId: 'battle-id-123',
+          phase: 'PENDING',
+        }),
+      )
+      expect(broadcaster.emitRoundUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          battleId: 'battle-id-123',
+          round: 1,
+        }),
+      )
+    })
+
+    it('타이머를 스케줄한다', async () => {
+      const mockState = createMockState()
+      mockState.expiredAt = Date.now() + BATTLE_PHASE.PENDING.time
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      await useCase.start('battle-id-123')
+
+      expect(timer.schedule).toHaveBeenCalledWith('battle-id-123', expect.any(Object), expect.any(Function))
+    })
+  })
+})

--- a/backend/src/battles/application/usecases/battleInteraction.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/battleInteraction.usecase.spec.ts
@@ -1,0 +1,225 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { BadRequestException, ForbiddenException } from '@nestjs/common'
+import { BattleInteractionUseCase } from './battleInteraction.usecase'
+import { BATTLE_TEAM } from '../../domains/models/const/battles.const'
+import type { BattleStatePort } from '../ports/out/battleState.port'
+import type { BattleRepoPort } from '../ports/out/battleRepository.port'
+import type { BattleIdentifierPort } from '../ports/out/battleIdentifier.port'
+import type { BattleVoteService } from '../../domains/services/battleVote/battleVote.service'
+import type { BattleDiscussionService } from '../../domains/services/battleDiscussion/battleDiscussion.service'
+import type { BattleChatService } from '../../domains/services/battleChat/battleChat.service'
+import type { BattleTeamSwitchService } from '../../domains/services/battleTeamSwitch/battleTeamSwitch.service'
+import type { ActiveBattleState, BattleDiscussion } from '../../domains/models/types/battle.types'
+import type { BattleChatDto } from '../../dto/battleChat.dto'
+
+describe('BattleInteractionUseCase', () => {
+  let useCase: BattleInteractionUseCase
+  let stateRepo: jest.Mocked<BattleStatePort>
+  let repo: jest.Mocked<BattleRepoPort>
+  let identifierPort: jest.Mocked<BattleIdentifierPort>
+  let voteService: jest.Mocked<BattleVoteService>
+  let discussionService: jest.Mocked<BattleDiscussionService>
+  let chatService: jest.Mocked<BattleChatService>
+  let teamSwitchService: jest.Mocked<BattleTeamSwitchService>
+
+  const createMockState = (): ActiveBattleState =>
+    ({
+      battleId: 'battle-1',
+      participants: new Map([['user-1', 'A']]),
+      userInfoMap: new Map([['user-1', '테스터']]),
+      teamA: { users: ['user-1'], attacks: [], defenses: [], chats: [] },
+      teamB: { users: [], attacks: [], defenses: [], chats: [] },
+      all: { attacks: [], defenses: [], chats: [] },
+    }) as unknown as ActiveBattleState
+
+  const createMockDiscussion = (): BattleDiscussion =>
+    ({
+      discussionId: 'discussion-1',
+      author: { authorId: 'user-1', nickname: '테스터' },
+      type: 'ATTACK',
+      content: '의견 내용',
+      upvotes: 0,
+      votes: [],
+      status: 'PENDING',
+      team: BATTLE_TEAM.A,
+    }) as BattleDiscussion
+
+  beforeEach(() => {
+    stateRepo = {
+      loadBattleState: jest.fn(),
+      saveBattleState: jest.fn().mockResolvedValue(undefined),
+      getNicknameByUserId: jest.fn().mockReturnValue('테스터'),
+    } as unknown as jest.Mocked<BattleStatePort>
+
+    repo = {
+      findUniqueUser: jest.fn().mockResolvedValue({ tier: 'GOLD' }),
+    } as unknown as jest.Mocked<BattleRepoPort>
+
+    identifierPort = {
+      generateId: jest.fn().mockReturnValue('new-id-123'),
+    } as unknown as jest.Mocked<BattleIdentifierPort>
+
+    voteService = {
+      applyAttackVote: jest.fn().mockReturnValue([]),
+      applyDefenseVote: jest.fn().mockReturnValue([]),
+    } as unknown as jest.Mocked<BattleVoteService>
+
+    discussionService = {
+      applyAttack: jest.fn().mockReturnValue(createMockDiscussion()),
+      applyDefense: jest.fn().mockReturnValue(createMockDiscussion()),
+      canUserSubmitAttack: jest.fn().mockReturnValue(true),
+      canUserSubmitDefense: jest.fn().mockReturnValue(true),
+      canUserVoteAttack: jest.fn().mockReturnValue(true),
+      canUserVoteDefense: jest.fn().mockReturnValue(true),
+    } as unknown as jest.Mocked<BattleDiscussionService>
+
+    chatService = {
+      buildChatMessage: jest.fn().mockReturnValue({
+        messageId: 'msg-1',
+        team: BATTLE_TEAM.A,
+        sender: { userId: 'user-1', nickname: '테스터', tier: 'GOLD' },
+        text: '안녕하세요',
+        createdAt: new Date(),
+      }),
+      applyChatMessage: jest.fn(),
+    } as unknown as jest.Mocked<BattleChatService>
+
+    teamSwitchService = {
+      applyTeamVote: jest.fn(),
+    } as unknown as jest.Mocked<BattleTeamSwitchService>
+
+    useCase = new BattleInteractionUseCase(stateRepo, repo, identifierPort, voteService, discussionService, chatService, teamSwitchService)
+  })
+
+  describe('submitDiscussion', () => {
+    it('공격 의견을 제출한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      const result = await useCase.submitDiscussion('battle-1', 'user-1', '의견 내용', BATTLE_TEAM.A, 'attack')
+
+      expect(discussionService.applyAttack).toHaveBeenCalled()
+      expect(stateRepo.saveBattleState).toHaveBeenCalledWith('battle-1', mockState)
+      expect(result.type).toBe('ATTACK')
+    })
+
+    it('반론 의견을 제출한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      const defense = { ...createMockDiscussion(), type: 'DEFENSE' }
+      discussionService.applyDefense.mockReturnValue(defense as BattleDiscussion)
+
+      const result = await useCase.submitDiscussion('battle-1', 'user-1', '반론 내용', BATTLE_TEAM.A, 'defense')
+
+      expect(discussionService.applyDefense).toHaveBeenCalled()
+      expect(stateRepo.saveBattleState).toHaveBeenCalled()
+      expect(result.type).toBe('DEFENSE')
+    })
+  })
+
+  describe('submitVote', () => {
+    it('공격에 투표한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      await useCase.submitVote('battle-1', 'discussion-1', 'user-1', BATTLE_TEAM.A, 'attack')
+
+      expect(voteService.applyAttackVote).toHaveBeenCalled()
+      expect(stateRepo.saveBattleState).toHaveBeenCalled()
+    })
+
+    it('반론에 투표한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      await useCase.submitVote('battle-1', 'discussion-1', 'user-1', BATTLE_TEAM.A, 'defense')
+
+      expect(voteService.applyDefenseVote).toHaveBeenCalled()
+      expect(stateRepo.saveBattleState).toHaveBeenCalled()
+    })
+
+    it('NONE 팀은 ForbiddenException을 던진다', async () => {
+      await expect(useCase.submitVote('battle-1', 'discussion-1', 'user-1', BATTLE_TEAM.NONE, 'attack')).rejects.toThrow(ForbiddenException)
+      await expect(useCase.submitVote('battle-1', 'discussion-1', 'user-1', BATTLE_TEAM.NONE, 'attack')).rejects.toThrow(
+        '중립 진영은 투표할 수 없습니다.',
+      )
+    })
+  })
+
+  describe('sendChat', () => {
+    it('채팅을 전송한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      const dto: BattleChatDto = {
+        battleId: 'battle-1',
+        scope: 'all',
+        team: BATTLE_TEAM.A,
+        text: '안녕하세요',
+      } as BattleChatDto
+
+      const result = await useCase.sendChat(dto, 'user-1')
+
+      expect(chatService.buildChatMessage).toHaveBeenCalled()
+      expect(chatService.applyChatMessage).toHaveBeenCalled()
+      expect(stateRepo.saveBattleState).toHaveBeenCalled()
+      expect(result.battleId).toBe('battle-1')
+      expect(result.scope).toBe('all')
+    })
+
+    it('battleId가 없으면 BadRequestException을 던진다', async () => {
+      const dto: BattleChatDto = {
+        battleId: '',
+        scope: 'all',
+        team: BATTLE_TEAM.A,
+        text: '안녕하세요',
+      } as BattleChatDto
+
+      await expect(useCase.sendChat(dto, 'user-1')).rejects.toThrow(BadRequestException)
+      await expect(useCase.sendChat(dto, 'user-1')).rejects.toThrow('잘못된 요청입니다.')
+    })
+
+    it('빈 메시지는 BadRequestException을 던진다', async () => {
+      const dto: BattleChatDto = {
+        battleId: 'battle-1',
+        scope: 'all',
+        team: BATTLE_TEAM.A,
+        text: '   ',
+      } as BattleChatDto
+
+      await expect(useCase.sendChat(dto, 'user-1')).rejects.toThrow(BadRequestException)
+      await expect(useCase.sendChat(dto, 'user-1')).rejects.toThrow('메시지가 비어 있습니다.')
+    })
+  })
+
+  describe('switchTeam', () => {
+    it('진영 변경 투표를 처리한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      await useCase.switchTeam('battle-1', 'user-1', BATTLE_TEAM.B)
+
+      expect(teamSwitchService.applyTeamVote).toHaveBeenCalledWith(mockState, 'user-1', BATTLE_TEAM.B)
+      expect(stateRepo.saveBattleState).toHaveBeenCalled()
+    })
+  })
+})

--- a/backend/src/battles/application/usecases/battleParticipation.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/battleParticipation.usecase.spec.ts
@@ -1,0 +1,200 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { BadRequestException } from '@nestjs/common'
+import { BattleParticipationUseCase } from './battleParticipation.usecase'
+import { BATTLE_STATUS, BATTLE_TEAM } from '../../domains/models/const/battles.const'
+import type { BattleRepoPort } from '../ports/out/battleRepository.port'
+import type { BattleStatePort } from '../ports/out/battleState.port'
+import type { BattleBroadcasterPort } from '../ports/out/battleBroadcaster.port'
+import type { BattleTeamSwitchService } from '../../domains/services/battleTeamSwitch/battleTeamSwitch.service'
+import type { BattlePhaseTransitionUseCase } from './battlePhaseTransition.usecase'
+import type { BattleJoinRequestDto } from '../../dto/battleJoinRequest.dto'
+import type { ActiveBattleState } from '../../domains/models/types/battle.types'
+
+describe('BattleParticipationUseCase', () => {
+  let useCase: BattleParticipationUseCase
+  let repo: jest.Mocked<BattleRepoPort>
+  let stateRepo: jest.Mocked<BattleStatePort>
+  let broadcaster: jest.Mocked<BattleBroadcasterPort>
+  let teamSwitchService: jest.Mocked<BattleTeamSwitchService>
+  let phaseTransitionUseCase: jest.Mocked<BattlePhaseTransitionUseCase>
+
+  const createMockState = (): ActiveBattleState =>
+    ({
+      battleId: 'battle-1',
+      participants: new Map(),
+      userInfoMap: new Map(),
+      teamVotes: new Map(),
+      skipState: new Set<string>(),
+      teamA: { users: ['user-1'] },
+      teamB: { users: [] },
+    }) as unknown as ActiveBattleState
+
+  beforeEach(() => {
+    repo = {
+      findUniqueUser: jest.fn().mockResolvedValue({ id: 'user-1' }),
+      upsertBattleParticipant: jest.fn().mockResolvedValue({}),
+    } as unknown as jest.Mocked<BattleRepoPort>
+
+    stateRepo = {
+      loadBattleState: jest.fn(),
+      saveBattleState: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<BattleStatePort>
+
+    broadcaster = {
+      emitUserUpdated: jest.fn(),
+    } as unknown as jest.Mocked<BattleBroadcasterPort>
+
+    teamSwitchService = {
+      applyParticipant: jest.fn(),
+    } as unknown as jest.Mocked<BattleTeamSwitchService>
+
+    phaseTransitionUseCase = {
+      checkAndSkipPhase: jest.fn().mockResolvedValue(false),
+    } as unknown as jest.Mocked<BattlePhaseTransitionUseCase>
+
+    useCase = new BattleParticipationUseCase(repo, stateRepo, broadcaster, teamSwitchService, phaseTransitionUseCase)
+  })
+
+  describe('join', () => {
+    it('배틀에 참가한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: { status: BATTLE_STATUS.OPEN },
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      const dto: BattleJoinRequestDto = {
+        battleId: 'battle-1',
+        team: BATTLE_TEAM.A,
+        nickname: '테스터',
+      } as unknown as BattleJoinRequestDto
+
+      const result = await useCase.join(dto, 'user-1')
+
+      expect(result.battleState).toBe(mockState)
+      expect(result.team).toBe(BATTLE_TEAM.A)
+      expect(stateRepo.saveBattleState).toHaveBeenCalledWith('battle-1', mockState)
+    })
+
+    it('닉네임이 userInfoMap에 저장된다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: { status: BATTLE_STATUS.OPEN },
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      const dto: BattleJoinRequestDto = {
+        battleId: 'battle-1',
+        team: BATTLE_TEAM.A,
+        nickname: '테스터',
+      } as unknown as BattleJoinRequestDto
+
+      await useCase.join(dto, 'user-1')
+
+      expect(mockState.userInfoMap.get('user-1')).toBe('테스터')
+    })
+
+    it('battleId가 없으면 BadRequestException을 던진다', async () => {
+      const dto: BattleJoinRequestDto = {
+        battleId: '',
+        team: BATTLE_TEAM.A,
+        nickname: '테스터',
+      } as unknown as BattleJoinRequestDto
+
+      await expect(useCase.join(dto, 'user-1')).rejects.toThrow(BadRequestException)
+      await expect(useCase.join(dto, 'user-1')).rejects.toThrow('Battle ID가 필요합니다.')
+    })
+
+    it('CLOSED 상태의 배틀에는 참가할 수 없다', async () => {
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: { status: BATTLE_STATUS.CLOSED },
+        state: createMockState(),
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      const dto: BattleJoinRequestDto = {
+        battleId: 'battle-1',
+        team: BATTLE_TEAM.A,
+        nickname: '테스터',
+      } as unknown as BattleJoinRequestDto
+
+      await expect(useCase.join(dto, 'user-1')).rejects.toThrow(BadRequestException)
+      await expect(useCase.join(dto, 'user-1')).rejects.toThrow('이미 종료된 배틀입니다.')
+    })
+
+    it('등록된 사용자는 battleParticipant에 저장된다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: { status: BATTLE_STATUS.OPEN },
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      const dto: BattleJoinRequestDto = {
+        battleId: 'battle-1',
+        team: BATTLE_TEAM.A,
+        nickname: '테스터',
+      } as unknown as BattleJoinRequestDto
+
+      await useCase.join(dto, 'user-1')
+
+      expect(repo.upsertBattleParticipant).toHaveBeenCalledWith({
+        userId: 'user-1',
+        battleId: 'battle-1',
+        team: 'A',
+        isMvp: false,
+      })
+    })
+
+    it('게스트 사용자는 battleParticipant에 저장되지 않는다', async () => {
+      repo.findUniqueUser.mockResolvedValue(null)
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: { status: BATTLE_STATUS.OPEN },
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      const dto: BattleJoinRequestDto = {
+        battleId: 'battle-1',
+        team: BATTLE_TEAM.A,
+        nickname: '테스터',
+      } as unknown as BattleJoinRequestDto
+
+      await useCase.join(dto, 'guest-1')
+
+      expect(repo.upsertBattleParticipant).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('leave', () => {
+    it('배틀에서 나간다', async () => {
+      const mockState = createMockState()
+      mockState.teamA.users = ['user-1', 'user-2']
+      mockState.participants.set('user-1', BATTLE_TEAM.A)
+      mockState.skipState.add('user-1')
+      mockState.teamVotes.set('user-1', BATTLE_TEAM.B)
+
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      const result = await useCase.leave('user-1', 'battle-1')
+
+      expect(mockState.teamA.users).not.toContain('user-1')
+      expect(mockState.participants.has('user-1')).toBe(false)
+      expect(mockState.skipState.has('user-1')).toBe(false)
+      expect(mockState.teamVotes.has('user-1')).toBe(false)
+      expect(stateRepo.saveBattleState).toHaveBeenCalledWith('battle-1', mockState)
+      expect(phaseTransitionUseCase.checkAndSkipPhase).toHaveBeenCalledWith('battle-1', mockState)
+      expect(result).toBeDefined()
+    })
+
+    it('userId가 없으면 BadRequestException을 던진다', async () => {
+      await expect(useCase.leave('', 'battle-1')).rejects.toThrow(BadRequestException)
+      await expect(useCase.leave('', 'battle-1')).rejects.toThrow('유효하지 않은 요청입니다.')
+    })
+
+    it('battleId가 없으면 BadRequestException을 던진다', async () => {
+      await expect(useCase.leave('user-1', '')).rejects.toThrow(BadRequestException)
+    })
+  })
+})

--- a/backend/src/battles/application/usecases/battlePhaseTransition.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/battlePhaseTransition.usecase.spec.ts
@@ -234,4 +234,140 @@ describe('BattlePhaseTransitionUseCase', () => {
       expect(skipService.shouldSkipPhase).toHaveBeenCalledWith(mockState, expect.any(Function), expect.any(Function))
     })
   })
+
+  describe('advancePhase 콜백 테스트', () => {
+    it('공격 투표 페이즈에서 onAttacked 콜백을 호출한다', async () => {
+      const mockState = createMockState({ phase: 'ATTACK' })
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      phaseService.nextPhase.mockImplementation((state, onAttacked) => {
+        onAttacked(state)
+        return { name: 'DEFENSE', time: 60000 }
+      })
+
+      await useCase.advancePhase('battle-1')
+
+      expect(voteService.buildAttackedResult).toHaveBeenCalled()
+      expect(broadcaster.emitAttacked).toHaveBeenCalled()
+    })
+
+    it('방어 투표 페이즈에서 onDefensed 콜백을 호출한다', async () => {
+      const mockState = createMockState({ phase: 'DEFENSE' })
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      phaseService.nextPhase.mockImplementation((state, _onAttacked, onDefensed) => {
+        onDefensed(state)
+        return { name: 'TEAM_SWITCH', time: 40000 }
+      })
+
+      await useCase.advancePhase('battle-1')
+
+      expect(voteService.buildDefensedResult).toHaveBeenCalled()
+      expect(broadcaster.emitDefensed).toHaveBeenCalled()
+    })
+
+    it('resetDiscussions 콜백을 호출한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      phaseService.nextPhase.mockImplementation((state, _onAttacked, _onDefensed, onReset) => {
+        onReset(state)
+        return { name: 'ATTACK', time: 60000 }
+      })
+
+      await useCase.advancePhase('battle-1')
+
+      expect(discussionService.resetDiscussions).toHaveBeenCalledWith(mockState)
+    })
+
+    it('배틀 종료 시 terminationUseCase.finish를 호출한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      phaseService.nextPhase.mockImplementation((state, _onAttacked, _onDefensed, _onReset, onFinish) => {
+        void onFinish(state)
+        return null
+      })
+
+      await useCase.advancePhase('battle-1')
+
+      expect(terminationUseCase.finish).toHaveBeenCalledWith(mockState)
+    })
+
+    it('팀 스위치 페이즈에서 applyTeamSwitch를 호출한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      phaseService.nextPhase.mockImplementation((state, _onAttacked, _onDefensed, _onReset, _onFinish, onTeamSwitch) => {
+        onTeamSwitch(state)
+        return { name: 'ATTACK', time: 60000 }
+      })
+
+      await useCase.advancePhase('battle-1')
+
+      expect(teamSwitchService.applyTeamSwitch).toHaveBeenCalled()
+    })
+  })
+
+  describe('scheduleNextTick 에러 처리', () => {
+    it('loadBattleState 에러를 무시한다', async () => {
+      const mockState = createMockState()
+      let callCount = 0
+      stateRepo.loadBattleState.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          return Promise.resolve({
+            battle: {},
+            state: mockState,
+          } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+        }
+        return Promise.reject(new Error('Battle not found'))
+      })
+
+      // 에러가 발생해도 예외가 전파되지 않아야 함
+      await expect(useCase.advancePhase('battle-1')).resolves.not.toThrow()
+    })
+
+    it('expiredAt이 null이면 스케줄링하지 않는다', async () => {
+      const mockState = createMockState({ expiredAt: null })
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      await useCase.advancePhase('battle-1')
+
+      // timer.schedule이 호출되었는지 확인 (expiredAt이 null이면 호출되지 않음)
+      // scheduleNextTick 내부에서 early return 됨
+    })
+  })
+
+  describe('타이머 스케줄링', () => {
+    it('올바른 지연 시간으로 타이머를 스케줄링한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      await useCase.advancePhase('battle-1')
+
+      expect(timer.schedule).toHaveBeenCalledWith('battle-1', expect.any(Object), expect.any(Function))
+    })
+  })
 })

--- a/backend/src/battles/application/usecases/battlePhaseTransition.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/battlePhaseTransition.usecase.spec.ts
@@ -358,7 +358,7 @@ describe('BattlePhaseTransitionUseCase', () => {
   })
 
   describe('타이머 스케줄링', () => {
-    it('올바른 지연 시간으로 타이머를 스케줄링한다', async () => {
+    it('올바른 상태로 타이머를 스케줄링한다', async () => {
       const mockState = createMockState()
       stateRepo.loadBattleState.mockResolvedValue({
         battle: {},
@@ -367,7 +367,7 @@ describe('BattlePhaseTransitionUseCase', () => {
 
       await useCase.advancePhase('battle-1')
 
-      expect(timer.schedule).toHaveBeenCalledWith('battle-1', expect.any(Object), expect.any(Function))
+      expect(timer.schedule).toHaveBeenCalledWith('battle-1', expect.any(Object))
     })
   })
 })

--- a/backend/src/battles/application/usecases/battlePhaseTransition.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/battlePhaseTransition.usecase.spec.ts
@@ -1,0 +1,237 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { BattlePhaseTransitionUseCase } from './battlePhaseTransition.usecase'
+import type { BattleStatePort } from '../ports/out/battleState.port'
+import type { BattleBroadcasterPort } from '../ports/out/battleBroadcaster.port'
+import type { BattleTimerPort } from '../ports/out/battleTimer.port'
+import type { BattlePhaseService } from '../../domains/services/battlePhase/battlePhase.service'
+import type { BattleVoteService } from '../../domains/services/battleVote/battleVote.service'
+import type { BattleDiscussionService } from '../../domains/services/battleDiscussion/battleDiscussion.service'
+import type { BattleTeamSwitchService } from '../../domains/services/battleTeamSwitch/battleTeamSwitch.service'
+import type { BattleSkipService } from '../../domains/services/battleSkip/battleSkip.service'
+import type { BattleTerminationUseCase } from './battleTermination.usecase'
+import type { ActiveBattleState } from '../../domains/models/types/battle.types'
+
+describe('BattlePhaseTransitionUseCase', () => {
+  let useCase: BattlePhaseTransitionUseCase
+  let stateRepo: jest.Mocked<BattleStatePort>
+  let broadcaster: jest.Mocked<BattleBroadcasterPort>
+  let timer: jest.Mocked<BattleTimerPort>
+  let phaseService: jest.Mocked<BattlePhaseService>
+  let voteService: jest.Mocked<BattleVoteService>
+  let discussionService: jest.Mocked<BattleDiscussionService>
+  let teamSwitchService: jest.Mocked<BattleTeamSwitchService>
+  let skipService: jest.Mocked<BattleSkipService>
+  let terminationUseCase: jest.Mocked<BattleTerminationUseCase>
+
+  const createMockState = (overrides = {}): ActiveBattleState =>
+    ({
+      battleId: 'battle-1',
+      round: 1,
+      phase: 'ATTACK',
+      phaseCount: 1,
+      startedAt: Date.now(),
+      expiredAt: Date.now() + 60000,
+      topics: ['topic1', 'topic2'],
+      participants: new Map([['user-1', 'A']]),
+      skipState: new Set<string>(),
+      teamA: { users: ['user-1'], attacks: [], defenses: [] },
+      teamB: { users: [], attacks: [], defenses: [] },
+      all: { attacks: [], defenses: [] },
+      ...overrides,
+    }) as unknown as ActiveBattleState
+
+  beforeEach(() => {
+    stateRepo = {
+      loadBattleState: jest.fn(),
+      saveBattleState: jest.fn().mockResolvedValue(undefined),
+      updateSkipState: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<BattleStatePort>
+
+    broadcaster = {
+      emitPhaseUpdated: jest.fn(),
+      emitRoundUpdated: jest.fn(),
+      emitAttacked: jest.fn(),
+      emitDefensed: jest.fn(),
+      emitTeamUpdated: jest.fn(),
+      emitPhaseSkipped: jest.fn(),
+    } as unknown as jest.Mocked<BattleBroadcasterPort>
+
+    timer = {
+      schedule: jest.fn(),
+    } as unknown as jest.Mocked<BattleTimerPort>
+
+    phaseService = {
+      nextPhase: jest.fn().mockReturnValue({ name: 'ATTACK_VOTE', time: 30000 }),
+    } as unknown as jest.Mocked<BattlePhaseService>
+
+    voteService = {
+      buildAttackedResult: jest.fn().mockReturnValue({ aTeam: null, bTeam: null }),
+      buildDefensedResult: jest.fn().mockReturnValue({ aTeam: null, bTeam: null }),
+    } as unknown as jest.Mocked<BattleVoteService>
+
+    discussionService = {
+      buildNullPlaceholder: jest.fn(),
+      resetDiscussions: jest.fn(),
+    } as unknown as jest.Mocked<BattleDiscussionService>
+
+    teamSwitchService = {
+      applyTeamSwitch: jest.fn(),
+    } as unknown as jest.Mocked<BattleTeamSwitchService>
+
+    skipService = {
+      applyPhaseSkip: jest.fn(),
+      shouldSkipPhase: jest.fn().mockResolvedValue(false),
+      buildActiveParticipantsCount: jest.fn().mockReturnValue(1),
+    } as unknown as jest.Mocked<BattleSkipService>
+
+    terminationUseCase = {
+      finish: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<BattleTerminationUseCase>
+
+    useCase = new BattlePhaseTransitionUseCase(
+      stateRepo,
+      broadcaster,
+      timer,
+      phaseService,
+      voteService,
+      discussionService,
+      teamSwitchService,
+      skipService,
+      terminationUseCase,
+    )
+  })
+
+  describe('advancePhase', () => {
+    it('다음 페이즈로 전환한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      await useCase.advancePhase('battle-1')
+
+      expect(phaseService.nextPhase).toHaveBeenCalled()
+      expect(stateRepo.saveBattleState).toHaveBeenCalled()
+    })
+
+    it('페이즈가 변경되면 브로드캐스트한다', async () => {
+      const mockState = createMockState({ phase: 'ATTACK' })
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      await useCase.advancePhase('battle-1')
+
+      expect(broadcaster.emitPhaseUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          battleId: 'battle-1',
+          phase: 'ATTACK_VOTE',
+        }),
+      )
+    })
+
+    it('라운드가 변경되면 라운드 업데이트를 브로드캐스트한다', async () => {
+      const mockState = createMockState({ round: 1 })
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      phaseService.nextPhase.mockImplementation((state: ActiveBattleState) => {
+        state.round = 2
+        return { name: 'ATTACK', time: 60000 }
+      })
+
+      await useCase.advancePhase('battle-1')
+
+      expect(broadcaster.emitRoundUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          battleId: 'battle-1',
+          round: 2,
+        }),
+      )
+    })
+
+    it('nextPhase가 null이면 아무 작업도 하지 않는다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+      phaseService.nextPhase.mockReturnValue(null)
+
+      await useCase.advancePhase('battle-1')
+
+      expect(stateRepo.saveBattleState).not.toHaveBeenCalled()
+      expect(broadcaster.emitPhaseUpdated).not.toHaveBeenCalled()
+    })
+
+    it('skipState를 초기화한다', async () => {
+      const mockState = createMockState()
+      mockState.skipState.add('user-1')
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      await useCase.advancePhase('battle-1')
+
+      expect(mockState.skipState.size).toBe(0)
+    })
+  })
+
+  describe('handlePhaseSkip', () => {
+    it('스킵 요청을 처리한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      const result = await useCase.handlePhaseSkip('battle-1', 'user-1', true)
+
+      expect(skipService.applyPhaseSkip).toHaveBeenCalledWith(mockState, 'user-1', true)
+      expect(stateRepo.updateSkipState).toHaveBeenCalledWith('battle-1', mockState.skipState)
+      expect(typeof result).toBe('number')
+    })
+
+    it('스킵되면 0을 반환한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+      skipService.shouldSkipPhase.mockResolvedValue(true)
+
+      const result = await useCase.handlePhaseSkip('battle-1', 'user-1', true)
+
+      expect(result).toBe(0)
+    })
+
+    it('스킵되지 않으면 skipState 크기를 반환한다', async () => {
+      const mockState = createMockState()
+      mockState.skipState.add('user-1')
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+      skipService.shouldSkipPhase.mockResolvedValue(false)
+
+      const result = await useCase.handlePhaseSkip('battle-1', 'user-1', true)
+
+      expect(result).toBe(1)
+    })
+  })
+
+  describe('checkAndSkipPhase', () => {
+    it('스킵 조건을 확인한다', async () => {
+      const mockState = createMockState()
+
+      await useCase.checkAndSkipPhase('battle-1', mockState)
+
+      expect(skipService.shouldSkipPhase).toHaveBeenCalledWith(mockState, expect.any(Function), expect.any(Function))
+    })
+  })
+})

--- a/backend/src/battles/application/usecases/battleQuery.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/battleQuery.usecase.spec.ts
@@ -1,0 +1,241 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { BadRequestException, NotFoundException } from '@nestjs/common'
+import { BattleQueryUseCase } from './battleQuery.usecase'
+import { BATTLE_STATUS } from '../../domains/models/const/battles.const'
+import type { BattleRepoPort } from '../ports/out/battleRepository.port'
+import type { BattleStatePort } from '../ports/out/battleState.port'
+import type { BattleResultService } from '../../domains/services/battleResult/battleResult.service'
+import type { BattleTimelineService } from '../../domains/services/battleTimeline/battleTimeline.service'
+import type { BattleMvpService } from '../../domains/services/battleMvp/battleMvp.service'
+import type { ActiveBattleState } from '../../domains/models/types/battle.types'
+
+describe('BattleQueryUseCase', () => {
+  let useCase: BattleQueryUseCase
+  let repo: jest.Mocked<BattleRepoPort>
+  let stateRepo: jest.Mocked<BattleStatePort>
+  let resultService: jest.Mocked<BattleResultService>
+  let timelineService: jest.Mocked<BattleTimelineService>
+  let mvpService: jest.Mocked<BattleMvpService>
+
+  const createMockBattle = (overrides = {}) => ({
+    id: 'battle-1',
+    userId: 'user-1',
+    title: '테스트 배틀',
+    description: '설명',
+    codeA: 'code A',
+    codeB: 'code B',
+    language: 'javascript',
+    category: 'algorithm',
+    playTime: 'FIFTEEN_MIN',
+    topics: ['topic1'],
+    inviteCode: null,
+    isPrivate: false,
+    status: BATTLE_STATUS.OPEN,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  })
+
+  const createMockState = (): ActiveBattleState =>
+    ({
+      battleId: 'battle-1',
+      participants: new Map([['user-1', 'A']]),
+      teamA: { users: ['user-1'], attacks: [], defenses: [] },
+      teamB: { users: [], attacks: [], defenses: [] },
+      all: { attacks: [], defenses: [] },
+    }) as unknown as ActiveBattleState
+
+  beforeEach(() => {
+    repo = {
+      findBattleList: jest.fn().mockResolvedValue([]),
+      countBattleList: jest.fn().mockResolvedValue(0),
+      findUnique: jest.fn(),
+      findUniqueByInviteCode: jest.fn(),
+    } as unknown as jest.Mocked<BattleRepoPort>
+
+    stateRepo = {
+      loadBattleState: jest.fn(),
+      parseMvpsState: jest.fn().mockReturnValue([]),
+    } as unknown as jest.Mocked<BattleStatePort>
+
+    resultService = {
+      buildBattleResult: jest.fn().mockReturnValue({
+        winner: 'A',
+        teamAVotes: 5,
+        teamBVotes: 3,
+      }),
+    } as unknown as jest.Mocked<BattleResultService>
+
+    timelineService = {
+      toTimeline: jest.fn().mockReturnValue([]),
+    } as unknown as jest.Mocked<BattleTimelineService>
+
+    mvpService = {
+      buildLegacyMvpsFromNicknames: jest.fn().mockReturnValue([]),
+    } as unknown as jest.Mocked<BattleMvpService>
+
+    useCase = new BattleQueryUseCase(repo, stateRepo, resultService, timelineService, mvpService)
+  })
+
+  describe('getOpenBattles', () => {
+    it('열린 배틀 목록을 반환한다', async () => {
+      repo.findBattleList.mockResolvedValue([createMockBattle()])
+      repo.countBattleList.mockResolvedValue(1)
+
+      const result = await useCase.getOpenBattles(10, 0)
+
+      expect(result.battles).toHaveLength(1)
+      expect(result.meta).toEqual({ offset: 0, limit: 10, total: 1 })
+      expect(repo.findBattleList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onlyPublic: true,
+          status: { in: [BATTLE_STATUS.OPEN, BATTLE_STATUS.PENDING] },
+        }),
+      )
+    })
+
+    it('빈 배열을 반환할 수 있다', async () => {
+      repo.findBattleList.mockResolvedValue([])
+      repo.countBattleList.mockResolvedValue(0)
+
+      const result = await useCase.getOpenBattles(10, 0)
+
+      expect(result.battles).toEqual([])
+      expect(result.meta.total).toBe(0)
+    })
+  })
+
+  describe('getClosedBattles', () => {
+    it('종료된 배틀 목록을 반환한다', async () => {
+      repo.findBattleList.mockResolvedValue([
+        createMockBattle({
+          status: BATTLE_STATUS.CLOSED,
+          teamACount: 5,
+          teamBCount: 3,
+          totalParticipantsCount: 8,
+          winningTeam: 'A',
+        }),
+      ])
+      repo.countBattleList.mockResolvedValue(1)
+
+      const result = await useCase.getClosedBattles(10, 0)
+
+      expect(result.battles).toHaveLength(1)
+      expect(repo.findBattleList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: BATTLE_STATUS.CLOSED,
+        }),
+      )
+    })
+  })
+
+  describe('getBattleByInviteCode', () => {
+    it('초대 코드로 배틀 ID를 찾는다', async () => {
+      repo.findUniqueByInviteCode.mockResolvedValue(createMockBattle({ id: 'battle-123' }))
+
+      const result = await useCase.getBattleByInviteCode('INVITE123')
+
+      expect(result.battleId).toBe('battle-123')
+    })
+
+    it('초대 코드가 없으면 BadRequestException을 던진다', async () => {
+      await expect(useCase.getBattleByInviteCode('')).rejects.toThrow(BadRequestException)
+      await expect(useCase.getBattleByInviteCode('')).rejects.toThrow('초대 코드가 필요합니다.')
+    })
+
+    it('배틀을 찾을 수 없으면 NotFoundException을 던진다', async () => {
+      repo.findUniqueByInviteCode.mockResolvedValue(null)
+
+      await expect(useCase.getBattleByInviteCode('INVALID')).rejects.toThrow(NotFoundException)
+      await expect(useCase.getBattleByInviteCode('INVALID')).rejects.toThrow('잘못된 초대 코드입니다.')
+    })
+
+    it('배틀이 종료되었으면 BadRequestException을 던진다', async () => {
+      repo.findUniqueByInviteCode.mockResolvedValue(createMockBattle({ status: BATTLE_STATUS.CLOSED }))
+
+      await expect(useCase.getBattleByInviteCode('INVITE123')).rejects.toThrow(BadRequestException)
+      await expect(useCase.getBattleByInviteCode('INVITE123')).rejects.toThrow('이미 종료된 배틀입니다.')
+    })
+  })
+
+  describe('getJoinBattleInfo', () => {
+    it('배틀 참가 정보를 반환한다', async () => {
+      repo.findUnique.mockResolvedValue(createMockBattle())
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: createMockState(),
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      const result = await useCase.getJoinBattleInfo('battle-1')
+
+      expect(result).toBeDefined()
+      expect(repo.findUnique).toHaveBeenCalledWith('battle-1')
+    })
+
+    it('battleId가 없으면 BadRequestException을 던진다', async () => {
+      await expect(useCase.getJoinBattleInfo('')).rejects.toThrow(BadRequestException)
+      await expect(useCase.getJoinBattleInfo('')).rejects.toThrow('Battle ID가 필요합니다.')
+    })
+
+    it('종료된 배틀은 상태를 로드하지 않는다', async () => {
+      repo.findUnique.mockResolvedValue(
+        createMockBattle({
+          status: BATTLE_STATUS.CLOSED,
+          totalParticipantsCount: 10,
+        }),
+      )
+
+      await useCase.getJoinBattleInfo('battle-1')
+
+      expect(stateRepo.loadBattleState).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getBattleResult', () => {
+    it('배틀 결과를 반환한다', async () => {
+      repo.findUnique.mockResolvedValue(
+        createMockBattle({
+          status: BATTLE_STATUS.CLOSED,
+          teamACount: 5,
+          teamBCount: 3,
+          totalParticipantsCount: 8,
+          winningTeam: 'A',
+          finishedAt: new Date(),
+          timeline: [],
+          mvps: [],
+          mvpsState: [],
+        }),
+      )
+
+      const result = await useCase.getBattleResult('battle-1')
+
+      expect(result.battleId).toBe('battle-1')
+      expect(result.status).toBe('CLOSED')
+    })
+
+    it('진행 중인 배틀은 BadRequestException을 던진다', async () => {
+      repo.findUnique.mockResolvedValue(createMockBattle({ status: BATTLE_STATUS.OPEN }))
+
+      await expect(useCase.getBattleResult('battle-1')).rejects.toThrow(BadRequestException)
+      await expect(useCase.getBattleResult('battle-1')).rejects.toThrow('배틀이 아직 진행 중입니다.')
+    })
+  })
+
+  describe('isPrivateBattle', () => {
+    it('비공개 배틀이면 true를 반환한다', async () => {
+      repo.findUnique.mockResolvedValue(createMockBattle({ isPrivate: true }))
+
+      const result = await useCase.isPrivateBattle('battle-1')
+
+      expect(result).toBe(true)
+    })
+
+    it('공개 배틀이면 false를 반환한다', async () => {
+      repo.findUnique.mockResolvedValue(createMockBattle({ isPrivate: false }))
+
+      const result = await useCase.isPrivateBattle('battle-1')
+
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/backend/src/battles/application/usecases/battleTermination.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/battleTermination.usecase.spec.ts
@@ -48,7 +48,9 @@ describe('BattleTerminationUseCase', () => {
       }),
     } as unknown as jest.Mocked<BattleRepoPort>
 
-    stateRepo = {} as unknown as jest.Mocked<BattleStatePort>
+    stateRepo = {
+      clearCache: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<BattleStatePort>
 
     broadcaster = {
       emitBattleClosed: jest.fn(),
@@ -151,8 +153,8 @@ describe('BattleTerminationUseCase', () => {
         { id: 'user-2', rating: 1000, tier: 'SILVER' },
       ])
       tierService.buildRatingUpdates.mockReturnValue([
-        { userId: 'user-1', nextRating: 1050, nextTier: 'SILVER' },
-        { userId: 'user-2', nextRating: 950, nextTier: 'SILVER' },
+        { userId: 'user-1', currentRating: 1000, currentTier: 'SILVER', nextRating: 1050, nextTier: 'SILVER', delta: 50, mvpBonus: 0 },
+        { userId: 'user-2', currentRating: 1000, currentTier: 'SILVER', nextRating: 950, nextTier: 'SILVER', delta: -50, mvpBonus: 0 },
       ])
 
       await useCase.finish(mockState)

--- a/backend/src/battles/application/usecases/battleTermination.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/battleTermination.usecase.spec.ts
@@ -1,0 +1,204 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { BattleTerminationUseCase } from './battleTermination.usecase'
+import { BATTLE_STATUS, BATTLE_TEAM } from '../../domains/models/const/battles.const'
+import type { BattleRepoPort } from '../ports/out/battleRepository.port'
+import type { BattleStatePort } from '../ports/out/battleState.port'
+import type { BattleBroadcasterPort } from '../ports/out/battleBroadcaster.port'
+import type { BattleTimerPort } from '../ports/out/battleTimer.port'
+import type { BattleResultService } from '../../domains/services/battleResult/battleResult.service'
+import type { BattleTimelineService } from '../../domains/services/battleTimeline/battleTimeline.service'
+import type { BattleMvpService } from '../../domains/services/battleMvp/battleMvp.service'
+import type { BattleTierService } from '../../domains/services/battleTier/battleTier.service'
+import type { ActiveBattleState } from '../../domains/models/types/battle.types'
+
+describe('BattleTerminationUseCase', () => {
+  let useCase: BattleTerminationUseCase
+  let repo: jest.Mocked<BattleRepoPort>
+  let stateRepo: jest.Mocked<BattleStatePort>
+  let broadcaster: jest.Mocked<BattleBroadcasterPort>
+  let timer: jest.Mocked<BattleTimerPort>
+  let resultService: jest.Mocked<BattleResultService>
+  let timelineService: jest.Mocked<BattleTimelineService>
+  let mvpService: jest.Mocked<BattleMvpService>
+  let tierService: jest.Mocked<BattleTierService>
+
+  const createMockState = (overrides = {}): ActiveBattleState =>
+    ({
+      battleId: 'battle-1',
+      participants: new Map([
+        ['user-1', BATTLE_TEAM.A],
+        ['user-2', BATTLE_TEAM.B],
+      ]),
+      teamA: { users: ['user-1'] },
+      teamB: { users: ['user-2'] },
+      opinionHistory: [],
+      ...overrides,
+    }) as unknown as ActiveBattleState
+
+  beforeEach(() => {
+    repo = {
+      update: jest.fn().mockResolvedValue({}),
+      findManyUsers: jest.fn().mockResolvedValue([]),
+      transaction: jest.fn().mockImplementation(async (cb: (txRepo: unknown) => Promise<unknown>) => {
+        const txRepo = {
+          updateManyBattleParticipants: jest.fn().mockResolvedValue({}),
+          updateUser: jest.fn().mockResolvedValue({}),
+        }
+        await cb(txRepo)
+      }),
+    } as unknown as jest.Mocked<BattleRepoPort>
+
+    stateRepo = {} as unknown as jest.Mocked<BattleStatePort>
+
+    broadcaster = {
+      emitBattleClosed: jest.fn(),
+    } as unknown as jest.Mocked<BattleBroadcasterPort>
+
+    timer = {
+      cancel: jest.fn(),
+    } as unknown as jest.Mocked<BattleTimerPort>
+
+    resultService = {
+      determineWinningTeam: jest.fn().mockReturnValue('A'),
+      toBattleResultForTeam: jest.fn().mockReturnValue('WIN'),
+    } as unknown as jest.Mocked<BattleResultService>
+
+    timelineService = {
+      buildTimeline: jest.fn().mockReturnValue([]),
+    } as unknown as jest.Mocked<BattleTimelineService>
+
+    mvpService = {
+      buildMvps: jest.fn().mockReturnValue([{ userId: 'user-1', nickname: 'MVP1', team: 'A', score: 100 }]),
+    } as unknown as jest.Mocked<BattleMvpService>
+
+    tierService = {
+      buildRatingUpdates: jest.fn().mockReturnValue([]),
+    } as unknown as jest.Mocked<BattleTierService>
+
+    useCase = new BattleTerminationUseCase(repo, stateRepo, broadcaster, timer, resultService, timelineService, mvpService, tierService)
+  })
+
+  describe('finish', () => {
+    it('배틀을 종료한다', async () => {
+      const mockState = createMockState()
+
+      await useCase.finish(mockState)
+
+      expect(timer.cancel).toHaveBeenCalledWith('battle-1')
+      expect(repo.update).toHaveBeenCalledWith(
+        'battle-1',
+        expect.objectContaining({
+          status: BATTLE_STATUS.CLOSED,
+          teamACount: 1,
+          teamBCount: 1,
+          totalParticipantsCount: 2,
+        }),
+      )
+    })
+
+    it('우승 팀을 결정한다', async () => {
+      const mockState = createMockState()
+
+      await useCase.finish(mockState)
+
+      expect(resultService.determineWinningTeam).toHaveBeenCalledWith(1, 1)
+      expect(repo.update).toHaveBeenCalledWith(
+        'battle-1',
+        expect.objectContaining({
+          winningTeam: 'A',
+        }),
+      )
+    })
+
+    it('MVP를 계산한다', async () => {
+      const mockState = createMockState()
+
+      await useCase.finish(mockState)
+
+      expect(mvpService.buildMvps).toHaveBeenCalledWith(mockState, 'A')
+      expect(repo.update).toHaveBeenCalledWith(
+        'battle-1',
+        expect.objectContaining({
+          mvps: ['MVP1'],
+        }),
+      )
+    })
+
+    it('타임라인을 생성한다', async () => {
+      const mockState = createMockState()
+
+      await useCase.finish(mockState)
+
+      expect(timelineService.buildTimeline).toHaveBeenCalledWith(mockState)
+    })
+
+    it('배틀 종료를 브로드캐스트한다', async () => {
+      const mockState = createMockState()
+
+      await useCase.finish(mockState)
+
+      expect(broadcaster.emitBattleClosed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          battleId: 'battle-1',
+        }),
+      )
+    })
+
+    it('참가자가 있으면 레이팅 업데이트를 수행한다', async () => {
+      const mockState = createMockState()
+      repo.findManyUsers.mockResolvedValue([
+        { id: 'user-1', rating: 1000, tier: 'SILVER' },
+        { id: 'user-2', rating: 1000, tier: 'SILVER' },
+      ])
+      tierService.buildRatingUpdates.mockReturnValue([
+        { userId: 'user-1', nextRating: 1050, nextTier: 'SILVER' },
+        { userId: 'user-2', nextRating: 950, nextTier: 'SILVER' },
+      ])
+
+      await useCase.finish(mockState)
+
+      expect(repo.findManyUsers).toHaveBeenCalledWith({
+        where: { id: { in: ['user-1', 'user-2'] } },
+        select: { id: true, rating: true, tier: true },
+      })
+      expect(tierService.buildRatingUpdates).toHaveBeenCalled()
+      expect(repo.transaction).toHaveBeenCalled()
+    })
+
+    it('참가자가 없으면 레이팅 업데이트를 건너뛴다', async () => {
+      const mockState = createMockState({ participants: new Map() })
+
+      await useCase.finish(mockState)
+
+      expect(repo.findManyUsers).not.toHaveBeenCalled()
+      expect(tierService.buildRatingUpdates).not.toHaveBeenCalled()
+    })
+
+    it('등록된 사용자가 없으면 레이팅 업데이트를 건너뛴다', async () => {
+      const mockState = createMockState()
+      repo.findManyUsers.mockResolvedValue([])
+
+      await useCase.finish(mockState)
+
+      expect(tierService.buildRatingUpdates).not.toHaveBeenCalled()
+      expect(repo.transaction).not.toHaveBeenCalled()
+    })
+
+    it('상태 필드를 null로 초기화한다', async () => {
+      const mockState = createMockState()
+
+      await useCase.finish(mockState)
+
+      expect(repo.update).toHaveBeenCalledWith(
+        'battle-1',
+        expect.objectContaining({
+          currentRound: null,
+          currentPhase: null,
+          phaseCount: null,
+          startedAt: null,
+          expiredAt: null,
+        }),
+      )
+    })
+  })
+})

--- a/backend/src/battles/application/usecases/createGuest.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/createGuest.usecase.spec.ts
@@ -44,9 +44,9 @@ describe('CreateGuestUseCase', () => {
     guestService = {
       buildGuestNickname: jest.fn().mockResolvedValue('Guest1234'),
       buildGuest: jest.fn().mockReturnValue({
-        odpiUserId: 'guest-id-123',
+        id: 'guest-id-123',
         nickname: 'Guest1234',
-        isGuest: true,
+        createdAt: Date.now(),
       }),
       applyGuestToState: jest.fn(),
     } as unknown as jest.Mocked<BattleGuestService>
@@ -65,9 +65,9 @@ describe('CreateGuestUseCase', () => {
       const result = await useCase.execute('battle-1')
 
       expect(result).toEqual({
-        odpiUserId: 'guest-id-123',
+        id: 'guest-id-123',
         nickname: 'Guest1234',
-        isGuest: true,
+        createdAt: expect.any(Number),
       })
       expect(guestService.buildGuestNickname).toHaveBeenCalledWith('battle-1', expect.any(Function), expect.any(Function))
       expect(guestService.buildGuest).toHaveBeenCalledWith('Guest1234', expect.any(Function))

--- a/backend/src/battles/application/usecases/createGuest.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/createGuest.usecase.spec.ts
@@ -1,0 +1,100 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { NotFoundException } from '@nestjs/common'
+import { CreateGuestUseCase } from './createGuest.usecase'
+import { BATTLE_STATUS } from '../../domains/models/const/battles.const'
+import type { BattleStatePort } from '../ports/out/battleState.port'
+import type { BattleIdentifierPort } from '../ports/out/battleIdentifier.port'
+import type { GuestCheckPort } from '../ports/out/guestCheck.port'
+import type { BattleGuestService } from '../../domains/services/battleGuest/battleGuest.service'
+import type { ActiveBattleState } from '../../domains/models/types/battle.types'
+
+describe('CreateGuestUseCase', () => {
+  let useCase: CreateGuestUseCase
+  let stateRepo: jest.Mocked<BattleStatePort>
+  let identifierPort: jest.Mocked<BattleIdentifierPort>
+  let guestCheckPort: jest.Mocked<GuestCheckPort>
+  let guestService: jest.Mocked<BattleGuestService>
+
+  const createMockState = (): ActiveBattleState =>
+    ({
+      battleId: 'battle-1',
+      round: 1,
+      phase: 'PENDING',
+      participants: new Map(),
+      userInfoMap: new Map(),
+      teamA: { users: [] },
+      teamB: { users: [] },
+    }) as unknown as ActiveBattleState
+
+  beforeEach(() => {
+    stateRepo = {
+      loadBattleState: jest.fn(),
+      saveBattleState: jest.fn(),
+      isNicknameDuplicate: jest.fn(),
+    } as unknown as jest.Mocked<BattleStatePort>
+
+    identifierPort = {
+      generateId: jest.fn().mockReturnValue('guest-id-123'),
+    } as unknown as jest.Mocked<BattleIdentifierPort>
+
+    guestCheckPort = {
+      isNicknameExists: jest.fn().mockResolvedValue(false),
+    } as unknown as jest.Mocked<GuestCheckPort>
+
+    guestService = {
+      buildGuestNickname: jest.fn().mockResolvedValue('Guest1234'),
+      buildGuest: jest.fn().mockReturnValue({
+        odpiUserId: 'guest-id-123',
+        nickname: 'Guest1234',
+        isGuest: true,
+      }),
+      applyGuestToState: jest.fn(),
+    } as unknown as jest.Mocked<BattleGuestService>
+
+    useCase = new CreateGuestUseCase(stateRepo, identifierPort, guestCheckPort, guestService)
+  })
+
+  describe('execute', () => {
+    it('게스트를 생성하고 반환한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: { status: BATTLE_STATUS.OPEN },
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      const result = await useCase.execute('battle-1')
+
+      expect(result).toEqual({
+        odpiUserId: 'guest-id-123',
+        nickname: 'Guest1234',
+        isGuest: true,
+      })
+      expect(guestService.buildGuestNickname).toHaveBeenCalledWith('battle-1', expect.any(Function), expect.any(Function))
+      expect(guestService.buildGuest).toHaveBeenCalledWith('Guest1234', expect.any(Function))
+      expect(guestService.applyGuestToState).toHaveBeenCalledWith(mockState, expect.any(Object))
+      expect(stateRepo.saveBattleState).toHaveBeenCalledWith('battle-1', mockState)
+    })
+
+    it('배틀이 CLOSED 상태이면 NotFoundException을 던진다', async () => {
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: { status: BATTLE_STATUS.CLOSED },
+        state: createMockState(),
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      await expect(useCase.execute('battle-1')).rejects.toThrow(NotFoundException)
+      await expect(useCase.execute('battle-1')).rejects.toThrow('해당 배틀은 현재 진행 중이지 않습니다.')
+    })
+
+    it('PENDING 상태에서도 게스트 생성이 가능하다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: { status: BATTLE_STATUS.PENDING },
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      const result = await useCase.execute('battle-1')
+
+      expect(result.isGuest).toBe(true)
+    })
+  })
+})

--- a/backend/src/battles/application/usecases/createGuest.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/createGuest.usecase.spec.ts
@@ -94,7 +94,63 @@ describe('CreateGuestUseCase', () => {
 
       const result = await useCase.execute('battle-1')
 
-      expect(result.isGuest).toBe(true)
+      expect(result.id).toBeDefined()
+      expect(result.nickname).toBeDefined()
+    })
+
+    it('닉네임 존재 체크 콜백이 올바르게 전달된다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: { status: BATTLE_STATUS.OPEN },
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      guestService.buildGuestNickname.mockImplementation(async (_battleId, isNicknameExists) => {
+        await isNicknameExists('TestNickname')
+        return 'Guest1234'
+      })
+
+      await useCase.execute('battle-1')
+
+      expect(guestCheckPort.isNicknameExists).toHaveBeenCalledWith('TestNickname')
+    })
+
+    it('닉네임 중복 체크 콜백이 올바르게 전달된다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: { status: BATTLE_STATUS.OPEN },
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      guestService.buildGuestNickname.mockImplementation(async (battleId, _isNicknameExists, isNicknameDuplicate) => {
+        await isNicknameDuplicate(battleId, 'TestNickname')
+        return 'Guest1234'
+      })
+
+      await useCase.execute('battle-1')
+
+      expect(stateRepo.isNicknameDuplicate).toHaveBeenCalledWith('battle-1', 'TestNickname')
+    })
+
+    it('ID 생성 콜백이 올바르게 전달된다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: { status: BATTLE_STATUS.OPEN },
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      guestService.buildGuest.mockImplementation((_nickname, generateId) => {
+        const id = generateId()
+        return {
+          id,
+          nickname: 'Guest1234',
+          createdAt: Date.now(),
+        }
+      })
+
+      await useCase.execute('battle-1')
+
+      expect(identifierPort.generateId).toHaveBeenCalled()
     })
   })
 })

--- a/backend/src/battles/domains/services/battleChat/battleChat.service.spec.ts
+++ b/backend/src/battles/domains/services/battleChat/battleChat.service.spec.ts
@@ -96,4 +96,69 @@ describe('BattleChatService', () => {
       )
     })
   })
+
+  describe('applyChatMessage 예외 처리', () => {
+    it('TEAM scope에서 team이 없으면 예외를 발생시킨다', () => {
+      const state = createActiveState()
+      const chat = service.buildChatMessage('msg-1', 'user-1', 'test-user', undefined, BATTLE_TEAM.A, 'hello')
+
+      expect(() => {
+        service.applyChatMessage(state, chat, BATTLE_CHAT_SCOPE.TEAM)
+      }).toThrow('진영 채팅은 team 값이 필요합니다.')
+    })
+
+    it('TEAM scope에서 NONE 팀이면 예외를 발생시킨다', () => {
+      const state = createActiveState()
+      const chat = service.buildChatMessage('msg-1', 'user-1', 'test-user', undefined, BATTLE_TEAM.NONE, 'hello')
+
+      expect(() => {
+        service.applyChatMessage(state, chat, BATTLE_CHAT_SCOPE.TEAM, BATTLE_TEAM.NONE)
+      }).toThrow('진영 채팅은 A/B 진영만 사용할 수 있습니다.')
+    })
+
+    it('B팀 채팅을 올바르게 추가한다', () => {
+      const state = createActiveState()
+      const chat = service.buildChatMessage('msg-1', 'user-1', 'test-user', undefined, BATTLE_TEAM.B, 'hello B team')
+
+      service.applyChatMessage(state, chat, BATTLE_CHAT_SCOPE.TEAM, BATTLE_TEAM.B)
+
+      expect(state.teamB.chats).toHaveLength(1)
+      expect(state.teamA.chats).toHaveLength(0)
+      expect(state.teamB.chats[0].text).toBe('hello B team')
+    })
+  })
+
+  describe('buildChatMessage', () => {
+    it('텍스트의 공백을 트림한다', () => {
+      const chat = service.buildChatMessage('msg-1', 'user-1', 'test-user', undefined, BATTLE_TEAM.A, '  hello world  ')
+
+      expect(chat.text).toBe('hello world')
+    })
+
+    it('tier 정보를 포함한 채팅 메시지를 생성한다', () => {
+      const chat = service.buildChatMessage('msg-1', 'user-1', 'test-user', 'gold', BATTLE_TEAM.A, 'hello')
+
+      expect(chat.sender.tier).toBe('gold')
+    })
+
+    it('createdAt이 현재 시간으로 설정된다', () => {
+      const before = new Date()
+      const chat = service.buildChatMessage('msg-1', 'user-1', 'test-user', undefined, BATTLE_TEAM.A, 'hello')
+      const after = new Date()
+
+      expect(chat.createdAt.getTime()).toBeGreaterThanOrEqual(before.getTime())
+      expect(chat.createdAt.getTime()).toBeLessThanOrEqual(after.getTime())
+    })
+
+    it('모든 필드가 올바르게 설정된다', () => {
+      const chat = service.buildChatMessage('msg-123', 'user-456', 'nickname', 'silver', BATTLE_TEAM.B, 'test message')
+
+      expect(chat.messageId).toBe('msg-123')
+      expect(chat.team).toBe(BATTLE_TEAM.B)
+      expect(chat.sender.userId).toBe('user-456')
+      expect(chat.sender.nickname).toBe('nickname')
+      expect(chat.sender.tier).toBe('silver')
+      expect(chat.text).toBe('test message')
+    })
+  })
 })

--- a/backend/src/battles/domains/services/battleDiscussion/battleDiscussion.service.spec.ts
+++ b/backend/src/battles/domains/services/battleDiscussion/battleDiscussion.service.spec.ts
@@ -1,174 +1,203 @@
-import { Test, TestingModule } from '@nestjs/testing'
+import { BadRequestException } from '@nestjs/common'
 import { BattleDiscussionService } from './battleDiscussion.service'
-import { ActiveBattleState } from '../../models/types/battle.types'
-import { BATTLE_PHASE, BATTLE_TEAM } from '../../models/const/battles.const'
+import { BATTLE_DISCUSSION_TYPE, BATTLE_TEAM, BATTLE_PHASE } from '../../models/const/battles.const'
+import type { ActiveBattleState, BattleTeam, BattleDiscussion, BattleDefense } from '../../models/types/battle.types'
 
 describe('BattleDiscussionService', () => {
   let service: BattleDiscussionService
 
-  const createActiveState = (overrides: Partial<ActiveBattleState> = {}): ActiveBattleState => ({
-    battleId: 'battle-1',
-    all: { roomId: 'battle:battle-1', chats: [], attacks: [], defenses: [] },
-    teamA: { roomId: 'battle:battle-1:A', chats: [], users: [], attacks: [], defenses: [] },
-    teamB: { roomId: 'battle:battle-1:B', chats: [], users: [], attacks: [], defenses: [] },
-    phase: BATTLE_PHASE.ATTACK.name,
-    participants: new Map(),
-    teamVotes: new Map(),
-    userInfoMap: new Map(),
-    opinionHistory: [],
-    skipState: new Set(),
-    round: 1,
-    topics: [],
-    totalRounds: 1,
-    phaseCount: 1,
-    startedAt: null,
-    expiredAt: null,
-    ...overrides,
+  beforeEach(() => {
+    service = new BattleDiscussionService()
   })
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [BattleDiscussionService],
-    }).compile()
+  const createState = (phase: string): ActiveBattleState =>
+    ({
+      battleId: 'battle-1',
+      phase,
+      teamA: { attacks: [], defenses: [], users: [], chats: [], roomId: 'r-a' },
+      teamB: { attacks: [], defenses: [], users: [], chats: [], roomId: 'r-b' },
+      all: { attacks: [], defenses: [], chats: [], roomId: 'r-all' },
+      opinionHistory: [],
+      participants: new Map(),
+      teamVotes: new Map(),
+      userInfoMap: new Map([['user-1', '테스터']]),
+      skipState: new Set(),
+    }) as unknown as ActiveBattleState
 
-    service = module.get(BattleDiscussionService)
+  describe('buildAttack', () => {
+    it('공격 객체를 생성한다', () => {
+      const attack = service.buildAttack('d-1', 'user-1', '테스터', '  내용  ', BATTLE_TEAM.A)
+      expect(attack.discussionId).toBe('d-1')
+      expect(attack.author.authorId).toBe('user-1')
+      expect(attack.author.nickname).toBe('테스터')
+      expect(attack.type).toBe(BATTLE_DISCUSSION_TYPE.ATTACK)
+      expect(attack.content).toBe('내용')
+      expect(attack.upvotes).toBe(0)
+      expect(attack.votes).toEqual([])
+      expect(attack.status).toBe('PENDING')
+      expect(attack.team).toBe(BATTLE_TEAM.A)
+    })
   })
 
-  describe('BattleDiscussionService', () => {
-    let state: ActiveBattleState
+  describe('buildDefense', () => {
+    it('방어 객체를 생성한다', () => {
+      const defense = service.buildDefense('d-2', 'user-1', '테스터', '반론 내용', BATTLE_TEAM.B)
+      expect(defense.type).toBe(BATTLE_DISCUSSION_TYPE.DEFENSE)
+      expect(defense.team).toBe(BATTLE_TEAM.B)
+    })
+  })
 
-    beforeEach(() => {
-      state = createActiveState({ battleId: 'battle-1' })
-      state.participants.set('user-1', BATTLE_TEAM.A)
-      state.participants.set('user-2', BATTLE_TEAM.B)
-      state.userInfoMap.set('user-1', 'User1')
-      state.userInfoMap.set('user-2', 'User2')
+  describe('buildNullPlaceholder', () => {
+    it('팀A 공격 플레이스홀더를 생성한다', () => {
+      const placeholder = service.buildNullPlaceholder('A', 'ATTACK')
+      expect(placeholder.status).toBe('SELECTED')
+      expect(placeholder.selectedAt).toBeDefined()
+      expect(placeholder.content).toBe('투표로 선정된 의견이 없습니다')
+      expect(placeholder.team).toBe(BATTLE_TEAM.A)
     })
 
-    it('applyAttack: opinionHistory에 공격 의견이 저장된다', () => {
-      state.phase = BATTLE_PHASE.ATTACK.name
-      expect(state.opinionHistory.length).toBe(0)
+    it('팀B 방어 플레이스홀더를 생성한다', () => {
+      const placeholder = service.buildNullPlaceholder('B', 'DEFENSE')
+      expect(placeholder.team).toBe(BATTLE_TEAM.B)
+    })
+  })
 
-      const attack = service.applyAttack(
-        state,
-        'user-1',
-        '공격 의견입니다',
-        BATTLE_TEAM.A,
-        'attack-1',
-        () => 'User1',
-        () => true,
-      )
+  describe('applyAttack', () => {
+    it('공격 의견을 상태에 적용한다', () => {
+      const state = createState(BATTLE_PHASE.ATTACK.name)
+      const getNickname = jest.fn().mockReturnValue('테스터')
+      const canSubmit = jest.fn().mockReturnValue(true)
 
-      expect(state.opinionHistory.length).toBe(1)
-      expect(state.opinionHistory[0].content).toBe('공격 의견입니다')
-      expect(state.opinionHistory[0].author.authorId).toBe('user-1')
-      expect(state.opinionHistory[0].status).toBe('PENDING')
-      expect(state.opinionHistory[0].type).toBe('ATTACK')
-      expect(attack).toBe(state.opinionHistory[0])
+      const attack = service.applyAttack(state, 'user-1', '공격 내용', BATTLE_TEAM.A, 'd-1', getNickname, canSubmit)
+
+      expect(attack.content).toBe('공격 내용')
+      expect(state.teamA.attacks).toHaveLength(1)
+      expect(state.opinionHistory).toHaveLength(1)
     })
 
-    it('applyDefense: opinionHistory에 수비 의견이 저장된다', () => {
-      state.phase = BATTLE_PHASE.DEFENSE.name
-      expect(state.opinionHistory.length).toBe(0)
+    it('팀B 공격은 teamB에 추가된다', () => {
+      const state = createState(BATTLE_PHASE.ATTACK.name)
+      const getNickname = jest.fn().mockReturnValue('테스터')
+      const canSubmit = jest.fn().mockReturnValue(true)
 
-      const defense = service.applyDefense(
-        state,
-        'user-2',
-        '수비 의견입니다',
-        BATTLE_TEAM.B,
-        'defense-1',
-        () => 'User2',
-        () => true,
-      )
-
-      expect(state.opinionHistory.length).toBe(1)
-      expect(state.opinionHistory[0].content).toBe('수비 의견입니다')
-      expect(state.opinionHistory[0].author.authorId).toBe('user-2')
-      expect(state.opinionHistory[0].status).toBe('PENDING')
-      expect(state.opinionHistory[0].type).toBe('DEFENSE')
-      expect(defense).toBe(state.opinionHistory[0])
+      service.applyAttack(state, 'user-1', '공격', BATTLE_TEAM.B, 'd-1', getNickname, canSubmit)
+      expect(state.teamB.attacks).toHaveLength(1)
     })
 
-    it('공격 2개 + 수비 1개가 opinionHistory에 누적된다', () => {
-      // ATTACK 1
-      state.phase = BATTLE_PHASE.ATTACK.name
-      service.applyAttack(
-        state,
-        'user-1',
-        '첫 번째 공격',
-        BATTLE_TEAM.A,
-        'attack-1',
-        () => 'User1',
-        () => true,
-      )
+    it('canSubmit이 false면 BadRequestException을 던진다', () => {
+      const state = createState(BATTLE_PHASE.PENDING.name)
+      const getNickname = jest.fn().mockReturnValue('테스터')
+      const canSubmit = jest.fn().mockReturnValue(false)
 
-      // ATTACK 2
-      state.phase = BATTLE_PHASE.ATTACK.name
-      service.applyAttack(
-        state,
-        'user-2',
-        '두 번째 공격',
-        BATTLE_TEAM.B,
-        'attack-2',
-        () => 'User2',
-        () => true,
-      )
+      expect(() => service.applyAttack(state, 'user-1', '공격', BATTLE_TEAM.A, 'd-1', getNickname, canSubmit)).toThrow(BadRequestException)
+    })
+  })
 
-      // DEFENSE 1
-      state.phase = BATTLE_PHASE.DEFENSE.name
-      service.applyDefense(
-        state,
-        'user-1',
-        '첫 번째 수비',
-        BATTLE_TEAM.A,
-        'defense-1',
-        () => 'User1',
-        () => true,
-      )
+  describe('applyDefense', () => {
+    it('반론 의견을 상태에 적용한다', () => {
+      const state = createState(BATTLE_PHASE.DEFENSE.name)
+      const getNickname = jest.fn().mockReturnValue('테스터')
+      const canSubmit = jest.fn().mockReturnValue(true)
 
-      expect(state.opinionHistory.length).toBe(3)
-      expect(state.opinionHistory[0].type).toBe('ATTACK')
-      expect(state.opinionHistory[1].type).toBe('ATTACK')
-      expect(state.opinionHistory[2].type).toBe('DEFENSE')
+      const defense = service.applyDefense(state, 'user-1', '반론 내용', BATTLE_TEAM.A, 'd-1', getNickname, canSubmit)
+
+      expect(defense.content).toBe('반론 내용')
+      expect(state.teamA.defenses).toHaveLength(1)
     })
 
-    it('applyAttack 호출 시 opinionHistory와 teamA/teamB 배열이 같은 객체를 참조한다', () => {
-      state.phase = BATTLE_PHASE.ATTACK.name
+    it('팀B 반론은 teamB에 추가된다', () => {
+      const state = createState(BATTLE_PHASE.DEFENSE.name)
+      const getNickname = jest.fn().mockReturnValue('테스터')
+      const canSubmit = jest.fn().mockReturnValue(true)
 
-      const attackA = service.applyAttack(
-        state,
-        'user-1',
-        'A팀 공격',
-        BATTLE_TEAM.A,
-        'attack-a',
-        () => 'User1',
-        () => true,
-      )
+      service.applyDefense(state, 'user-1', '반론', BATTLE_TEAM.B, 'd-1', getNickname, canSubmit)
+      expect(state.teamB.defenses).toHaveLength(1)
+    })
 
-      const attackB = service.applyAttack(
-        state,
-        'user-2',
-        'B팀 공격',
-        BATTLE_TEAM.B,
-        'attack-b',
-        () => 'User2',
-        () => true,
-      )
+    it('canSubmit이 false면 BadRequestException을 던진다', () => {
+      const state = createState(BATTLE_PHASE.PENDING.name)
+      const getNickname = jest.fn().mockReturnValue('')
+      const canSubmit = jest.fn().mockReturnValue(false)
 
-      // opinionHistory에 모두 저장
-      expect(state.opinionHistory.length).toBe(2)
+      expect(() => service.applyDefense(state, 'user-1', '반론', BATTLE_TEAM.A, 'd-1', getNickname, canSubmit)).toThrow(BadRequestException)
+    })
+  })
 
-      // teamA/teamB에도 각각 저장 (applyAttack이 team별 배열에 넣는 구조라는 전제)
-      expect(state.teamA.attacks.length).toBe(1)
-      expect(state.teamB.attacks.length).toBe(1)
+  describe('resetDiscussions', () => {
+    it('모든 토론 데이터를 초기화한다', () => {
+      const state = createState(BATTLE_PHASE.ATTACK.name)
+      state.teamA.attacks = [{ discussionId: '1' } as BattleDiscussion]
+      state.teamB.defenses = [{ discussionId: '2' } as BattleDefense]
 
-      // 같은 객체 참조 확인
-      expect(state.opinionHistory[0]).toBe(state.teamA.attacks[0])
-      expect(state.opinionHistory[1]).toBe(state.teamB.attacks[0])
+      service.resetDiscussions(state)
 
-      // 반환값도 같은 객체인지
-      expect(attackA).toBe(state.opinionHistory[0])
-      expect(attackB).toBe(state.opinionHistory[1])
+      expect(state.teamA.attacks).toHaveLength(0)
+      expect(state.teamB.attacks).toHaveLength(0)
+      expect(state.teamA.defenses).toHaveLength(0)
+      expect(state.teamB.defenses).toHaveLength(0)
+    })
+  })
+
+  describe('canUserSubmitAttack', () => {
+    it('OPINION_SHARE 단계에서 true를 반환한다', () => {
+      const state = createState(BATTLE_PHASE.OPINION_SHARE.name)
+      expect(service.canUserSubmitAttack(state, BATTLE_TEAM.A)).toBe(true)
+    })
+
+    it('ATTACK 단계에서 true를 반환한다', () => {
+      const state = createState(BATTLE_PHASE.ATTACK.name)
+      expect(service.canUserSubmitAttack(state, BATTLE_TEAM.B)).toBe(true)
+    })
+
+    it('NONE 팀은 false를 반환한다', () => {
+      const state = createState(BATTLE_PHASE.ATTACK.name)
+      expect(service.canUserSubmitAttack(state, BATTLE_TEAM.NONE as BattleTeam)).toBe(false)
+    })
+
+    it('다른 단계에서는 false를 반환한다', () => {
+      const state = createState(BATTLE_PHASE.DEFENSE.name)
+      expect(service.canUserSubmitAttack(state, BATTLE_TEAM.A)).toBe(false)
+    })
+  })
+
+  describe('canUserSubmitDefense', () => {
+    it('DEFENSE 단계에서 true를 반환한다', () => {
+      const state = createState(BATTLE_PHASE.DEFENSE.name)
+      expect(service.canUserSubmitDefense(state, BATTLE_TEAM.A)).toBe(true)
+    })
+
+    it('NONE 팀은 false를 반환한다', () => {
+      const state = createState(BATTLE_PHASE.DEFENSE.name)
+      expect(service.canUserSubmitDefense(state, BATTLE_TEAM.NONE as BattleTeam)).toBe(false)
+    })
+
+    it('다른 단계에서는 false를 반환한다', () => {
+      const state = createState(BATTLE_PHASE.ATTACK.name)
+      expect(service.canUserSubmitDefense(state, BATTLE_TEAM.A)).toBe(false)
+    })
+  })
+
+  describe('canUserVoteAttack', () => {
+    it('ATTACK 단계에서 true를 반환한다', () => {
+      const state = createState(BATTLE_PHASE.ATTACK.name)
+      expect(service.canUserVoteAttack(state)).toBe(true)
+    })
+
+    it('다른 단계에서는 false를 반환한다', () => {
+      const state = createState(BATTLE_PHASE.DEFENSE.name)
+      expect(service.canUserVoteAttack(state)).toBe(false)
+    })
+  })
+
+  describe('canUserVoteDefense', () => {
+    it('DEFENSE 단계에서 true를 반환한다', () => {
+      const state = createState(BATTLE_PHASE.DEFENSE.name)
+      expect(service.canUserVoteDefense(state)).toBe(true)
+    })
+
+    it('다른 단계에서는 false를 반환한다', () => {
+      const state = createState(BATTLE_PHASE.ATTACK.name)
+      expect(service.canUserVoteDefense(state)).toBe(false)
     })
   })
 })

--- a/backend/src/battles/domains/services/battleGuest/battleGuest.service.spec.ts
+++ b/backend/src/battles/domains/services/battleGuest/battleGuest.service.spec.ts
@@ -1,0 +1,95 @@
+import { BattleGuestService } from './battleGuest.service'
+import type { ActiveBattleState } from '../../models/types/battle.types'
+import { BATTLE_TEAM } from '../../models/const/battles.const'
+
+describe('BattleGuestService', () => {
+  let service: BattleGuestService
+
+  beforeEach(() => {
+    service = new BattleGuestService()
+  })
+
+  describe('buildGuest', () => {
+    it('ID 생성 함수를 사용하여 게스트 계정을 생성한다', () => {
+      const generateId = jest.fn().mockReturnValue('guest-123')
+      const guest = service.buildGuest('테스트닉네임', generateId)
+
+      expect(generateId).toHaveBeenCalled()
+      expect(guest.id).toBe('guest-123')
+      expect(guest.nickname).toBe('테스트닉네임')
+      expect(guest.createdAt).toBeDefined()
+    })
+
+    it('생성 시점의 타임스탬프를 포함한다', () => {
+      const before = Date.now()
+      const guest = service.buildGuest('닉네임', () => 'id')
+      const after = Date.now()
+
+      expect(guest.createdAt).toBeGreaterThanOrEqual(before)
+      expect(guest.createdAt).toBeLessThanOrEqual(after)
+    })
+  })
+
+  describe('applyGuestToState', () => {
+    it('게스트를 배틀 상태에 NONE 팀으로 추가한다', () => {
+      const state = {
+        userInfoMap: new Map<string, string>(),
+        participants: new Map<string, string>(),
+      } as unknown as ActiveBattleState
+
+      const guest = { id: 'guest-1', nickname: '게스트', createdAt: Date.now() }
+      service.applyGuestToState(state, guest)
+
+      expect(state.userInfoMap.get('guest-1')).toBe('게스트')
+      expect(state.participants.get('guest-1')).toBe(BATTLE_TEAM.NONE)
+    })
+  })
+
+  describe('buildGuestNickname', () => {
+    it('중복이 없으면 첫 번째 생성된 닉네임을 반환한다', async () => {
+      const isTaken = jest.fn().mockResolvedValue(false)
+      const isNicknameDuplicate = jest.fn().mockResolvedValue(false)
+
+      const nickname = await service.buildGuestNickname('battle-1', isTaken, isNicknameDuplicate)
+
+      expect(typeof nickname).toBe('string')
+      expect(nickname.length).toBeGreaterThan(0)
+    })
+
+    it('중복이 있으면 다른 닉네임으로 재시도한다', async () => {
+      let callCount = 0
+      const isTaken = jest.fn().mockImplementation(() => {
+        callCount++
+        return Promise.resolve(callCount <= 2)
+      })
+      const isNicknameDuplicate = jest.fn().mockResolvedValue(false)
+
+      const nickname = await service.buildGuestNickname('battle-1', isTaken, isNicknameDuplicate)
+
+      expect(typeof nickname).toBe('string')
+      expect(isTaken).toHaveBeenCalledTimes(3)
+    })
+
+    it('50회 초과 시 타임스탬프 기반 폴백 닉네임을 반환한다', async () => {
+      const isTaken = jest.fn().mockResolvedValue(true)
+      const isNicknameDuplicate = jest.fn().mockResolvedValue(false)
+
+      const nickname = await service.buildGuestNickname('battle-1', isTaken, isNicknameDuplicate)
+
+      expect(nickname).toMatch(/^게스트\d+$/)
+    })
+
+    it('배틀 내 닉네임 중복도 체크한다', async () => {
+      let callCount = 0
+      const isTaken = jest.fn().mockResolvedValue(false)
+      const isNicknameDuplicate = jest.fn().mockImplementation(() => {
+        callCount++
+        return Promise.resolve(callCount <= 1)
+      })
+
+      await service.buildGuestNickname('battle-1', isTaken, isNicknameDuplicate)
+
+      expect(isNicknameDuplicate).toHaveBeenCalledWith('battle-1', expect.any(String))
+    })
+  })
+})

--- a/backend/src/battles/domains/services/battleResult/battleResult.service.spec.ts
+++ b/backend/src/battles/domains/services/battleResult/battleResult.service.spec.ts
@@ -1,0 +1,75 @@
+import { BattleResultService } from './battleResult.service'
+
+describe('BattleResultService', () => {
+  let service: BattleResultService
+
+  beforeEach(() => {
+    service = new BattleResultService()
+  })
+
+  describe('determineWinningTeam', () => {
+    it('A팀 투표가 많으면 A를 반환한다', () => {
+      expect(service.determineWinningTeam(5, 3)).toBe('A')
+    })
+
+    it('B팀 투표가 많으면 B를 반환한다', () => {
+      expect(service.determineWinningTeam(3, 5)).toBe('B')
+    })
+
+    it('동점이면 DRAW를 반환한다', () => {
+      expect(service.determineWinningTeam(5, 5)).toBe('DRAW')
+    })
+
+    it('둘 다 0이면 DRAW를 반환한다', () => {
+      expect(service.determineWinningTeam(0, 0)).toBe('DRAW')
+    })
+  })
+
+  describe('buildBattleResult', () => {
+    it('투표 수와 퍼센트를 포함한 결과를 반환한다', () => {
+      const result = service.buildBattleResult(6, 4)
+      expect(result.winner).toBe('A')
+      expect(result.teamA).toEqual({ votes: 6, percentage: 60 })
+      expect(result.teamB).toEqual({ votes: 4, percentage: 40 })
+      expect(result.neutral).toEqual({ votes: 0, percentage: 0 })
+    })
+
+    it('totalParticipantsCount가 주어지면 중립 투표를 계산한다', () => {
+      const result = service.buildBattleResult(3, 2, 10)
+      expect(result.neutral).toEqual({ votes: 5, percentage: 50 })
+    })
+
+    it('winningTeam이 주어지면 해당 값을 사용한다', () => {
+      const result = service.buildBattleResult(3, 5, null, 'DRAW')
+      expect(result.winner).toBe('DRAW')
+    })
+
+    it('total이 0이면 모든 퍼센트가 0이다', () => {
+      const result = service.buildBattleResult(0, 0)
+      expect(result.teamA.percentage).toBe(0)
+      expect(result.teamB.percentage).toBe(0)
+      expect(result.neutral.percentage).toBe(0)
+    })
+  })
+
+  describe('toBattleResultForTeam', () => {
+    it('NONE 팀은 null을 반환한다', () => {
+      expect(service.toBattleResultForTeam('NONE', 'A')).toBeNull()
+    })
+
+    it('DRAW이면 DRAW를 반환한다', () => {
+      expect(service.toBattleResultForTeam('A', 'DRAW')).toBe('DRAW')
+      expect(service.toBattleResultForTeam('B', 'DRAW')).toBe('DRAW')
+    })
+
+    it('A팀이 승리하면 A팀은 WIN, B팀은 LOSE를 반환한다', () => {
+      expect(service.toBattleResultForTeam('A', 'A')).toBe('WIN')
+      expect(service.toBattleResultForTeam('B', 'A')).toBe('LOSE')
+    })
+
+    it('B팀이 승리하면 B팀은 WIN, A팀은 LOSE를 반환한다', () => {
+      expect(service.toBattleResultForTeam('B', 'B')).toBe('WIN')
+      expect(service.toBattleResultForTeam('A', 'B')).toBe('LOSE')
+    })
+  })
+})

--- a/backend/src/battles/domains/services/battleSkip/battleSkip.service.spec.ts
+++ b/backend/src/battles/domains/services/battleSkip/battleSkip.service.spec.ts
@@ -98,5 +98,105 @@ describe('BattleSkipService', () => {
 
       expect(count).toBe(2)
     })
+
+    it('참가자가 아닌 유저는 스킵할 수 없다', () => {
+      const state = createActiveState()
+
+      expect(() => {
+        service.applyPhaseSkip(state, 'non-existent-user', true)
+      }).toThrow(UnauthorizedException)
+    })
+  })
+
+  describe('buildSkipCount', () => {
+    it('skipped가 true이면 0을 반환한다', () => {
+      const count = service.buildSkipCount(true, 5)
+
+      expect(count).toBe(0)
+    })
+
+    it('skipped가 false이면 skipStateSize를 반환한다', () => {
+      const count = service.buildSkipCount(false, 3)
+
+      expect(count).toBe(3)
+    })
+  })
+
+  describe('buildActiveParticipantsCount', () => {
+    it('모든 참가자가 NONE이면 0을 반환한다', () => {
+      const state = createActiveState()
+      state.participants.set('user-a', BATTLE_TEAM.NONE)
+      state.participants.set('user-b', BATTLE_TEAM.NONE)
+
+      const count = service.buildActiveParticipantsCount(state)
+
+      expect(count).toBe(0)
+    })
+
+    it('빈 participants Map이면 0을 반환한다', () => {
+      const state = createActiveState()
+      state.participants.clear()
+
+      const count = service.buildActiveParticipantsCount(state)
+
+      expect(count).toBe(0)
+    })
+  })
+
+  describe('shouldSkipPhase', () => {
+    it('모든 활성 참가자가 스킵하면 skipPhase 콜백을 호출하고 true를 반환한다', async () => {
+      const state = createActiveState()
+      state.skipState.add('user-a')
+      state.skipState.add('user-b')
+
+      const mockGetActiveCount = jest.fn().mockReturnValue(2)
+      const mockSkipPhase = jest.fn().mockResolvedValue(undefined)
+
+      const result = await service.shouldSkipPhase(state, mockGetActiveCount, mockSkipPhase)
+
+      expect(mockSkipPhase).toHaveBeenCalledWith('battle-id')
+      expect(result).toBe(true)
+    })
+
+    it('일부 참가자만 스킵하면 false를 반환한다', async () => {
+      const state = createActiveState()
+      state.skipState.add('user-a')
+      // user-b는 스킵하지 않음
+
+      const mockGetActiveCount = jest.fn().mockReturnValue(2)
+      const mockSkipPhase = jest.fn().mockResolvedValue(undefined)
+
+      const result = await service.shouldSkipPhase(state, mockGetActiveCount, mockSkipPhase)
+
+      expect(mockSkipPhase).not.toHaveBeenCalled()
+      expect(result).toBe(false)
+    })
+
+    it('활성 참가자가 0명이면 스킵하지 않는다', async () => {
+      const state = createActiveState()
+      state.participants.set('user-a', BATTLE_TEAM.NONE)
+      state.participants.set('user-b', BATTLE_TEAM.NONE)
+
+      const mockGetActiveCount = jest.fn().mockReturnValue(0)
+      const mockSkipPhase = jest.fn().mockResolvedValue(undefined)
+
+      const result = await service.shouldSkipPhase(state, mockGetActiveCount, mockSkipPhase)
+
+      expect(mockSkipPhase).not.toHaveBeenCalled()
+      expect(result).toBe(false)
+    })
+
+    it('아무도 스킵하지 않으면 false를 반환한다', async () => {
+      const state = createActiveState()
+      // skipState가 비어있음
+
+      const mockGetActiveCount = jest.fn().mockReturnValue(2)
+      const mockSkipPhase = jest.fn().mockResolvedValue(undefined)
+
+      const result = await service.shouldSkipPhase(state, mockGetActiveCount, mockSkipPhase)
+
+      expect(mockSkipPhase).not.toHaveBeenCalled()
+      expect(result).toBe(false)
+    })
   })
 })

--- a/backend/src/battles/domains/services/battleTeamSwitch/battleTeamSwitch.service.spec.ts
+++ b/backend/src/battles/domains/services/battleTeamSwitch/battleTeamSwitch.service.spec.ts
@@ -101,4 +101,167 @@ describe('BattleTeamSwitchService', () => {
       expect(state.participants.get('user-none')).toBe(BATTLE_TEAM.NONE)
     })
   })
+
+  describe('applyTeamSwitch', () => {
+    it('변경 사항이 없으면 이벤트를 발생시키지 않는다', () => {
+      const state = createActiveState()
+      state.participants.set('user-1', BATTLE_TEAM.A)
+      service.rebuildTeamUsers(state)
+      // teamVotes에 아무것도 없음
+
+      const emitTeamUpdated = jest.fn()
+      service.applyTeamSwitch(state, emitTeamUpdated)
+
+      expect(emitTeamUpdated).not.toHaveBeenCalled()
+    })
+
+    it('같은 팀으로 투표하면 변경되지 않는다', () => {
+      const state = createActiveState()
+      state.participants.set('user-1', BATTLE_TEAM.A)
+      service.rebuildTeamUsers(state)
+      state.teamVotes.set('user-1', BATTLE_TEAM.A) // 같은 팀으로 투표
+
+      const emitTeamUpdated = jest.fn()
+      service.applyTeamSwitch(state, emitTeamUpdated)
+
+      expect(emitTeamUpdated).not.toHaveBeenCalled()
+      expect(state.participants.get('user-1')).toBe(BATTLE_TEAM.A)
+    })
+
+    it('스위치 후 teamVotes를 클리어한다', () => {
+      const state = createActiveState()
+      state.participants.set('user-1', BATTLE_TEAM.A)
+      service.rebuildTeamUsers(state)
+      state.teamVotes.set('user-1', BATTLE_TEAM.B)
+
+      const emitTeamUpdated = jest.fn()
+      service.applyTeamSwitch(state, emitTeamUpdated)
+
+      expect(state.teamVotes.size).toBe(0)
+    })
+
+    it('변경 시 올바른 콜백 파라미터를 전달한다', () => {
+      const state = createActiveState()
+      state.participants.set('user-1', BATTLE_TEAM.A)
+      state.participants.set('user-2', BATTLE_TEAM.B)
+      service.rebuildTeamUsers(state)
+      state.teamVotes.set('user-1', BATTLE_TEAM.B)
+
+      const emitTeamUpdated = jest.fn()
+      service.applyTeamSwitch(state, emitTeamUpdated)
+
+      expect(emitTeamUpdated).toHaveBeenCalledWith('battle-1', 1, { teamA: 1, teamB: 1, teamNone: 0 }, { teamA: 0, teamB: 2, teamNone: 0 }, [
+        { userId: 'user-1', from: BATTLE_TEAM.A, to: BATTLE_TEAM.B },
+      ])
+    })
+  })
+
+  describe('applyTeamVote', () => {
+    it('참가자가 아닌 유저는 팀 변경 투표를 할 수 없다', () => {
+      const state = createActiveState()
+      state.phase = BATTLE_PHASE.TEAM_SWITCH.name
+
+      expect(() => {
+        service.applyTeamVote(state, 'non-participant', BATTLE_TEAM.A)
+      }).toThrow(BadRequestException)
+      expect(() => {
+        service.applyTeamVote(state, 'non-participant', BATTLE_TEAM.A)
+      }).toThrow('배틀 참가자만 팀 변경 투표를 할 수 있습니다.')
+    })
+
+    it('팀 변경 투표를 올바르게 저장한다', () => {
+      const state = createActiveState()
+      state.phase = BATTLE_PHASE.TEAM_SWITCH.name
+      state.participants.set('user-1', BATTLE_TEAM.A)
+
+      service.applyTeamVote(state, 'user-1', BATTLE_TEAM.B)
+
+      expect(state.teamVotes.get('user-1')).toBe(BATTLE_TEAM.B)
+    })
+  })
+
+  describe('applyParticipant', () => {
+    it('참가자를 올바른 팀에 추가한다', () => {
+      const state = createActiveState()
+      const emitUserUpdated = jest.fn()
+
+      service.applyParticipant(state, 'user-1', BATTLE_TEAM.A, emitUserUpdated)
+
+      expect(state.participants.get('user-1')).toBe(BATTLE_TEAM.A)
+      expect(state.teamA.users).toContain('user-1')
+    })
+
+    it('사용자 업데이트 이벤트를 발생시킨다', () => {
+      const state = createActiveState()
+      const emitUserUpdated = jest.fn()
+
+      service.applyParticipant(state, 'user-1', BATTLE_TEAM.A, emitUserUpdated)
+
+      expect(emitUserUpdated).toHaveBeenCalledWith('battle-1', {
+        teamA: 1,
+        teamB: 0,
+        teamNone: 0,
+      })
+    })
+
+    it('B팀에 참가자를 추가할 수 있다', () => {
+      const state = createActiveState()
+      const emitUserUpdated = jest.fn()
+
+      service.applyParticipant(state, 'user-1', BATTLE_TEAM.B, emitUserUpdated)
+
+      expect(state.participants.get('user-1')).toBe(BATTLE_TEAM.B)
+      expect(state.teamB.users).toContain('user-1')
+    })
+
+    it('NONE 팀에 참가자를 추가할 수 있다', () => {
+      const state = createActiveState()
+      const emitUserUpdated = jest.fn()
+
+      service.applyParticipant(state, 'user-1', BATTLE_TEAM.NONE, emitUserUpdated)
+
+      expect(state.participants.get('user-1')).toBe(BATTLE_TEAM.NONE)
+      expect(state.teamA.users).not.toContain('user-1')
+      expect(state.teamB.users).not.toContain('user-1')
+    })
+  })
+
+  describe('rebuildTeamUsers', () => {
+    it('빈 참가자로도 정상 작동한다', () => {
+      const state = createActiveState()
+      state.participants.clear()
+
+      service.rebuildTeamUsers(state)
+
+      expect(state.teamA.users).toHaveLength(0)
+      expect(state.teamB.users).toHaveLength(0)
+    })
+
+    it('모든 참가자가 NONE이면 팀 배열이 비어있다', () => {
+      const state = createActiveState()
+      state.participants.set('user-1', BATTLE_TEAM.NONE)
+      state.participants.set('user-2', BATTLE_TEAM.NONE)
+
+      service.rebuildTeamUsers(state)
+
+      expect(state.teamA.users).toHaveLength(0)
+      expect(state.teamB.users).toHaveLength(0)
+    })
+
+    it('팀 배열을 올바르게 재구성한다', () => {
+      const state = createActiveState()
+      state.participants.set('user-1', BATTLE_TEAM.A)
+      state.participants.set('user-2', BATTLE_TEAM.A)
+      state.participants.set('user-3', BATTLE_TEAM.B)
+      state.participants.set('user-4', BATTLE_TEAM.NONE)
+
+      service.rebuildTeamUsers(state)
+
+      expect(state.teamA.users).toHaveLength(2)
+      expect(state.teamA.users).toContain('user-1')
+      expect(state.teamA.users).toContain('user-2')
+      expect(state.teamB.users).toHaveLength(1)
+      expect(state.teamB.users).toContain('user-3')
+    })
+  })
 })

--- a/backend/src/battles/domains/services/battleTier/battleTier.service.spec.ts
+++ b/backend/src/battles/domains/services/battleTier/battleTier.service.spec.ts
@@ -76,5 +76,140 @@ describe('BattleTierService', () => {
       expect(updates.find(u => u.userId === 'user-d')).toBeDefined()
       expect(updates.find(u => u.userId === 'user-e')).toBeDefined()
     })
+
+    it('참가자 목록에 없는 유저는 업데이트하지 않는다', () => {
+      const participants = new Map([['user-a', BATTLE_TEAM.A]])
+
+      const users = [
+        { id: 'user-a', rating: 100, tier: 'BRONZE' },
+        { id: 'user-unknown', rating: 200, tier: 'SILVER' },
+      ]
+
+      const getBattleResultForTeam = (team: string, winningTeam: 'A' | 'B' | 'DRAW'): 'WIN' | 'LOSE' | 'DRAW' | null => {
+        if (team === BATTLE_TEAM.NONE) return null
+        if (winningTeam === 'DRAW') return 'DRAW'
+        if (team === winningTeam) return 'WIN'
+        return 'LOSE'
+      }
+
+      const updates = service.buildRatingUpdates(participants, users, 'A', [], getBattleResultForTeam)
+
+      expect(updates.length).toBe(1)
+      expect(updates.find(u => u.userId === 'user-a')).toBeDefined()
+      expect(updates.find(u => u.userId === 'user-unknown')).toBeUndefined()
+    })
+
+    it('rating이 null인 유저는 0으로 처리한다', () => {
+      const participants = new Map([['user-a', BATTLE_TEAM.A]])
+
+      const users = [{ id: 'user-a', rating: null, tier: null }]
+
+      const getBattleResultForTeam = (team: string, winningTeam: 'A' | 'B' | 'DRAW'): 'WIN' | 'LOSE' | 'DRAW' | null => {
+        if (team === BATTLE_TEAM.NONE) return null
+        if (winningTeam === 'DRAW') return 'DRAW'
+        if (team === winningTeam) return 'WIN'
+        return 'LOSE'
+      }
+
+      const updates = service.buildRatingUpdates(participants, users, 'A', [], getBattleResultForTeam)
+
+      expect(updates.length).toBe(1)
+      expect(updates[0].currentRating).toBe(0)
+      expect(updates[0].nextRating).toBeGreaterThan(0)
+    })
+
+    it('레이팅이 0인 유저가 패배해도 음수가 되지 않는다', () => {
+      const participants = new Map([['user-a', BATTLE_TEAM.A]])
+
+      const users = [{ id: 'user-a', rating: 0, tier: 'BRONZE' }]
+
+      const getBattleResultForTeam = (): 'WIN' | 'LOSE' | 'DRAW' | null => 'LOSE'
+
+      const updates = service.buildRatingUpdates(participants, users, 'B', [], getBattleResultForTeam)
+
+      expect(updates.length).toBe(0) // 레이팅 변화 없으므로 업데이트 없음
+    })
+
+    it('레이팅과 티어 모두 변화가 없으면 업데이트하지 않는다', () => {
+      const participants = new Map([['user-a', BATTLE_TEAM.A]])
+
+      const users = [{ id: 'user-a', rating: 5, tier: 'BRONZE' }]
+
+      // 패배해도 0 이하로 떨어지지 않고, 티어도 BRONZE 유지
+      const getBattleResultForTeam = (): 'WIN' | 'LOSE' | 'DRAW' | null => 'LOSE'
+
+      const updates = service.buildRatingUpdates(participants, users, 'B', [], getBattleResultForTeam)
+
+      // rating: 5 - 10 = -5 -> 0 (floor), tier: BRONZE -> BRONZE
+      // currentRating(5) !== nextRating(0) 이므로 업데이트됨
+      expect(updates.length).toBe(1)
+      expect(updates[0].nextRating).toBe(0)
+    })
+
+    it('티어 경계값에서 승리하면 다음 티어로 승급한다', () => {
+      const participants = new Map([['user-a', BATTLE_TEAM.A]])
+
+      // BRONZE(0-199) -> SILVER(200-399) 경계
+      const users = [{ id: 'user-a', rating: 190, tier: 'BRONZE' }]
+
+      const getBattleResultForTeam = (): 'WIN' | 'LOSE' | 'DRAW' | null => 'WIN'
+
+      const updates = service.buildRatingUpdates(participants, users, 'A', [], getBattleResultForTeam)
+
+      // BRONZE 승리: 15 * 2.0 = 30점 추가, 190 + 30 = 220 -> SILVER
+      expect(updates.length).toBe(1)
+      expect(updates[0].currentTier).toBe('BRONZE')
+      expect(updates[0].nextTier).toBe('SILVER')
+      expect(updates[0].nextRating).toBe(220)
+    })
+
+    it('4위 이하 MVP는 보너스를 받지 않는다', () => {
+      const participants = new Map([
+        ['user-a', BATTLE_TEAM.A],
+        ['user-b', BATTLE_TEAM.A],
+        ['user-c', BATTLE_TEAM.A],
+        ['user-d', BATTLE_TEAM.A],
+      ])
+
+      const users = [
+        { id: 'user-a', rating: 100, tier: 'BRONZE' },
+        { id: 'user-b', rating: 100, tier: 'BRONZE' },
+        { id: 'user-c', rating: 100, tier: 'BRONZE' },
+        { id: 'user-d', rating: 100, tier: 'BRONZE' },
+      ]
+
+      const mvps: Mvp[] = [
+        { userId: 'user-a', nickname: 'A', team: 'A', score: 40, totalVotes: 10, opinionCount: 1, selectedOpinionCount: 0, joinedAt: 0 },
+        { userId: 'user-b', nickname: 'B', team: 'A', score: 30, totalVotes: 9, opinionCount: 1, selectedOpinionCount: 0, joinedAt: 1 },
+        { userId: 'user-c', nickname: 'C', team: 'A', score: 20, totalVotes: 8, opinionCount: 1, selectedOpinionCount: 0, joinedAt: 2 },
+        { userId: 'user-d', nickname: 'D', team: 'A', score: 10, totalVotes: 7, opinionCount: 1, selectedOpinionCount: 0, joinedAt: 3 },
+      ]
+
+      const getBattleResultForTeam = (): 'WIN' | 'LOSE' | 'DRAW' | null => 'WIN'
+
+      const updates = service.buildRatingUpdates(participants, users, 'A', mvps, getBattleResultForTeam)
+
+      const userA = updates.find(u => u.userId === 'user-a')
+      const userB = updates.find(u => u.userId === 'user-b')
+      const userC = updates.find(u => u.userId === 'user-c')
+      const userD = updates.find(u => u.userId === 'user-d')
+
+      expect(userA?.mvpBonus).toBe(10) // 1위
+      expect(userB?.mvpBonus).toBe(5) // 2위
+      expect(userC?.mvpBonus).toBe(3) // 3위
+      expect(userD?.mvpBonus).toBe(0) // 4위 - 보너스 없음
+    })
+
+    it('getBattleResultForTeam이 null을 반환하면 업데이트하지 않는다', () => {
+      const participants = new Map([['user-a', BATTLE_TEAM.A]])
+
+      const users = [{ id: 'user-a', rating: 100, tier: 'BRONZE' }]
+
+      const getBattleResultForTeam = (): 'WIN' | 'LOSE' | 'DRAW' | null => null
+
+      const updates = service.buildRatingUpdates(participants, users, 'A', [], getBattleResultForTeam)
+
+      expect(updates.length).toBe(0)
+    })
   })
 })

--- a/backend/src/battles/domains/services/battleTimeline/battleTimeline.service.spec.ts
+++ b/backend/src/battles/domains/services/battleTimeline/battleTimeline.service.spec.ts
@@ -1,0 +1,111 @@
+import { BattleTimelineService } from './battleTimeline.service'
+import type { ActiveBattleState, BattleDiscussion } from '../../models/types/battle.types'
+
+describe('BattleTimelineService', () => {
+  let service: BattleTimelineService
+
+  beforeEach(() => {
+    service = new BattleTimelineService()
+  })
+
+  const createDiscussion = (overrides: Partial<BattleDiscussion> = {}): BattleDiscussion => ({
+    discussionId: 'disc-1',
+    author: { authorId: 'user-1', nickname: '테스터' },
+    team: 'A',
+    content: '이의제기 내용',
+    upvotes: 5,
+    selectedAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  })
+
+  const createState = (attacks: (BattleDiscussion | null)[] = [], defenses: (BattleDiscussion | null)[] = []): ActiveBattleState =>
+    ({
+      all: { attacks, defenses },
+    }) as unknown as ActiveBattleState
+
+  describe('buildTimeline', () => {
+    it('빈 상태에서 빈 타임라인을 반환한다', () => {
+      const state = createState([], [])
+      const result = service.buildTimeline(state)
+      expect(result).toEqual([])
+    })
+
+    it('공격 토론을 타임라인 아이템으로 변환한다', () => {
+      const attack = createDiscussion({ discussionId: 'atk-1', team: 'A' })
+      const state = createState([attack], [])
+      const result = service.buildTimeline(state)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        id: 'atk-1',
+        type: 'ATTACK',
+        author: { id: 'user-1', nickname: '테스터' },
+        team: 'A',
+        content: '이의제기 내용',
+        turn: 1,
+        upvotes: 5,
+      })
+    })
+
+    it('방어 토론을 타임라인 아이템으로 변환한다', () => {
+      const defense = createDiscussion({ discussionId: 'def-1', team: 'B' })
+      const state = createState([], [defense])
+      const result = service.buildTimeline(state)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        id: 'def-1',
+        type: 'DEFENSE',
+        team: 'B',
+      })
+    })
+
+    it('null 토론은 필터링한다', () => {
+      const attack = createDiscussion({ discussionId: 'atk-1' })
+      const state = createState([null, attack, null], [null])
+      const result = service.buildTimeline(state)
+
+      expect(result).toHaveLength(1)
+    })
+
+    it('생성시간 기준으로 정렬한다', () => {
+      const attack = createDiscussion({ discussionId: 'atk-1', selectedAt: '2025-01-01T00:01:00.000Z' })
+      const defense = createDiscussion({ discussionId: 'def-1', selectedAt: '2025-01-01T00:00:30.000Z' })
+      const state = createState([attack], [defense])
+      const result = service.buildTimeline(state)
+
+      expect(result[0].id).toBe('def-1')
+      expect(result[1].id).toBe('atk-1')
+    })
+
+    it('turn 번호를 인덱스 기반으로 계산한다', () => {
+      const atk1 = createDiscussion({ discussionId: 'atk-1', selectedAt: '2025-01-01T00:00:00.000Z' })
+      const atk2 = createDiscussion({ discussionId: 'atk-2', selectedAt: '2025-01-01T00:01:00.000Z' })
+      const atk3 = createDiscussion({ discussionId: 'atk-3', selectedAt: '2025-01-01T00:02:00.000Z' })
+      const state = createState([atk1, atk2, atk3], [])
+      const result = service.buildTimeline(state)
+
+      expect(result[0].turn).toBe(1) // index 0: floor(0/2)+1
+      expect(result[1].turn).toBe(1) // index 1: floor(1/2)+1
+      expect(result[2].turn).toBe(2) // index 2: floor(2/2)+1
+    })
+  })
+
+  describe('toTimeline', () => {
+    it('배열이 아닌 값은 빈 배열을 반환한다', () => {
+      expect(service.toTimeline(null)).toEqual([])
+      expect(service.toTimeline(undefined)).toEqual([])
+      expect(service.toTimeline('string')).toEqual([])
+      expect(service.toTimeline(123)).toEqual([])
+    })
+
+    it('배열은 그대로 반환한다', () => {
+      const timeline = [{ id: '1', type: 'ATTACK' }]
+      expect(service.toTimeline(timeline)).toEqual(timeline)
+    })
+
+    it('빈 배열은 빈 배열을 반환한다', () => {
+      expect(service.toTimeline([])).toEqual([])
+    })
+  })
+})

--- a/backend/src/battles/domains/services/battleVote/battleVote.service.spec.ts
+++ b/backend/src/battles/domains/services/battleVote/battleVote.service.spec.ts
@@ -1,111 +1,197 @@
-import { Test, TestingModule } from '@nestjs/testing'
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common'
 import { BattleVoteService } from './battleVote.service'
-import { ActiveBattleState } from '../../models/types/battle.types'
-import { BATTLE_PHASE, BATTLE_TEAM, BATTLE_DISCUSSION_TYPE } from '../../models/const/battles.const'
+import { BATTLE_TEAM } from '../../models/const/battles.const'
+import type { ActiveBattleState, BattleDiscussion, BattleTeam } from '../../models/types/battle.types'
 
 describe('BattleVoteService', () => {
   let service: BattleVoteService
 
-  const createActiveState = (overrides: Partial<ActiveBattleState> = {}): ActiveBattleState => ({
-    battleId: 'battle-1',
-    all: { roomId: 'battle:battle-1', chats: [], attacks: [], defenses: [] },
-    teamA: { roomId: 'battle:battle-1:A', chats: [], users: [], attacks: [], defenses: [] },
-    teamB: { roomId: 'battle:battle-1:B', chats: [], users: [], attacks: [], defenses: [] },
-    phase: BATTLE_PHASE.ATTACK.name,
-    participants: new Map(),
-    teamVotes: new Map(),
-    userInfoMap: new Map(),
-    opinionHistory: [],
-    skipState: new Set(),
-    round: 1,
-    topics: [],
-    totalRounds: 1,
-    phaseCount: 1,
-    startedAt: null,
-    expiredAt: null,
-    ...overrides,
+  beforeEach(() => {
+    service = new BattleVoteService()
   })
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [BattleVoteService],
-    }).compile()
+  const createDiscussion = (id: string, votes: string[] = [], upvotes = 0, team: BattleTeam = BATTLE_TEAM.A): BattleDiscussion =>
+    ({
+      discussionId: id,
+      author: { authorId: 'author-1', nickname: '작성자' },
+      type: 'ATTACK',
+      content: '내용',
+      upvotes,
+      votes,
+      status: 'PENDING',
+      team,
+    }) as BattleDiscussion
 
-    service = module.get(BattleVoteService)
-  })
+  const createState = (teamAAttacks: (BattleDiscussion | null)[] = [], teamBAttacks: (BattleDiscussion | null)[] = []): ActiveBattleState =>
+    ({
+      battleId: 'battle-1',
+      teamA: { attacks: teamAAttacks, defenses: [], users: ['user-1', 'user-2'] },
+      teamB: { attacks: teamBAttacks, defenses: [], users: ['user-3'] },
+      all: { attacks: [], defenses: [] },
+      opinionHistory: [...teamAAttacks.filter(Boolean), ...teamBAttacks.filter(Boolean)] as BattleDiscussion[],
+    }) as unknown as ActiveBattleState
 
   describe('applyAttackVote', () => {
-    let state: ActiveBattleState
+    it('공격 의견에 투표한다', () => {
+      const d1 = createDiscussion('d-1')
+      const state = createState([d1])
+      const canVote = jest.fn().mockReturnValue(true)
 
-    beforeEach(() => {
-      state = createActiveState({ battleId: 'battle-1' })
-      state.phase = BATTLE_PHASE.ATTACK.name
+      const result = service.applyAttackVote(state, 'd-1', 'user-1', BATTLE_TEAM.A, canVote)
 
-      const attack = {
-        discussionId: 'attack-1',
-        author: { authorId: 'user-a', nickname: 'UserA' },
-        type: BATTLE_DISCUSSION_TYPE.ATTACK,
-        content: 'attack!',
-        upvotes: 0,
-        votes: [],
-        status: 'PENDING' as const,
-        team: BATTLE_TEAM.A,
-      }
-      state.teamA.attacks.push(attack)
-      state.opinionHistory.push(attack)
-    })
-
-    it('case', () => {
-      const attack = state.teamA.attacks[0]!
-
-      const result = service.applyAttackVote(
-        state,
-        attack.discussionId,
-        'voter-1',
-        BATTLE_TEAM.A,
-        () => true, // canVote
-      )
       expect(result).toHaveLength(1)
-      expect(result[0]).toEqual(
-        expect.objectContaining({
-          discussionId: attack.discussionId,
-          upvotes: 1,
-          votes: ['voter-1'],
-        }),
-      )
+      expect(result[0].upvotes).toBe(1)
     })
 
-    it('case', () => {
-      const attack = state.teamA.attacks[0]!
+    it('NONE 팀은 ForbiddenException을 던진다', () => {
+      const state = createState()
+      const canVote = jest.fn().mockReturnValue(true)
 
-      service.applyAttackVote(state, attack.discussionId, 'voter-1', BATTLE_TEAM.A, () => true)
-
-      expect(() => {
-        service.applyAttackVote(state, attack.discussionId, 'voter-1', BATTLE_TEAM.A, () => true)
-      }).toThrow(BadRequestException)
+      expect(() => service.applyAttackVote(state, 'd-1', 'user-1', BATTLE_TEAM.NONE, canVote)).toThrow(ForbiddenException)
     })
 
-    it('case', () => {
-      const attack = state.teamA.attacks[0]!
+    it('투표 불가 단계에서는 BadRequestException을 던진다', () => {
+      const d1 = createDiscussion('d-1')
+      const state = createState([d1])
+      const canVote = jest.fn().mockReturnValue(false)
 
-      expect(() => {
-        service.applyAttackVote(state, attack.discussionId, 'neutral', BATTLE_TEAM.NONE, () => true)
-      }).toThrow(ForbiddenException)
+      expect(() => service.applyAttackVote(state, 'd-1', 'user-1', BATTLE_TEAM.A, canVote)).toThrow(BadRequestException)
     })
 
-    it('case', () => {
-      const attack = state.teamA.attacks[0]!
+    it('존재하지 않는 의견에 투표하면 NotFoundException을 던진다', () => {
+      const state = createState([createDiscussion('d-1')])
+      const canVote = jest.fn().mockReturnValue(true)
 
-      expect(() => {
-        service.applyDefenseVote(state, attack.discussionId, 'user', BATTLE_TEAM.A, () => false)
-      }).toThrow(BadRequestException)
+      expect(() => service.applyAttackVote(state, 'nonexistent', 'user-1', BATTLE_TEAM.A, canVote)).toThrow(NotFoundException)
     })
 
-    it('case', () => {
-      expect(() => {
-        service.applyAttackVote(state, 'invalid-id', 'user', BATTLE_TEAM.A, () => true)
-      }).toThrow(NotFoundException)
+    it('이미 투표한 의견에 다시 투표하면 BadRequestException을 던진다', () => {
+      const d1 = createDiscussion('d-1', ['user-1'], 1)
+      const state = createState([d1])
+      const canVote = jest.fn().mockReturnValue(true)
+
+      expect(() => service.applyAttackVote(state, 'd-1', 'user-1', BATTLE_TEAM.A, canVote)).toThrow(BadRequestException)
+    })
+
+    it('다른 의견에 투표한 기록이 있으면 이전 투표를 취소한다', () => {
+      const d1 = createDiscussion('d-1', ['user-1'], 1)
+      const d2 = createDiscussion('d-2')
+      const state = createState([d1, d2])
+      const canVote = jest.fn().mockReturnValue(true)
+
+      const result = service.applyAttackVote(state, 'd-2', 'user-1', BATTLE_TEAM.A, canVote)
+
+      expect(result).toHaveLength(2)
+      const canceledDto = result.find(r => r.discussionId === 'd-1')
+      const votedDto = result.find(r => r.discussionId === 'd-2')
+      expect(canceledDto!.upvotes).toBe(0)
+      expect(votedDto!.upvotes).toBe(1)
+    })
+
+    it('팀B 공격에도 투표할 수 있다', () => {
+      const d1 = createDiscussion('d-1', [], 0, BATTLE_TEAM.B)
+      const state = createState([], [d1])
+      const canVote = jest.fn().mockReturnValue(true)
+
+      const result = service.applyAttackVote(state, 'd-1', 'user-3', BATTLE_TEAM.B, canVote)
+      expect(result).toHaveLength(1)
+      expect(result[0].upvotes).toBe(1)
+    })
+  })
+
+  describe('applyDefenseVote', () => {
+    it('반론 의견에 투표한다', () => {
+      const d1 = createDiscussion('d-1', [], 0, BATTLE_TEAM.A)
+      const state = {
+        ...createState(),
+        teamA: { attacks: [], defenses: [d1], users: ['user-1'] },
+        teamB: { attacks: [], defenses: [], users: [] },
+        opinionHistory: [d1],
+      } as unknown as ActiveBattleState
+      const canVote = jest.fn().mockReturnValue(true)
+
+      const result = service.applyDefenseVote(state, 'd-1', 'user-1', BATTLE_TEAM.A, canVote)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].upvotes).toBe(1)
+    })
+
+    it('NONE 팀은 ForbiddenException을 던진다', () => {
+      const state = createState()
+      const canVote = jest.fn().mockReturnValue(true)
+
+      expect(() => service.applyDefenseVote(state, 'd-1', 'user-1', BATTLE_TEAM.NONE, canVote)).toThrow(ForbiddenException)
+    })
+
+    it('투표 불가 단계에서는 BadRequestException을 던진다', () => {
+      const d1 = createDiscussion('d-1')
+      const state = {
+        ...createState(),
+        teamA: { attacks: [], defenses: [d1], users: ['user-1'] },
+      } as unknown as ActiveBattleState
+      const canVote = jest.fn().mockReturnValue(false)
+
+      expect(() => service.applyDefenseVote(state, 'd-1', 'user-1', BATTLE_TEAM.A, canVote)).toThrow(BadRequestException)
+    })
+  })
+
+  describe('buildAttackedResult', () => {
+    it('각 팀의 최고 득표 공격을 선정한다', () => {
+      const d1 = createDiscussion('d-1', ['user-1', 'user-2'], 2, BATTLE_TEAM.A)
+      const d2 = createDiscussion('d-2', ['user-1'], 1, BATTLE_TEAM.A)
+      const d3 = createDiscussion('d-3', ['user-3'], 1, BATTLE_TEAM.B)
+      const state = createState([d1, d2], [d3])
+      const createNullPlaceholder = jest.fn().mockReturnValue(createDiscussion('null-placeholder'))
+
+      const result = service.buildAttackedResult(state, createNullPlaceholder)
+
+      expect(result.aTeam).not.toBeNull()
+      expect(result.aTeam!.discussionId).toBe('d-1')
+      expect(result.aTeam!.status).toBe('SELECTED')
+      expect(result.bTeam).not.toBeNull()
+    })
+
+    it('투표가 없으면 null을 반환하고 placeholder를 사용한다', () => {
+      const d1 = createDiscussion('d-1', [], 0, BATTLE_TEAM.A)
+      const state = createState([d1], [])
+      const placeholder = createDiscussion('null', [], 0, BATTLE_TEAM.A)
+      const createNullPlaceholder = jest.fn().mockReturnValue(placeholder)
+
+      const result = service.buildAttackedResult(state, createNullPlaceholder)
+
+      expect(result.aTeam).toBeNull()
+      expect(createNullPlaceholder).toHaveBeenCalled()
+      expect(state.all.attacks).toHaveLength(2)
+    })
+
+    it('의견이 아예 없으면 null placeholder를 사용한다', () => {
+      const state = createState([], [])
+      const placeholder = createDiscussion('null')
+      const createNullPlaceholder = jest.fn().mockReturnValue(placeholder)
+
+      const result = service.buildAttackedResult(state, createNullPlaceholder)
+
+      expect(result.aTeam).toBeNull()
+      expect(result.bTeam).toBeNull()
+    })
+  })
+
+  describe('buildDefensedResult', () => {
+    it('각 팀의 최고 득표 반론을 선정한다', () => {
+      const d1 = createDiscussion('d-1', ['user-1'], 1, BATTLE_TEAM.A)
+      const state = {
+        ...createState(),
+        battleId: 'battle-1',
+        teamA: { attacks: [], defenses: [d1], users: ['user-1'] },
+        teamB: { attacks: [], defenses: [], users: [] },
+        all: { attacks: [], defenses: [] },
+      } as unknown as ActiveBattleState
+      const createNullPlaceholder = jest.fn().mockReturnValue(createDiscussion('null'))
+
+      const result = service.buildDefensedResult(state, createNullPlaceholder)
+
+      expect(result.aTeam).not.toBeNull()
+      expect(result.aTeam!.status).toBe('SELECTED')
     })
   })
 })

--- a/backend/src/battles/domains/services/utils/battle.util.spec.ts
+++ b/backend/src/battles/domains/services/utils/battle.util.spec.ts
@@ -1,0 +1,45 @@
+import { getBattleRoomId, shuffleTopics } from './battle.util'
+import { BadRequestException } from '@nestjs/common'
+
+describe('Battle Utils', () => {
+  describe('getBattleRoomId', () => {
+    it('팀이 없으면 전체 룸 ID를 반환한다', () => {
+      expect(getBattleRoomId('battle-123')).toBe('battle:battle-123')
+    })
+
+    it('팀이 있으면 팀별 룸 ID를 반환한다', () => {
+      expect(getBattleRoomId('battle-123', 'A')).toBe('battle:battle-123:A')
+      expect(getBattleRoomId('battle-123', 'B')).toBe('battle:battle-123:B')
+    })
+  })
+
+  describe('shuffleTopics', () => {
+    it('FIFTEEN_MIN일 때 주제 1개를 그대로 반환한다', () => {
+      const result = shuffleTopics(['주제1'], 'FIFTEEN_MIN')
+      expect(result).toEqual(['주제1'])
+    })
+
+    it('THIRTY_MIN일 때 주제 2개를 셔플하여 반환한다', () => {
+      const topics = ['주제1', '주제2']
+      const result = shuffleTopics(topics, 'THIRTY_MIN')
+      expect(result).toHaveLength(2)
+      expect(result.sort()).toEqual(topics.sort())
+    })
+
+    it('원본 배열을 변경하지 않는다', () => {
+      const topics = ['주제1', '주제2']
+      const original = [...topics]
+      shuffleTopics(topics, 'THIRTY_MIN')
+      expect(topics).toEqual(original)
+    })
+
+    it('올바르지 않은 playTime이면 BadRequestException을 던진다', () => {
+      expect(() => shuffleTopics(['주제1'], 'INVALID')).toThrow(BadRequestException)
+    })
+
+    it('주제 수가 라운드 수와 일치하지 않으면 BadRequestException을 던진다', () => {
+      expect(() => shuffleTopics(['주제1', '주제2'], 'FIFTEEN_MIN')).toThrow(BadRequestException)
+      expect(() => shuffleTopics(['주제1'], 'THIRTY_MIN')).toThrow(BadRequestException)
+    })
+  })
+})

--- a/backend/src/battles/domains/services/utils/nickname.util.spec.ts
+++ b/backend/src/battles/domains/services/utils/nickname.util.spec.ts
@@ -1,0 +1,50 @@
+import { generateNickname, isGuestNicknamePattern } from './nickname.util'
+
+describe('Nickname Utils', () => {
+  describe('generateNickname', () => {
+    it('문자열을 반환한다', () => {
+      const nickname = generateNickname()
+      expect(typeof nickname).toBe('string')
+      expect(nickname.length).toBeGreaterThan(0)
+    })
+
+    it('8자 이하의 닉네임을 반환한다', () => {
+      for (let i = 0; i < 100; i++) {
+        const nickname = generateNickname()
+        expect(nickname.length).toBeLessThanOrEqual(8)
+      }
+    })
+
+    it('공백으로 구분된 형식을 가진다', () => {
+      for (let i = 0; i < 50; i++) {
+        const nickname = generateNickname()
+        expect(nickname).toContain(' ')
+      }
+    })
+  })
+
+  describe('isGuestNicknamePattern', () => {
+    it('공백이 포함된 닉네임은 게스트 패턴으로 판단한다', () => {
+      expect(isGuestNicknamePattern('귀여운 레오')).toBe(true)
+      expect(isGuestNicknamePattern('아무 이름')).toBe(true)
+    })
+
+    it('형용사+명사 조합이 포함되면 게스트 패턴으로 판단한다', () => {
+      expect(isGuestNicknamePattern('귀여운레오')).toBe(true)
+      expect(isGuestNicknamePattern('멋진스티브')).toBe(true)
+    })
+
+    it('형용사만 포함된 경우 게스트 패턴이 아니다', () => {
+      expect(isGuestNicknamePattern('귀여운사람')).toBe(false)
+    })
+
+    it('명사만 포함된 경우 게스트 패턴이 아니다', () => {
+      expect(isGuestNicknamePattern('레오짱')).toBe(false)
+    })
+
+    it('관련 없는 닉네임은 게스트 패턴이 아니다', () => {
+      expect(isGuestNicknamePattern('홍길동')).toBe(false)
+      expect(isGuestNicknamePattern('TestUser')).toBe(false)
+    })
+  })
+})

--- a/backend/src/battles/domains/services/utils/rating.util.spec.ts
+++ b/backend/src/battles/domains/services/utils/rating.util.spec.ts
@@ -1,0 +1,90 @@
+import { coerceTierName, getTierFromRating, getWinDrawMultiplier, calculateRatingDelta, getMvpBonus } from './rating.util'
+
+describe('Rating Utils', () => {
+  describe('coerceTierName', () => {
+    it('유효한 티어 이름을 그대로 반환한다', () => {
+      expect(coerceTierName('BRONZE')).toBe('BRONZE')
+      expect(coerceTierName('SILVER')).toBe('SILVER')
+      expect(coerceTierName('GOLD')).toBe('GOLD')
+      expect(coerceTierName('DIAMOND')).toBe('DIAMOND')
+      expect(coerceTierName('MASTER')).toBe('MASTER')
+      expect(coerceTierName('GRANDMASTER')).toBe('GRANDMASTER')
+    })
+
+    it('유효하지 않은 티어 이름은 BRONZE를 반환한다', () => {
+      expect(coerceTierName('INVALID')).toBe('BRONZE')
+      expect(coerceTierName('')).toBe('BRONZE')
+    })
+
+    it('null이나 undefined는 BRONZE를 반환한다', () => {
+      expect(coerceTierName(null)).toBe('BRONZE')
+      expect(coerceTierName(undefined)).toBe('BRONZE')
+    })
+  })
+
+  describe('getTierFromRating', () => {
+    it('레이팅 구간에 따라 올바른 티어를 반환한다', () => {
+      expect(getTierFromRating(0)).toBe('BRONZE')
+      expect(getTierFromRating(100)).toBe('BRONZE')
+      expect(getTierFromRating(199)).toBe('BRONZE')
+      expect(getTierFromRating(200)).toBe('SILVER')
+      expect(getTierFromRating(400)).toBe('GOLD')
+      expect(getTierFromRating(600)).toBe('DIAMOND')
+      expect(getTierFromRating(800)).toBe('MASTER')
+      expect(getTierFromRating(1000)).toBe('GRANDMASTER')
+    })
+
+    it('최대 티어를 초과하는 레이팅도 GRANDMASTER를 반환한다', () => {
+      expect(getTierFromRating(5000)).toBe('GRANDMASTER')
+    })
+
+    it('음수 레이팅은 BRONZE를 반환한다', () => {
+      expect(getTierFromRating(-100)).toBe('BRONZE')
+    })
+  })
+
+  describe('getWinDrawMultiplier', () => {
+    it('티어별 배수를 올바르게 반환한다', () => {
+      expect(getWinDrawMultiplier('BRONZE')).toBe(2.0)
+      expect(getWinDrawMultiplier('SILVER')).toBe(1.5)
+      expect(getWinDrawMultiplier('GOLD')).toBe(1.2)
+      expect(getWinDrawMultiplier('DIAMOND')).toBe(1.0)
+      expect(getWinDrawMultiplier('MASTER')).toBe(1.0)
+      expect(getWinDrawMultiplier('GRANDMASTER')).toBe(1.0)
+    })
+  })
+
+  describe('calculateRatingDelta', () => {
+    it('승리 시 티어 배수가 적용된 레이팅 변화량을 반환한다', () => {
+      expect(calculateRatingDelta('WIN', 'BRONZE')).toBe(30) // 15 * 2.0
+      expect(calculateRatingDelta('WIN', 'SILVER')).toBe(23) // Math.round(15 * 1.5)
+      expect(calculateRatingDelta('WIN', 'GOLD')).toBe(18) // Math.round(15 * 1.2)
+      expect(calculateRatingDelta('WIN', 'DIAMOND')).toBe(15) // 15 * 1.0
+    })
+
+    it('무승부 시 티어 배수가 적용된 레이팅 변화량을 반환한다', () => {
+      expect(calculateRatingDelta('DRAW', 'BRONZE')).toBe(10) // 5 * 2.0
+      expect(calculateRatingDelta('DRAW', 'SILVER')).toBe(8) // Math.round(5 * 1.5)
+      expect(calculateRatingDelta('DRAW', 'GOLD')).toBe(6) // Math.round(5 * 1.2)
+    })
+
+    it('패배 시 티어와 무관하게 고정 레이팅을 차감한다', () => {
+      expect(calculateRatingDelta('LOSE', 'BRONZE')).toBe(-10)
+      expect(calculateRatingDelta('LOSE', 'SILVER')).toBe(-10)
+      expect(calculateRatingDelta('LOSE', 'GRANDMASTER')).toBe(-10)
+    })
+  })
+
+  describe('getMvpBonus', () => {
+    it('순위별 MVP 보너스를 반환한다', () => {
+      expect(getMvpBonus(0)).toBe(10) // 1등
+      expect(getMvpBonus(1)).toBe(5) // 2등
+      expect(getMvpBonus(2)).toBe(3) // 3등
+    })
+
+    it('순위 범위 밖이면 0을 반환한다', () => {
+      expect(getMvpBonus(3)).toBe(0)
+      expect(getMvpBonus(100)).toBe(0)
+    })
+  })
+})

--- a/backend/src/battles/dto/battleResult.dto.spec.ts
+++ b/backend/src/battles/dto/battleResult.dto.spec.ts
@@ -1,0 +1,356 @@
+import { BattleResultResponseDto } from './battleResult.dto'
+import { FinishedBattleState } from '../domains/models/types/battle.types'
+import { BattleResult, Metrics, VoteTimeline, TimelineItem, Mvp } from '../domains/models/types/battleResult.types'
+import { type Battle as PrismaBattle } from 'generated/prisma/client'
+
+describe('BattleResultResponseDto', () => {
+  const mockResult: BattleResult = {
+    winner: 'A',
+    teamA: { votes: 5, percentage: 50 },
+    teamB: { votes: 3, percentage: 30 },
+    neutral: { votes: 2, percentage: 20 },
+  }
+
+  const mockMetrics: Metrics = {
+    totalParticipants: 10,
+    totalViews: 15,
+    strategiesCount: 5,
+    totalChats: 100,
+  }
+
+  const mockVoteTimeline: VoteTimeline[] = [
+    { turn: 1, teamAVotes: 3, teamBVotes: 2, neutralVotes: 5, timestamp: '2024-01-01T00:00:00.000Z' },
+    { turn: 2, teamAVotes: 5, teamBVotes: 3, neutralVotes: 2, timestamp: '2024-01-01T00:10:00.000Z' },
+  ]
+
+  const mockTimeline: TimelineItem[] = [
+    {
+      id: 'timeline-1',
+      type: 'ATTACK',
+      author: { id: 'user-1', nickname: 'User1' },
+      team: 'A',
+      content: 'Attack content',
+      turn: 1,
+      upvotes: 5,
+      createdAt: '2024-01-01T00:05:00.000Z',
+    },
+    {
+      id: 'timeline-2',
+      type: 'DEFENSE',
+      author: { id: 'user-2', nickname: 'User2' },
+      team: 'B',
+      content: 'Defense content',
+      turn: 1,
+      upvotes: 3,
+      createdAt: '2024-01-01T00:06:00.000Z',
+    },
+  ]
+
+  const mockMvps: Mvp[] = [
+    {
+      userId: 'mvp-1',
+      nickname: 'MVP1',
+      team: 'A',
+      score: 100,
+      totalVotes: 10,
+      opinionCount: 5,
+      selectedOpinionCount: 3,
+      joinedAt: 1704067200000,
+    },
+    {
+      userId: 'mvp-2',
+      nickname: 'MVP2',
+      team: 'B',
+      score: 80,
+      totalVotes: 8,
+      opinionCount: 4,
+      selectedOpinionCount: 2,
+      joinedAt: 1704067200000,
+    },
+  ]
+
+  describe('fromEntity', () => {
+    const mockFinishedBattleState: FinishedBattleState = {
+      battleId: 'battle-123',
+      authorId: 'author-123',
+      title: 'Test Battle',
+      description: 'Test Description',
+      status: 'CLOSED',
+      language: 'TS',
+      category: 'ALGORITHM',
+      playTime: 15,
+      topics: ['topic1', 'topic2'],
+      createdAt: '2024-01-01T00:00:00.000Z',
+      finishedAt: '2024-01-01T00:15:00.000Z',
+      codeA: 'const a = 1;',
+      codeB: 'const b = 2;',
+      result: mockResult,
+      metrics: mockMetrics,
+      voteTimeline: mockVoteTimeline,
+      timeline: mockTimeline,
+      mvps: mockMvps,
+    }
+
+    it('모든 필드가 올바르게 매핑된 DTO를 생성해야 한다', () => {
+      const dto = BattleResultResponseDto.fromEntity(mockFinishedBattleState)
+
+      expect(dto.battleId).toBe('battle-123')
+      expect(dto.authorId).toBe('author-123')
+      expect(dto.title).toBe('Test Battle')
+      expect(dto.description).toBe('Test Description')
+      expect(dto.status).toBe('CLOSED')
+      expect(dto.language).toBe('TS')
+      expect(dto.category).toBe('ALGORITHM')
+      expect(dto.playTime).toBe(15)
+      expect(dto.topics).toEqual(['topic1', 'topic2'])
+      expect(dto.createdAt).toBe('2024-01-01T00:00:00.000Z')
+      expect(dto.finishedAt).toBe('2024-01-01T00:15:00.000Z')
+      expect(dto.codeA).toBe('const a = 1;')
+      expect(dto.codeB).toBe('const b = 2;')
+    })
+
+    it('result를 올바르게 매핑해야 한다', () => {
+      const dto = BattleResultResponseDto.fromEntity(mockFinishedBattleState)
+
+      expect(dto.result).toEqual(mockResult)
+      expect(dto.result.winner).toBe('A')
+      expect(dto.result.teamA.votes).toBe(5)
+      expect(dto.result.teamB.votes).toBe(3)
+      expect(dto.result.neutral.votes).toBe(2)
+    })
+
+    it('metrics를 올바르게 매핑해야 한다', () => {
+      const dto = BattleResultResponseDto.fromEntity(mockFinishedBattleState)
+
+      expect(dto.metrics).toEqual(mockMetrics)
+      expect(dto.metrics.totalParticipants).toBe(10)
+      expect(dto.metrics.totalViews).toBe(15)
+      expect(dto.metrics.strategiesCount).toBe(5)
+      expect(dto.metrics.totalChats).toBe(100)
+    })
+
+    it('voteTimeline 배열을 올바르게 매핑해야 한다', () => {
+      const dto = BattleResultResponseDto.fromEntity(mockFinishedBattleState)
+
+      expect(dto.voteTimeline).toEqual(mockVoteTimeline)
+      expect(dto.voteTimeline).toHaveLength(2)
+      expect(dto.voteTimeline[0].turn).toBe(1)
+      expect(dto.voteTimeline[1].turn).toBe(2)
+    })
+
+    it('timeline 아이템들을 올바르게 매핑해야 한다', () => {
+      const dto = BattleResultResponseDto.fromEntity(mockFinishedBattleState)
+
+      expect(dto.timeline).toEqual(mockTimeline)
+      expect(dto.timeline).toHaveLength(2)
+      expect(dto.timeline[0].type).toBe('ATTACK')
+      expect(dto.timeline[1].type).toBe('DEFENSE')
+    })
+
+    it('mvps를 올바르게 매핑해야 한다', () => {
+      const dto = BattleResultResponseDto.fromEntity(mockFinishedBattleState)
+
+      expect(dto.mvps).toEqual(mockMvps)
+      expect(dto.mvps).toHaveLength(2)
+      expect(dto.mvps[0].nickname).toBe('MVP1')
+      expect(dto.mvps[1].nickname).toBe('MVP2')
+    })
+
+    it('DRAW 승자를 올바르게 처리해야 한다', () => {
+      const drawState: FinishedBattleState = {
+        ...mockFinishedBattleState,
+        result: {
+          winner: 'DRAW',
+          teamA: { votes: 5, percentage: 50 },
+          teamB: { votes: 5, percentage: 50 },
+          neutral: { votes: 0, percentage: 0 },
+        },
+      }
+
+      const dto = BattleResultResponseDto.fromEntity(drawState)
+
+      expect(dto.result.winner).toBe('DRAW')
+    })
+
+    it('B팀 승리를 올바르게 처리해야 한다', () => {
+      const bWinnerState: FinishedBattleState = {
+        ...mockFinishedBattleState,
+        result: {
+          winner: 'B',
+          teamA: { votes: 3, percentage: 30 },
+          teamB: { votes: 7, percentage: 70 },
+          neutral: { votes: 0, percentage: 0 },
+        },
+      }
+
+      const dto = BattleResultResponseDto.fromEntity(bWinnerState)
+
+      expect(dto.result.winner).toBe('B')
+    })
+
+    it('빈 배열들을 올바르게 처리해야 한다', () => {
+      const emptyState: FinishedBattleState = {
+        ...mockFinishedBattleState,
+        topics: [],
+        voteTimeline: [],
+        timeline: [],
+        mvps: [],
+      }
+
+      const dto = BattleResultResponseDto.fromEntity(emptyState)
+
+      expect(dto.topics).toEqual([])
+      expect(dto.voteTimeline).toEqual([])
+      expect(dto.timeline).toEqual([])
+      expect(dto.mvps).toEqual([])
+    })
+  })
+
+  describe('fromPrismaBattle', () => {
+    const now = new Date('2024-01-01T00:00:00.000Z')
+    const finishedAt = new Date('2024-01-01T00:15:00.000Z')
+
+    const mockPrismaBattle: PrismaBattle = {
+      id: 'prisma-battle-123',
+      userId: 'prisma-user-123',
+      title: 'Prisma Battle',
+      description: 'Prisma Description',
+      codeA: 'const prismaA = 1;',
+      codeB: 'const prismaB = 2;',
+      language: 'TS',
+      category: 'REFACTORING',
+      type: 'PUBLIC',
+      playTime: 'FIFTEEN_MIN',
+      topics: ['prisma-topic1', 'prisma-topic2'],
+      status: 'CLOSED',
+      inviteCode: 'invite123',
+      teamACount: 5,
+      teamBCount: 3,
+      totalParticipantsCount: 10,
+      referenceData: null,
+      createdAt: now,
+      updatedAt: now,
+      finishedAt: finishedAt,
+    }
+
+    it('Prisma 배틀에서 모든 필드가 포함된 DTO를 생성해야 한다', () => {
+      const dto = BattleResultResponseDto.fromPrismaBattle(mockPrismaBattle, mockResult, mockTimeline, mockMvps)
+
+      expect(dto.battleId).toBe('prisma-battle-123')
+      expect(dto.authorId).toBe('prisma-user-123')
+      expect(dto.title).toBe('Prisma Battle')
+      expect(dto.description).toBe('Prisma Description')
+      expect(dto.status).toBe('CLOSED')
+      expect(dto.language).toBe('TS')
+      expect(dto.category).toBe('REFACTORING')
+      expect(dto.topics).toEqual(['prisma-topic1', 'prisma-topic2'])
+      expect(dto.codeA).toBe('const prismaA = 1;')
+      expect(dto.codeB).toBe('const prismaB = 2;')
+    })
+
+    it('FIFTEEN_MIN에서 playTime을 올바르게 계산해야 한다', () => {
+      const dto = BattleResultResponseDto.fromPrismaBattle(mockPrismaBattle, mockResult, mockTimeline, mockMvps)
+
+      expect(dto.playTime).toBe(15)
+    })
+
+    it('THIRTY_MIN에서 playTime을 올바르게 계산해야 한다', () => {
+      const thirtyMinBattle: PrismaBattle = {
+        ...mockPrismaBattle,
+        playTime: 'THIRTY_MIN',
+      }
+
+      const dto = BattleResultResponseDto.fromPrismaBattle(thirtyMinBattle, mockResult, mockTimeline, mockMvps)
+
+      expect(dto.playTime).toBe(30)
+    })
+
+    it('finishedAt이 있을 때 해당 값을 사용해야 한다', () => {
+      const dto = BattleResultResponseDto.fromPrismaBattle(mockPrismaBattle, mockResult, mockTimeline, mockMvps)
+
+      expect(dto.finishedAt).toBe(finishedAt.toISOString())
+    })
+
+    it('finishedAt이 null일 때 updatedAt으로 대체해야 한다', () => {
+      const noFinishedAtBattle: PrismaBattle = {
+        ...mockPrismaBattle,
+        finishedAt: null,
+        updatedAt: new Date('2024-01-01T00:20:00.000Z'),
+      }
+
+      const dto = BattleResultResponseDto.fromPrismaBattle(noFinishedAtBattle, mockResult, mockTimeline, mockMvps)
+
+      expect(dto.finishedAt).toBe('2024-01-01T00:20:00.000Z')
+    })
+
+    it('finishedAt과 updatedAt 모두 null일 때 createdAt으로 대체해야 한다', () => {
+      const noFinishedOrUpdatedBattle: PrismaBattle = {
+        ...mockPrismaBattle,
+        finishedAt: null,
+        updatedAt: null,
+      }
+
+      const dto = BattleResultResponseDto.fromPrismaBattle(noFinishedOrUpdatedBattle, mockResult, mockTimeline, mockMvps)
+
+      expect(dto.finishedAt).toBe(now.toISOString())
+    })
+
+    it('metrics를 올바르게 계산해야 한다', () => {
+      const dto = BattleResultResponseDto.fromPrismaBattle(mockPrismaBattle, mockResult, mockTimeline, mockMvps)
+
+      expect(dto.metrics.totalParticipants).toBe(10)
+      expect(dto.metrics.totalViews).toBe(10)
+      expect(dto.metrics.strategiesCount).toBe(2) // timeline 길이
+      expect(dto.metrics.totalChats).toBe(0)
+    })
+
+    it('teamACount와 teamBCount가 null일 때 0으로 처리해야 한다', () => {
+      const nullCountsBattle: PrismaBattle = {
+        ...mockPrismaBattle,
+        teamACount: null,
+        teamBCount: null,
+        totalParticipantsCount: null,
+      }
+
+      const dto = BattleResultResponseDto.fromPrismaBattle(nullCountsBattle, mockResult, mockTimeline, mockMvps)
+
+      expect(dto.metrics.totalParticipants).toBe(0)
+      expect(dto.voteTimeline[0].neutralVotes).toBe(0)
+    })
+
+    it('voteTimeline을 올바르게 생성해야 한다', () => {
+      const dto = BattleResultResponseDto.fromPrismaBattle(mockPrismaBattle, mockResult, mockTimeline, mockMvps)
+
+      expect(dto.voteTimeline).toHaveLength(1)
+      expect(dto.voteTimeline[0].turn).toBe(1)
+      expect(dto.voteTimeline[0].teamAVotes).toBe(5)
+      expect(dto.voteTimeline[0].teamBVotes).toBe(3)
+      expect(dto.voteTimeline[0].neutralVotes).toBe(2) // 10 - 5 - 3
+    })
+
+    it('알 수 없는 playTime을 적절히 처리해야 한다', () => {
+      const unknownPlayTimeBattle: PrismaBattle = {
+        ...mockPrismaBattle,
+        playTime: 'UNKNOWN_TIME' as any,
+      }
+
+      const dto = BattleResultResponseDto.fromPrismaBattle(unknownPlayTimeBattle, mockResult, mockTimeline, mockMvps)
+
+      expect(dto.playTime).toBe(0)
+    })
+
+    it('result, timeline, mvps를 올바르게 매핑해야 한다', () => {
+      const dto = BattleResultResponseDto.fromPrismaBattle(mockPrismaBattle, mockResult, mockTimeline, mockMvps)
+
+      expect(dto.result).toEqual(mockResult)
+      expect(dto.timeline).toEqual(mockTimeline)
+      expect(dto.mvps).toEqual(mockMvps)
+    })
+
+    it('createdAt을 ISO 문자열로 변환해야 한다', () => {
+      const dto = BattleResultResponseDto.fromPrismaBattle(mockPrismaBattle, mockResult, mockTimeline, mockMvps)
+
+      expect(dto.createdAt).toBe(now.toISOString())
+    })
+  })
+})

--- a/backend/src/battles/dto/closedBattleResponse.dto.spec.ts
+++ b/backend/src/battles/dto/closedBattleResponse.dto.spec.ts
@@ -1,0 +1,195 @@
+import { ClosedBattleResponseDto } from './closedBattleResponse.dto'
+import { Battle, FinishedBattleState } from '../domains/models/types/battle.types'
+import { BattleResult } from '../domains/models/types/battleResult.types'
+import { BATTLE_PLAYTIME, BATTLE_CATEGORY, BATTLE_STATUS, BATTLE_LANGUAGE, BATTLE_TYPE } from '../domains/models/const/battles.const'
+
+describe('ClosedBattleResponseDto', () => {
+  const mockResult: BattleResult = {
+    winner: 'A',
+    teamA: { votes: 5, percentage: 50 },
+    teamB: { votes: 3, percentage: 30 },
+    neutral: { votes: 2, percentage: 20 },
+  }
+
+  describe('of', () => {
+    const baseDate = new Date('2024-01-01T00:00:00.000Z')
+
+    const mockBattle: Battle = {
+      id: 'battle-123',
+      authorId: 'author-123',
+      title: 'Test Battle',
+      description: 'Test Description',
+      aCode: 'const a = 1;',
+      bCode: 'const b = 2;',
+      language: BATTLE_LANGUAGE.TS,
+      type: BATTLE_TYPE.PUBLIC,
+      category: BATTLE_CATEGORY.ALGORITHM,
+      playTime: BATTLE_PLAYTIME.FIFTEEN_MIN,
+      topics: ['topic1', 'topic2'],
+      status: BATTLE_STATUS.CLOSED,
+      participantCount: 10,
+      initialState: {
+        round: 1,
+        phase: 'PENDING',
+        phaseCount: 0,
+        timeRemainingSeconds: 0,
+      },
+      createdAt: baseDate,
+      updatedAt: baseDate,
+    }
+
+    it('모든 배틀 필드가 포함된 DTO를 생성해야 한다', () => {
+      const dto = ClosedBattleResponseDto.of(mockBattle, mockResult)
+
+      expect(dto.id).toBe('battle-123')
+      expect(dto.title).toBe('Test Battle')
+      expect(dto.description).toBe('Test Description')
+      expect(dto.category).toBe(BATTLE_CATEGORY.ALGORITHM)
+      expect(dto.status).toBe(BATTLE_STATUS.CLOSED)
+    })
+
+    it('playTime으로부터 expiresAt을 올바르게 계산해야 한다 (FIFTEEN_MIN)', () => {
+      const dto = ClosedBattleResponseDto.of(mockBattle, mockResult)
+
+      // 15분 = 15 * 60 * 1000 = 900000ms
+      const expectedExpiresAt = new Date(baseDate.getTime() + 15 * 60 * 1000)
+      expect(dto.expiresAt).toEqual(expectedExpiresAt)
+    })
+
+    it('THIRTY_MIN playTime에서 expiresAt을 올바르게 계산해야 한다', () => {
+      const thirtyMinBattle: Battle = {
+        ...mockBattle,
+        playTime: BATTLE_PLAYTIME.THIRTY_MIN,
+      }
+
+      const dto = ClosedBattleResponseDto.of(thirtyMinBattle, mockResult)
+
+      // 30분 = 30 * 60 * 1000 = 1800000ms
+      const expectedExpiresAt = new Date(baseDate.getTime() + 30 * 60 * 1000)
+      expect(dto.expiresAt).toEqual(expectedExpiresAt)
+    })
+
+    it('createdAt을 올바르게 설정해야 한다', () => {
+      const dto = ClosedBattleResponseDto.of(mockBattle, mockResult)
+
+      expect(dto.createdAt).toEqual(baseDate)
+    })
+
+    it('result를 올바르게 설정해야 한다', () => {
+      const dto = ClosedBattleResponseDto.of(mockBattle, mockResult)
+
+      expect(dto.result).toEqual(mockResult)
+      expect(dto.result.winner).toBe('A')
+    })
+
+    it('DRAW 결과를 올바르게 처리해야 한다', () => {
+      const drawResult: BattleResult = {
+        winner: 'DRAW',
+        teamA: { votes: 5, percentage: 50 },
+        teamB: { votes: 5, percentage: 50 },
+        neutral: { votes: 0, percentage: 0 },
+      }
+
+      const dto = ClosedBattleResponseDto.of(mockBattle, drawResult)
+
+      expect(dto.result.winner).toBe('DRAW')
+    })
+
+    it('B팀 승리 결과를 올바르게 처리해야 한다', () => {
+      const bWinResult: BattleResult = {
+        winner: 'B',
+        teamA: { votes: 2, percentage: 20 },
+        teamB: { votes: 8, percentage: 80 },
+        neutral: { votes: 0, percentage: 0 },
+      }
+
+      const dto = ClosedBattleResponseDto.of(mockBattle, bWinResult)
+
+      expect(dto.result.winner).toBe('B')
+    })
+
+    it('REFACTORING 카테고리를 올바르게 처리해야 한다', () => {
+      const refactoringBattle: Battle = {
+        ...mockBattle,
+        category: BATTLE_CATEGORY.REFACTORING,
+      }
+
+      const dto = ClosedBattleResponseDto.of(refactoringBattle, mockResult)
+
+      expect(dto.category).toBe(BATTLE_CATEGORY.REFACTORING)
+    })
+  })
+
+  describe('fromFinished', () => {
+    const mockFinishedState: FinishedBattleState = {
+      battleId: 'finished-battle-123',
+      authorId: 'author-123',
+      title: 'Finished Battle',
+      description: 'Finished Description',
+      status: 'CLOSED',
+      language: 'TS',
+      category: 'ALGORITHM',
+      playTime: 15,
+      topics: ['topic1'],
+      createdAt: '2024-01-01T00:00:00.000Z',
+      finishedAt: '2024-01-01T00:15:00.000Z',
+      codeA: 'const a = 1;',
+      codeB: 'const b = 2;',
+      result: mockResult,
+      metrics: { totalParticipants: 10, totalViews: 15, strategiesCount: 5, totalChats: 100 },
+      voteTimeline: [],
+      timeline: [],
+      mvps: [],
+    }
+
+    it('FinishedBattleState에서 DTO를 생성해야 한다', () => {
+      const dto = ClosedBattleResponseDto.fromFinished(mockFinishedState)
+
+      expect(dto.id).toBe('finished-battle-123')
+      expect(dto.title).toBe('Finished Battle')
+      expect(dto.description).toBe('Finished Description')
+      expect(dto.category).toBe('ALGORITHM')
+    })
+
+    it('status를 CLOSED로 설정해야 한다', () => {
+      const dto = ClosedBattleResponseDto.fromFinished(mockFinishedState)
+
+      expect(dto.status).toBe('CLOSED')
+    })
+
+    it('날짜 변환을 올바르게 처리해야 한다', () => {
+      const dto = ClosedBattleResponseDto.fromFinished(mockFinishedState)
+
+      expect(dto.createdAt).toEqual(new Date('2024-01-01T00:00:00.000Z'))
+      expect(dto.expiresAt).toEqual(new Date('2024-01-01T00:15:00.000Z'))
+    })
+
+    it('result를 올바르게 매핑해야 한다', () => {
+      const dto = ClosedBattleResponseDto.fromFinished(mockFinishedState)
+
+      expect(dto.result).toEqual(mockResult)
+    })
+
+    it('다른 카테고리를 올바르게 처리해야 한다', () => {
+      const refactoringState: FinishedBattleState = {
+        ...mockFinishedState,
+        category: 'REFACTORING',
+      }
+
+      const dto = ClosedBattleResponseDto.fromFinished(refactoringState)
+
+      expect(dto.category).toBe('REFACTORING')
+    })
+
+    it('다른 finishedAt 날짜를 올바르게 처리해야 한다', () => {
+      const laterFinishState: FinishedBattleState = {
+        ...mockFinishedState,
+        finishedAt: '2024-01-01T00:30:00.000Z',
+      }
+
+      const dto = ClosedBattleResponseDto.fromFinished(laterFinishState)
+
+      expect(dto.expiresAt).toEqual(new Date('2024-01-01T00:30:00.000Z'))
+    })
+  })
+})

--- a/backend/src/battles/dto/discussionVoteResult.dto.spec.ts
+++ b/backend/src/battles/dto/discussionVoteResult.dto.spec.ts
@@ -1,0 +1,250 @@
+import { DiscussionVoteResultItemDto, DiscussionVoteResultDto } from './discussionVoteResult.dto'
+import { BattleDiscussion, BattleTopOpinions } from '../domains/models/types/battle.types'
+
+describe('DiscussionVoteResultItemDto', () => {
+  const mockDiscussion: BattleDiscussion = {
+    discussionId: 'discussion-123',
+    author: {
+      authorId: 'author-123',
+      nickname: 'TestUser',
+    },
+    type: 'ATTACK',
+    content: 'This is a test attack content',
+    upvotes: 10,
+    votes: ['user1', 'user2'],
+    status: 'SELECTED',
+    team: 'A',
+  }
+
+  describe('fromEntity', () => {
+    it('모든 필드가 올바르게 매핑된 DTO를 생성해야 한다', () => {
+      const dto = DiscussionVoteResultItemDto.fromEntity(mockDiscussion)
+
+      expect(dto.id).toBe('discussion-123')
+      expect(dto.text).toBe('This is a test attack content')
+      expect(dto.ownerId).toBe('author-123')
+      expect(dto.nickname).toBe('TestUser')
+      expect(dto.count).toBe(10)
+      expect(dto.team).toBe('A')
+    })
+
+    it('null인 discussion을 처리해야 한다', () => {
+      const dto = DiscussionVoteResultItemDto.fromEntity(null)
+
+      expect(dto.id).toBeNull()
+      expect(dto.text).toBeNull()
+      expect(dto.ownerId).toBeNull()
+      expect(dto.nickname).toBeNull()
+      expect(dto.count).toBeNull()
+      expect(dto.team).toBeNull()
+    })
+
+    it('author가 없는 discussion을 처리해야 한다', () => {
+      const discussionWithoutAuthor: BattleDiscussion = {
+        ...mockDiscussion,
+        author: undefined as any,
+      }
+
+      const dto = DiscussionVoteResultItemDto.fromEntity(discussionWithoutAuthor)
+
+      expect(dto.ownerId).toBeNull()
+      expect(dto.nickname).toBeNull()
+    })
+
+    it('B팀 discussion을 올바르게 매핑해야 한다', () => {
+      const bTeamDiscussion: BattleDiscussion = {
+        ...mockDiscussion,
+        team: 'B',
+      }
+
+      const dto = DiscussionVoteResultItemDto.fromEntity(bTeamDiscussion)
+
+      expect(dto.team).toBe('B')
+    })
+
+    it('DEFENSE 타입 discussion을 올바르게 매핑해야 한다', () => {
+      const defenseDiscussion: BattleDiscussion = {
+        ...mockDiscussion,
+        type: 'DEFENSE',
+        content: 'Defense content',
+      }
+
+      const dto = DiscussionVoteResultItemDto.fromEntity(defenseDiscussion)
+
+      expect(dto.text).toBe('Defense content')
+    })
+
+    it('upvotes가 0인 경우 null 대신 0을 반환해야 한다', () => {
+      const zeroUpvotesDiscussion: BattleDiscussion = {
+        ...mockDiscussion,
+        upvotes: 0,
+      }
+
+      const dto = DiscussionVoteResultItemDto.fromEntity(zeroUpvotesDiscussion)
+
+      // 0은 falsy이므로 null이 됨 (현재 로직)
+      expect(dto.count).toBeNull()
+    })
+  })
+
+  describe('of', () => {
+    it('fromEntity를 사용해 DTO를 생성해야 한다', () => {
+      const dto = DiscussionVoteResultItemDto.of(mockDiscussion)
+
+      expect(dto.id).toBe('discussion-123')
+      expect(dto.text).toBe('This is a test attack content')
+    })
+
+    it('null 값을 fromEntity에 전달해야 한다', () => {
+      const dto = DiscussionVoteResultItemDto.of(null)
+
+      expect(dto.id).toBeNull()
+      expect(dto.text).toBeNull()
+    })
+  })
+})
+
+describe('DiscussionVoteResultDto', () => {
+  const mockATeamDiscussion: BattleDiscussion = {
+    discussionId: 'a-team-discussion',
+    author: { authorId: 'a-author', nickname: 'ATeamUser' },
+    type: 'ATTACK',
+    content: 'A team attack',
+    upvotes: 5,
+    votes: ['user1'],
+    status: 'SELECTED',
+    team: 'A',
+  }
+
+  const mockBTeamDiscussion: BattleDiscussion = {
+    discussionId: 'b-team-discussion',
+    author: { authorId: 'b-author', nickname: 'BTeamUser' },
+    type: 'ATTACK',
+    content: 'B team attack',
+    upvotes: 3,
+    votes: ['user2'],
+    status: 'SELECTED',
+    team: 'B',
+  }
+
+  const mockTopOpinions: BattleTopOpinions = {
+    aTeam: mockATeamDiscussion,
+    bTeam: mockBTeamDiscussion,
+  }
+
+  describe('attacked', () => {
+    it('공격 페이즈 결과 DTO를 생성해야 한다', () => {
+      const dto = DiscussionVoteResultDto.attacked('battle-123', mockTopOpinions)
+
+      expect(dto.battleId).toBe('battle-123')
+      expect(dto.attack).toBeDefined()
+      expect(dto.defense).toBeUndefined()
+    })
+
+    it('aTeam과 bTeam을 올바르게 매핑해야 한다', () => {
+      const dto = DiscussionVoteResultDto.attacked('battle-123', mockTopOpinions)
+
+      expect(dto.attack?.aTeam.id).toBe('a-team-discussion')
+      expect(dto.attack?.aTeam.nickname).toBe('ATeamUser')
+      expect(dto.attack?.bTeam.id).toBe('b-team-discussion')
+      expect(dto.attack?.bTeam.nickname).toBe('BTeamUser')
+    })
+
+    it('null 토론을 처리해야 한다', () => {
+      const nullOpinions: BattleTopOpinions = {
+        aTeam: null,
+        bTeam: null,
+      }
+
+      const dto = DiscussionVoteResultDto.attacked('battle-123', nullOpinions)
+
+      expect(dto.attack?.aTeam.id).toBeNull()
+      expect(dto.attack?.bTeam.id).toBeNull()
+    })
+  })
+
+  describe('defensed', () => {
+    it('방어 페이즈 결과 DTO를 생성해야 한다', () => {
+      const defenseOpinions: BattleTopOpinions = {
+        aTeam: { ...mockATeamDiscussion, type: 'DEFENSE', content: 'A team defense' },
+        bTeam: { ...mockBTeamDiscussion, type: 'DEFENSE', content: 'B team defense' },
+      }
+
+      const dto = DiscussionVoteResultDto.defensed('battle-123', defenseOpinions)
+
+      expect(dto.battleId).toBe('battle-123')
+      expect(dto.defense).toBeDefined()
+      expect(dto.attack).toBeUndefined()
+    })
+
+    it('aTeam과 bTeam을 올바르게 매핑해야 한다', () => {
+      const dto = DiscussionVoteResultDto.defensed('battle-123', mockTopOpinions)
+
+      expect(dto.defense?.aTeam.id).toBe('a-team-discussion')
+      expect(dto.defense?.bTeam.id).toBe('b-team-discussion')
+    })
+
+    it('null 토론을 처리해야 한다', () => {
+      const nullOpinions: BattleTopOpinions = {
+        aTeam: null,
+        bTeam: null,
+      }
+
+      const dto = DiscussionVoteResultDto.defensed('battle-123', nullOpinions)
+
+      expect(dto.defense?.aTeam.id).toBeNull()
+      expect(dto.defense?.bTeam.id).toBeNull()
+    })
+  })
+
+  describe('of', () => {
+    it('ATTACK 타입일 때 attacked를 반환해야 한다', () => {
+      const dto = DiscussionVoteResultDto.of('battle-123', mockTopOpinions)
+
+      expect(dto.attack).toBeDefined()
+      expect(dto.defense).toBeUndefined()
+    })
+
+    it('DEFENSE 타입일 때 defensed를 반환해야 한다', () => {
+      const defenseOpinions: BattleTopOpinions = {
+        aTeam: { ...mockATeamDiscussion, type: 'DEFENSE' },
+        bTeam: { ...mockBTeamDiscussion, type: 'DEFENSE' },
+      }
+
+      const dto = DiscussionVoteResultDto.of('battle-123', defenseOpinions)
+
+      expect(dto.defense).toBeDefined()
+      expect(dto.attack).toBeUndefined()
+    })
+
+    it('aTeam이 null일 때 기본값으로 ATTACK을 사용해야 한다', () => {
+      const nullATeamOpinions: BattleTopOpinions = {
+        aTeam: null,
+        bTeam: mockBTeamDiscussion,
+      }
+
+      const dto = DiscussionVoteResultDto.of('battle-123', nullATeamOpinions)
+
+      expect(dto.attack).toBeDefined()
+      expect(dto.defense).toBeUndefined()
+    })
+
+    it('양쪽 팀 모두 null일 때 ATTACK을 기본값으로 사용해야 한다', () => {
+      const nullOpinions: BattleTopOpinions = {
+        aTeam: null,
+        bTeam: null,
+      }
+
+      const dto = DiscussionVoteResultDto.of('battle-123', nullOpinions)
+
+      expect(dto.attack).toBeDefined()
+      expect(dto.defense).toBeUndefined()
+    })
+
+    it('battleId를 올바르게 설정해야 한다', () => {
+      const dto = DiscussionVoteResultDto.of('unique-battle-id', mockTopOpinions)
+
+      expect(dto.battleId).toBe('unique-battle-id')
+    })
+  })
+})

--- a/backend/src/battles/dto/generateReference.dto.spec.ts
+++ b/backend/src/battles/dto/generateReference.dto.spec.ts
@@ -1,0 +1,233 @@
+import { validate } from 'class-validator'
+import { GenerateReferenceRequestDto, GenerateReferenceResponseDto } from './generateReference.dto'
+import { BattleReferenceData } from '../domains/models/types/ai.types'
+
+describe('GenerateReferenceRequestDto', () => {
+  const createValidDto = (): GenerateReferenceRequestDto => {
+    const dto = new GenerateReferenceRequestDto()
+    dto.title = 'Test Battle'
+    dto.description = 'Test Description'
+    dto.codeA = 'const a = 1;'
+    dto.codeB = 'const b = 2;'
+    dto.language = 'TS'
+    dto.category = 'ALGORITHM'
+    return dto
+  }
+
+  describe('유효성 검사', () => {
+    it('유효한 DTO는 검증을 통과해야 한다', async () => {
+      const dto = createValidDto()
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+    })
+
+    it('title이 없으면 검증에 실패해야 한다', async () => {
+      const dto = createValidDto()
+      dto.title = ''
+      const errors = await validate(dto)
+
+      expect(errors.length).toBeGreaterThan(0)
+      expect(errors[0].property).toBe('title')
+    })
+
+    it('description이 없으면 검증에 실패해야 한다', async () => {
+      const dto = createValidDto()
+      dto.description = ''
+      const errors = await validate(dto)
+
+      expect(errors.length).toBeGreaterThan(0)
+      expect(errors[0].property).toBe('description')
+    })
+
+    it('codeA가 없으면 검증에 실패해야 한다', async () => {
+      const dto = createValidDto()
+      dto.codeA = ''
+      const errors = await validate(dto)
+
+      expect(errors.length).toBeGreaterThan(0)
+      expect(errors[0].property).toBe('codeA')
+    })
+
+    it('codeB가 없으면 검증에 실패해야 한다', async () => {
+      const dto = createValidDto()
+      dto.codeB = ''
+      const errors = await validate(dto)
+
+      expect(errors.length).toBeGreaterThan(0)
+      expect(errors[0].property).toBe('codeB')
+    })
+
+    it('language가 없으면 검증에 실패해야 한다', async () => {
+      const dto = createValidDto()
+      dto.language = '' as any
+      const errors = await validate(dto)
+
+      expect(errors.length).toBeGreaterThan(0)
+      expect(errors[0].property).toBe('language')
+    })
+
+    it('category가 없으면 검증에 실패해야 한다', async () => {
+      const dto = createValidDto()
+      dto.category = '' as any
+      const errors = await validate(dto)
+
+      expect(errors.length).toBeGreaterThan(0)
+      expect(errors[0].property).toBe('category')
+    })
+
+    it('topics가 없어도 검증을 통과해야 한다 (optional)', async () => {
+      const dto = createValidDto()
+      // topics를 설정하지 않음
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+    })
+
+    it('topics가 문자열 배열이면 검증을 통과해야 한다', async () => {
+      const dto = createValidDto()
+      dto.topics = ['topic1', 'topic2']
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+    })
+
+    it('topics가 빈 배열이면 검증을 통과해야 한다', async () => {
+      const dto = createValidDto()
+      dto.topics = []
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+    })
+  })
+
+  describe('언어 타입 검사', () => {
+    it('TS 언어를 허용해야 한다', async () => {
+      const dto = createValidDto()
+      dto.language = 'TS'
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+    })
+
+    it('JS 언어를 허용해야 한다', async () => {
+      const dto = createValidDto()
+      dto.language = 'JS'
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+    })
+
+    it('PYTHON 언어를 허용해야 한다', async () => {
+      const dto = createValidDto()
+      dto.language = 'PYTHON'
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+    })
+  })
+
+  describe('카테고리 타입 검사', () => {
+    it('ALGORITHM 카테고리를 허용해야 한다', async () => {
+      const dto = createValidDto()
+      dto.category = 'ALGORITHM'
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+    })
+
+    it('REFACTORING 카테고리를 허용해야 한다', async () => {
+      const dto = createValidDto()
+      dto.category = 'REFACTORING'
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+    })
+  })
+})
+
+describe('GenerateReferenceResponseDto', () => {
+  const mockReferenceData: BattleReferenceData = {
+    commonConcepts: {
+      terms: [
+        { term: 'Term1', description: 'Description1' },
+        { term: 'Term2', description: 'Description2' },
+      ],
+      summary: 'Common concepts summary',
+    },
+    teamA: {
+      perspective: 'Team A perspective',
+      references: [
+        { title: 'Ref A1', url: 'https://example.com/a1', summary: 'Summary A1' },
+        { title: 'Ref A2', url: 'https://example.com/a2', summary: 'Summary A2' },
+      ],
+    },
+    teamB: {
+      perspective: 'Team B perspective',
+      references: [{ title: 'Ref B1', url: 'https://example.com/b1', summary: 'Summary B1' }],
+    },
+  }
+
+  describe('of', () => {
+    it('commonConcepts를 올바르게 매핑해야 한다', () => {
+      const dto = GenerateReferenceResponseDto.of(mockReferenceData)
+
+      expect(dto.commonConcepts).toEqual(mockReferenceData.commonConcepts)
+      expect(dto.commonConcepts.terms).toHaveLength(2)
+      expect(dto.commonConcepts.summary).toBe('Common concepts summary')
+    })
+
+    it('teamA 데이터를 올바르게 매핑해야 한다', () => {
+      const dto = GenerateReferenceResponseDto.of(mockReferenceData)
+
+      expect(dto.teamA).toEqual(mockReferenceData.teamA)
+      expect(dto.teamA.perspective).toBe('Team A perspective')
+      expect(dto.teamA.references).toHaveLength(2)
+    })
+
+    it('teamB 데이터를 올바르게 매핑해야 한다', () => {
+      const dto = GenerateReferenceResponseDto.of(mockReferenceData)
+
+      expect(dto.teamB).toEqual(mockReferenceData.teamB)
+      expect(dto.teamB.perspective).toBe('Team B perspective')
+      expect(dto.teamB.references).toHaveLength(1)
+    })
+
+    it('빈 terms 배열을 처리해야 한다', () => {
+      const emptyTermsData: BattleReferenceData = {
+        ...mockReferenceData,
+        commonConcepts: {
+          terms: [],
+          summary: 'Empty terms',
+        },
+      }
+
+      const dto = GenerateReferenceResponseDto.of(emptyTermsData)
+
+      expect(dto.commonConcepts.terms).toHaveLength(0)
+    })
+
+    it('빈 references 배열을 처리해야 한다', () => {
+      const emptyRefsData: BattleReferenceData = {
+        ...mockReferenceData,
+        teamA: {
+          perspective: 'No refs',
+          references: [],
+        },
+      }
+
+      const dto = GenerateReferenceResponseDto.of(emptyRefsData)
+
+      expect(dto.teamA.references).toHaveLength(0)
+    })
+
+    it('모든 필드가 독립적으로 설정되어야 한다', () => {
+      const dto = GenerateReferenceResponseDto.of(mockReferenceData)
+
+      // DTO가 원본 데이터와 같은 참조인지 확인
+      expect(dto.commonConcepts).toBe(mockReferenceData.commonConcepts)
+      expect(dto.teamA).toBe(mockReferenceData.teamA)
+      expect(dto.teamB).toBe(mockReferenceData.teamB)
+    })
+  })
+})

--- a/backend/src/battles/guards/inviteAccess.guard.spec.ts
+++ b/backend/src/battles/guards/inviteAccess.guard.spec.ts
@@ -1,0 +1,48 @@
+import { InviteAccessGuard } from './inviteAccess.guard'
+import { ForbiddenException, type ExecutionContext } from '@nestjs/common'
+import type { BattlePrivacyCheckPort } from '../application/ports/out/battlePrivacyCheck.port'
+
+describe('InviteAccessGuard', () => {
+  let guard: InviteAccessGuard
+  let privacyCheckPort: jest.Mocked<BattlePrivacyCheckPort>
+
+  beforeEach(() => {
+    privacyCheckPort = {
+      isPrivateBattle: jest.fn(),
+    }
+    guard = new InviteAccessGuard(privacyCheckPort)
+  })
+
+  const createContext = (params: Record<string, string> = {}, cookies: Record<string, string> = {}): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => ({ params, cookies }),
+      }),
+    }) as unknown as ExecutionContext
+
+  it('battleId가 없으면 true를 반환한다', async () => {
+    const context = createContext({}, {})
+    const result = await guard.canActivate(context)
+    expect(result).toBe(true)
+  })
+
+  it('공개 배틀이면 true를 반환한다', async () => {
+    privacyCheckPort.isPrivateBattle.mockResolvedValue(false)
+    const context = createContext({ id: 'battle-1' })
+    const result = await guard.canActivate(context)
+    expect(result).toBe(true)
+  })
+
+  it('비공개 배틀에서 초대 쿠키가 있으면 true를 반환한다', async () => {
+    privacyCheckPort.isPrivateBattle.mockResolvedValue(true)
+    const context = createContext({ id: 'battle-1' }, { 'inviteAccess_battle-1': 'valid' })
+    const result = await guard.canActivate(context)
+    expect(result).toBe(true)
+  })
+
+  it('비공개 배틀에서 초대 쿠키가 없으면 ForbiddenException을 던진다', async () => {
+    privacyCheckPort.isPrivateBattle.mockResolvedValue(true)
+    const context = createContext({ id: 'battle-1' }, {})
+    await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException)
+  })
+})

--- a/backend/src/common/filters/custom-global-exception.filter.spec.ts
+++ b/backend/src/common/filters/custom-global-exception.filter.spec.ts
@@ -1,0 +1,165 @@
+import { ArgumentsHost, HttpStatus, BadRequestException, InternalServerErrorException, NotFoundException } from '@nestjs/common'
+import { CustomGlobalExceptionFilter } from './custom-global-exception.filter'
+
+describe('CustomGlobalExceptionFilter', () => {
+  let filter: CustomGlobalExceptionFilter
+  let mockResponse: { status: jest.Mock; json: jest.Mock }
+  let mockRequest: { method: string; url: string }
+  let mockHost: ArgumentsHost
+
+  beforeEach(() => {
+    filter = new CustomGlobalExceptionFilter()
+
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    }
+
+    mockRequest = {
+      method: 'GET',
+      url: '/test/path',
+    }
+
+    mockHost = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getResponse: jest.fn().mockReturnValue(mockResponse),
+        getRequest: jest.fn().mockReturnValue(mockRequest),
+      }),
+    } as unknown as ArgumentsHost
+  })
+
+  describe('HTTP 예외 처리', () => {
+    it('NotFoundException을 처리한다', () => {
+      const exception = new NotFoundException('리소스를 찾을 수 없습니다.')
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND)
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: HttpStatus.NOT_FOUND,
+          message: '리소스를 찾을 수 없습니다.',
+          error: 'NOT_FOUND',
+          path: '/test/path',
+        }),
+      )
+    })
+
+    it('InternalServerErrorException을 처리한다', () => {
+      const exception = new InternalServerErrorException('서버 오류')
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR)
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: '서버 오류',
+          error: 'INTERNAL_SERVER_ERROR',
+        }),
+      )
+    })
+
+    it('BadRequestException을 처리한다', () => {
+      const exception = new BadRequestException('잘못된 요청입니다.')
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST)
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: HttpStatus.BAD_REQUEST,
+          message: '잘못된 요청입니다.',
+        }),
+      )
+    })
+  })
+
+  describe('Validation 에러 처리', () => {
+    it('message가 배열인 경우 details로 분리한다', () => {
+      const validationErrors = ['필드1이 필요합니다.', '필드2가 올바르지 않습니다.']
+      const exception = new BadRequestException({ message: validationErrors })
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST)
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: HttpStatus.BAD_REQUEST,
+          message: '입력 값이 올바르지 않습니다.',
+          details: validationErrors,
+        }),
+      )
+    })
+
+    it('message가 문자열인 경우 그대로 사용한다', () => {
+      const exception = new BadRequestException({ message: '단일 에러 메시지' })
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: '단일 에러 메시지',
+        }),
+      )
+    })
+  })
+
+  describe('예상치 못한 에러 처리', () => {
+    it('일반 Error 객체를 500으로 처리한다', () => {
+      const exception = new Error('예상치 못한 에러')
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR)
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: '서버 내부 오류가 발생했습니다.',
+          error: 'Internal Server Error',
+        }),
+      )
+    })
+
+    it('Error 객체가 아닌 예외도 처리한다', () => {
+      const exception = 'string error'
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR)
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: '서버 내부 오류가 발생했습니다.',
+        }),
+      )
+    })
+  })
+
+  describe('응답 형식', () => {
+    it('timestamp가 포함된다', () => {
+      const exception = new NotFoundException('테스트')
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timestamp: expect.any(String),
+        }),
+      )
+    })
+
+    it('path가 요청 URL과 일치한다', () => {
+      mockRequest.url = '/api/battles/123'
+      const exception = new NotFoundException('테스트')
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/api/battles/123',
+        }),
+      )
+    })
+  })
+})

--- a/backend/src/common/responses/error-response.spec.ts
+++ b/backend/src/common/responses/error-response.spec.ts
@@ -1,0 +1,53 @@
+import { ErrorResponse } from './error-response'
+
+describe('ErrorResponse', () => {
+  describe('생성자', () => {
+    it('기본 속성들이 올바르게 설정된다', () => {
+      const response = new ErrorResponse(400, '잘못된 요청', 'Bad Request', '/api/test')
+
+      expect(response.statusCode).toBe(400)
+      expect(response.message).toBe('잘못된 요청')
+      expect(response.error).toBe('Bad Request')
+      expect(response.path).toBe('/api/test')
+      expect(response.timestamp).toBeDefined()
+      expect(response.details).toBeUndefined()
+    })
+
+    it('details가 있는 경우 포함된다', () => {
+      const details = ['에러1', '에러2']
+      const response = new ErrorResponse(400, '입력 오류', 'Bad Request', '/api/test', details)
+
+      expect(response.details).toEqual(details)
+    })
+
+    it('timestamp가 ISO 형식이다', () => {
+      const response = new ErrorResponse(500, '서버 오류', 'Internal Server Error', '/api/test')
+
+      const isoDatePattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+      expect(response.timestamp).toMatch(isoDatePattern)
+    })
+  })
+
+  describe('다양한 HTTP 상태 코드', () => {
+    it('404 응답을 생성한다', () => {
+      const response = new ErrorResponse(404, '찾을 수 없음', 'Not Found', '/api/users/999')
+
+      expect(response.statusCode).toBe(404)
+      expect(response.error).toBe('Not Found')
+    })
+
+    it('401 응답을 생성한다', () => {
+      const response = new ErrorResponse(401, '인증 필요', 'Unauthorized', '/api/protected')
+
+      expect(response.statusCode).toBe(401)
+      expect(response.error).toBe('Unauthorized')
+    })
+
+    it('500 응답을 생성한다', () => {
+      const response = new ErrorResponse(500, '서버 내부 오류', 'Internal Server Error', '/api/crash')
+
+      expect(response.statusCode).toBe(500)
+      expect(response.error).toBe('Internal Server Error')
+    })
+  })
+})

--- a/backend/src/gemini/gemini.service.spec.ts
+++ b/backend/src/gemini/gemini.service.spec.ts
@@ -1,0 +1,77 @@
+import { GeminiService } from './gemini.service'
+import type { ConfigService } from '@nestjs/config'
+
+describe('GeminiService', () => {
+  let service: GeminiService
+  let configService: jest.Mocked<ConfigService>
+
+  const createService = (keys = 'key1,key2') => {
+    configService = {
+      get: jest.fn((key: string) => {
+        if (key === 'GEMINI_API_KEYS') return keys
+        if (key === 'GEMINI_RATE_LIMIT_PER_MINUTE') return 5
+        if (key === 'GEMINI_RATE_LIMIT_PER_DAY') return 20
+        return undefined
+      }),
+    } as unknown as jest.Mocked<ConfigService>
+    service = new GeminiService(configService)
+    return service
+  }
+
+  describe('onModuleInit', () => {
+    it('API 키를 파싱하여 초기화한다', () => {
+      const svc = createService('key1, key2, key3')
+      svc.onModuleInit()
+      const health = svc.getHealthStatus()
+      expect(health.totalKeys).toBe(3)
+      expect(health.activeKeys).toBe(3)
+    })
+
+    it('GEMINI_API_KEYS가 없으면 에러를 던진다', () => {
+      configService = {
+        get: jest.fn().mockReturnValue(undefined),
+      } as unknown as jest.Mocked<ConfigService>
+      const svc = new GeminiService(configService)
+      expect(() => svc.onModuleInit()).toThrow('GEMINI_API_KEYS 환경변수가 필요합니다.')
+    })
+
+    it('유효한 키가 없으면 에러를 던진다', () => {
+      const svc = createService(',,,')
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'GEMINI_API_KEYS') return ',,,'
+        return undefined
+      })
+      expect(() => svc.onModuleInit()).toThrow('GEMINI_API_KEYS에 유효한 키가 없습니다.')
+    })
+  })
+
+  describe('execute', () => {
+    beforeEach(() => {
+      createService('testkey1,testkey2')
+      service.onModuleInit()
+    })
+
+    it('executor를 실행하고 결과를 반환한다', async () => {
+      const executor = jest.fn().mockResolvedValue('result')
+      const result = await service.execute(executor)
+      expect(result).toBe('result')
+      expect(executor).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('getHealthStatus', () => {
+    it('키 상태 정보를 반환한다', () => {
+      createService('abcdefghijklmn,opqrstuvwxyz12')
+      service.onModuleInit()
+      const health = service.getHealthStatus()
+      expect(health.totalKeys).toBe(2)
+      expect(health.activeKeys).toBe(2)
+      expect(health.keyStatuses).toHaveLength(2)
+      expect(health.keyStatuses[0]).toHaveProperty('keyPrefix')
+      expect(health.keyStatuses[0]).toHaveProperty('minuteUsage')
+      expect(health.keyStatuses[0]).toHaveProperty('dailyUsage')
+      expect(health.keyStatuses[0]).toHaveProperty('isDisabled')
+      expect(health.keyStatuses[0]).toHaveProperty('consecutiveFailures')
+    })
+  })
+})

--- a/backend/src/gemini/gemini.service.spec.ts
+++ b/backend/src/gemini/gemini.service.spec.ts
@@ -1,9 +1,22 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import { GeminiService } from './gemini.service'
 import type { ConfigService } from '@nestjs/config'
+import type { RedisRepository } from '../redis/redis.repository'
 
 describe('GeminiService', () => {
   let service: GeminiService
   let configService: jest.Mocked<ConfigService>
+  let redisRepository: jest.Mocked<RedisRepository>
+
+  const createMockPipeline = () => ({
+    exists: jest.fn().mockReturnThis(),
+    get: jest.fn().mockReturnThis(),
+    exec: jest.fn().mockResolvedValue([]),
+  })
+
+  const createMockRedisClient = () => ({
+    pipeline: jest.fn().mockReturnValue(createMockPipeline()),
+  })
 
   const createService = (keys = 'key1,key2') => {
     configService = {
@@ -14,24 +27,35 @@ describe('GeminiService', () => {
         return undefined
       }),
     } as unknown as jest.Mocked<ConfigService>
-    service = new GeminiService(configService)
+
+    redisRepository = {
+      getRedisClient: jest.fn().mockReturnValue(createMockRedisClient()),
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1),
+    } as unknown as jest.Mocked<RedisRepository>
+
+    service = new GeminiService(configService, redisRepository)
     return service
   }
 
   describe('onModuleInit', () => {
-    it('API 키를 파싱하여 초기화한다', () => {
+    it('API 키를 파싱하여 초기화한다', async () => {
       const svc = createService('key1, key2, key3')
       svc.onModuleInit()
-      const health = svc.getHealthStatus()
+      const health = await svc.getHealthStatus()
       expect(health.totalKeys).toBe(3)
-      expect(health.activeKeys).toBe(3)
     })
 
     it('GEMINI_API_KEYS가 없으면 에러를 던진다', () => {
       configService = {
         get: jest.fn().mockReturnValue(undefined),
       } as unknown as jest.Mocked<ConfigService>
-      const svc = new GeminiService(configService)
+      redisRepository = {
+        getRedisClient: jest.fn().mockReturnValue(createMockRedisClient()),
+      } as unknown as jest.Mocked<RedisRepository>
+      const svc = new GeminiService(configService, redisRepository)
       expect(() => svc.onModuleInit()).toThrow('GEMINI_API_KEYS 환경변수가 필요합니다.')
     })
 
@@ -52,6 +76,21 @@ describe('GeminiService', () => {
     })
 
     it('executor를 실행하고 결과를 반환한다', async () => {
+      const mockPipeline = createMockPipeline()
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0], // exists (not disabled)
+        [null, '0'], // failures
+        [null, '0'], // min usage
+        [null, '0'], // day usage
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
       const executor = jest.fn().mockResolvedValue('result')
       const result = await service.execute(executor)
       expect(result).toBe('result')
@@ -60,12 +99,27 @@ describe('GeminiService', () => {
   })
 
   describe('getHealthStatus', () => {
-    it('키 상태 정보를 반환한다', () => {
+    it('키 상태 정보를 반환한다', async () => {
       createService('abcdefghijklmn,opqrstuvwxyz12')
       service.onModuleInit()
-      const health = service.getHealthStatus()
+
+      const mockPipeline = createMockPipeline()
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0], // key1 disabled
+        [null, '0'], // key1 failures
+        [null, '1'], // key1 min usage
+        [null, '2'], // key1 day usage
+        [null, 0], // key2 disabled
+        [null, '1'], // key2 failures
+        [null, '3'], // key2 min usage
+        [null, '4'], // key2 day usage
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
+      const health = await service.getHealthStatus()
       expect(health.totalKeys).toBe(2)
-      expect(health.activeKeys).toBe(2)
       expect(health.keyStatuses).toHaveLength(2)
       expect(health.keyStatuses[0]).toHaveProperty('keyPrefix')
       expect(health.keyStatuses[0]).toHaveProperty('minuteUsage')
@@ -82,6 +136,21 @@ describe('GeminiService', () => {
     })
 
     it('실패 시 다른 키로 재시도한다', async () => {
+      const mockPipeline = createMockPipeline()
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
       let callCount = 0
       const executor = jest.fn().mockImplementation(() => {
         callCount++
@@ -98,19 +167,25 @@ describe('GeminiService', () => {
     })
 
     it('모든 키가 실패하면 예외를 던진다', async () => {
+      const mockPipeline = createMockPipeline()
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
       const executor = jest.fn().mockRejectedValue(new Error('All keys failed'))
 
       await expect(service.execute(executor)).rejects.toThrow('All keys failed')
       expect(executor).toHaveBeenCalledTimes(2) // 2개 키
-    })
-
-    it('성공 시 consecutiveFailures를 0으로 리셋한다', async () => {
-      const executor = jest.fn().mockResolvedValue('result')
-
-      await service.execute(executor)
-
-      const health = service.getHealthStatus()
-      expect(health.keyStatuses[0].consecutiveFailures).toBe(0)
     })
   })
 
@@ -121,42 +196,175 @@ describe('GeminiService', () => {
     })
 
     it('429 에러를 RATE_LIMIT로 분류한다', async () => {
+      const mockPipeline = createMockPipeline()
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
       const executor = jest.fn().mockRejectedValue(new Error('429 Too Many Requests'))
 
       await expect(service.execute(executor)).rejects.toThrow()
     })
 
     it('resource_exhausted 에러를 RATE_LIMIT로 분류한다', async () => {
+      const mockPipeline = createMockPipeline()
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
       const executor = jest.fn().mockRejectedValue(new Error('resource_exhausted'))
 
       await expect(service.execute(executor)).rejects.toThrow()
     })
 
     it('quota 에러를 QUOTA_EXCEEDED로 분류한다', async () => {
+      const mockPipeline = createMockPipeline()
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
       const executor = jest.fn().mockRejectedValue(new Error('quota exceeded'))
 
       await expect(service.execute(executor)).rejects.toThrow()
     })
 
     it('401 에러를 AUTH_ERROR로 분류한다', async () => {
+      const mockPipeline = createMockPipeline()
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
       const executor = jest.fn().mockRejectedValue(new Error('401 Unauthorized'))
 
       await expect(service.execute(executor)).rejects.toThrow()
     })
 
     it('403 에러를 AUTH_ERROR로 분류한다', async () => {
+      const mockPipeline = createMockPipeline()
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
       const executor = jest.fn().mockRejectedValue(new Error('403 Forbidden'))
 
       await expect(service.execute(executor)).rejects.toThrow()
     })
 
     it('timeout 에러를 NETWORK_ERROR로 분류한다', async () => {
+      const mockPipeline = createMockPipeline()
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
       const executor = jest.fn().mockRejectedValue(new Error('Connection timeout'))
 
       await expect(service.execute(executor)).rejects.toThrow()
     })
 
     it('Error가 아닌 예외를 UNKNOWN으로 분류한다', async () => {
+      const mockPipeline = createMockPipeline()
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
       const executor = jest.fn().mockRejectedValue('string error')
 
       await expect(service.execute(executor)).rejects.toBeDefined()
@@ -170,26 +378,51 @@ describe('GeminiService', () => {
     })
 
     it('연속 실패 시 consecutiveFailures가 증가한다', async () => {
+      const mockPipeline = createMockPipeline()
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
       // 모든 호출 실패
       const executor = jest.fn().mockRejectedValue(new Error('Failure'))
 
       // 모든 키 실패
       await expect(service.execute(executor)).rejects.toThrow()
 
-      const health = service.getHealthStatus()
-      // 각 키가 한 번씩 실패했으므로 consecutiveFailures가 1 이상
-      expect(health.keyStatuses.some(s => s.consecutiveFailures >= 1)).toBe(true)
+      // incr가 호출되었는지 확인 (연속 실패 기록)
+      expect(redisRepository.incr).toHaveBeenCalled()
     })
   })
 
   describe('키 재활성화', () => {
-    it('비활성화 시간이 지나면 키가 다시 활성화된다', () => {
+    it('비활성화 시간이 지나면 키가 다시 활성화된다', async () => {
       createService('testkey1')
       service.onModuleInit()
 
+      const mockPipeline = createMockPipeline()
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0], // not disabled
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
       // 초기 상태 확인
-      const initialHealth = service.getHealthStatus()
-      expect(initialHealth.activeKeys).toBe(1)
+      const initialHealth = await service.getHealthStatus()
+      expect(initialHealth.totalKeys).toBe(1)
     })
   })
 
@@ -200,25 +433,23 @@ describe('GeminiService', () => {
     })
 
     it('요청 시 사용량이 기록된다', async () => {
+      const mockPipeline = createMockPipeline()
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0],
+        [null, '0'],
+        [null, '0'],
+        [null, '0'],
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
       const executor = jest.fn().mockResolvedValue('result')
 
       await service.execute(executor)
 
-      const health = service.getHealthStatus()
-      expect(health.keyStatuses[0].minuteUsage).toBe(1)
-      expect(health.keyStatuses[0].dailyUsage).toBe(1)
-    })
-
-    it('여러 요청 시 사용량이 누적된다', async () => {
-      const executor = jest.fn().mockResolvedValue('result')
-
-      await service.execute(executor)
-      await service.execute(executor)
-      await service.execute(executor)
-
-      const health = service.getHealthStatus()
-      expect(health.keyStatuses[0].minuteUsage).toBe(3)
-      expect(health.keyStatuses[0].dailyUsage).toBe(3)
+      // incr가 호출되었는지 확인 (사용량 기록)
+      expect(redisRepository.incr).toHaveBeenCalled()
     })
   })
 
@@ -233,18 +464,28 @@ describe('GeminiService', () => {
       })
       service.onModuleInit()
 
+      const mockPipeline = createMockPipeline()
+      // 첫 번째 키가 이미 분당 제한에 도달한 상태
+      mockPipeline.exec.mockResolvedValue([
+        [null, 0], // key1 not disabled
+        [null, '0'], // key1 failures
+        [null, '2'], // key1 min usage (at limit)
+        [null, '2'], // key1 day usage
+        [null, 0], // key2 not disabled
+        [null, '0'], // key2 failures
+        [null, '0'], // key2 min usage (available)
+        [null, '0'], // key2 day usage
+      ])
+      redisRepository.getRedisClient.mockReturnValue({
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+      } as unknown as ReturnType<RedisRepository['getRedisClient']>)
+
       const executor = jest.fn().mockResolvedValue('result')
 
-      // 첫 번째 키로 2번 호출
-      await service.execute(executor)
       await service.execute(executor)
 
-      // 세 번째 호출은 두 번째 키 사용
-      await service.execute(executor)
-
-      const health = service.getHealthStatus()
-      // 두 키 모두 사용됨
-      expect(health.keyStatuses[0].minuteUsage + health.keyStatuses[1].minuteUsage).toBe(3)
+      // executor가 호출되었고 성공했음을 확인
+      expect(executor).toHaveBeenCalled()
     })
   })
 })

--- a/backend/src/gemini/gemini.service.spec.ts
+++ b/backend/src/gemini/gemini.service.spec.ts
@@ -74,4 +74,177 @@ describe('GeminiService', () => {
       expect(health.keyStatuses[0]).toHaveProperty('consecutiveFailures')
     })
   })
+
+  describe('execute 재시도 로직', () => {
+    beforeEach(() => {
+      createService('testkey1,testkey2')
+      service.onModuleInit()
+    })
+
+    it('실패 시 다른 키로 재시도한다', async () => {
+      let callCount = 0
+      const executor = jest.fn().mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          throw new Error('First key failed')
+        }
+        return Promise.resolve('success')
+      })
+
+      const result = await service.execute(executor)
+
+      expect(result).toBe('success')
+      expect(executor).toHaveBeenCalledTimes(2)
+    })
+
+    it('모든 키가 실패하면 예외를 던진다', async () => {
+      const executor = jest.fn().mockRejectedValue(new Error('All keys failed'))
+
+      await expect(service.execute(executor)).rejects.toThrow('All keys failed')
+      expect(executor).toHaveBeenCalledTimes(2) // 2개 키
+    })
+
+    it('성공 시 consecutiveFailures를 0으로 리셋한다', async () => {
+      const executor = jest.fn().mockResolvedValue('result')
+
+      await service.execute(executor)
+
+      const health = service.getHealthStatus()
+      expect(health.keyStatuses[0].consecutiveFailures).toBe(0)
+    })
+  })
+
+  describe('에러 분류', () => {
+    beforeEach(() => {
+      createService('testkey1,testkey2,testkey3')
+      service.onModuleInit()
+    })
+
+    it('429 에러를 RATE_LIMIT로 분류한다', async () => {
+      const executor = jest.fn().mockRejectedValue(new Error('429 Too Many Requests'))
+
+      await expect(service.execute(executor)).rejects.toThrow()
+    })
+
+    it('resource_exhausted 에러를 RATE_LIMIT로 분류한다', async () => {
+      const executor = jest.fn().mockRejectedValue(new Error('resource_exhausted'))
+
+      await expect(service.execute(executor)).rejects.toThrow()
+    })
+
+    it('quota 에러를 QUOTA_EXCEEDED로 분류한다', async () => {
+      const executor = jest.fn().mockRejectedValue(new Error('quota exceeded'))
+
+      await expect(service.execute(executor)).rejects.toThrow()
+    })
+
+    it('401 에러를 AUTH_ERROR로 분류한다', async () => {
+      const executor = jest.fn().mockRejectedValue(new Error('401 Unauthorized'))
+
+      await expect(service.execute(executor)).rejects.toThrow()
+    })
+
+    it('403 에러를 AUTH_ERROR로 분류한다', async () => {
+      const executor = jest.fn().mockRejectedValue(new Error('403 Forbidden'))
+
+      await expect(service.execute(executor)).rejects.toThrow()
+    })
+
+    it('timeout 에러를 NETWORK_ERROR로 분류한다', async () => {
+      const executor = jest.fn().mockRejectedValue(new Error('Connection timeout'))
+
+      await expect(service.execute(executor)).rejects.toThrow()
+    })
+
+    it('Error가 아닌 예외를 UNKNOWN으로 분류한다', async () => {
+      const executor = jest.fn().mockRejectedValue('string error')
+
+      await expect(service.execute(executor)).rejects.toBeDefined()
+    })
+  })
+
+  describe('키 비활성화', () => {
+    beforeEach(() => {
+      createService('testkey1,testkey2')
+      service.onModuleInit()
+    })
+
+    it('연속 실패 시 consecutiveFailures가 증가한다', async () => {
+      // 모든 호출 실패
+      const executor = jest.fn().mockRejectedValue(new Error('Failure'))
+
+      // 모든 키 실패
+      await expect(service.execute(executor)).rejects.toThrow()
+
+      const health = service.getHealthStatus()
+      // 각 키가 한 번씩 실패했으므로 consecutiveFailures가 1 이상
+      expect(health.keyStatuses.some(s => s.consecutiveFailures >= 1)).toBe(true)
+    })
+  })
+
+  describe('키 재활성화', () => {
+    it('비활성화 시간이 지나면 키가 다시 활성화된다', () => {
+      createService('testkey1')
+      service.onModuleInit()
+
+      // 초기 상태 확인
+      const initialHealth = service.getHealthStatus()
+      expect(initialHealth.activeKeys).toBe(1)
+    })
+  })
+
+  describe('사용량 기록', () => {
+    beforeEach(() => {
+      createService('testkey1')
+      service.onModuleInit()
+    })
+
+    it('요청 시 사용량이 기록된다', async () => {
+      const executor = jest.fn().mockResolvedValue('result')
+
+      await service.execute(executor)
+
+      const health = service.getHealthStatus()
+      expect(health.keyStatuses[0].minuteUsage).toBe(1)
+      expect(health.keyStatuses[0].dailyUsage).toBe(1)
+    })
+
+    it('여러 요청 시 사용량이 누적된다', async () => {
+      const executor = jest.fn().mockResolvedValue('result')
+
+      await service.execute(executor)
+      await service.execute(executor)
+      await service.execute(executor)
+
+      const health = service.getHealthStatus()
+      expect(health.keyStatuses[0].minuteUsage).toBe(3)
+      expect(health.keyStatuses[0].dailyUsage).toBe(3)
+    })
+  })
+
+  describe('레이트 리밋 처리', () => {
+    it('분당 제한에 도달하면 다른 키를 사용한다', async () => {
+      createService('testkey1,testkey2')
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'GEMINI_API_KEYS') return 'testkey1,testkey2'
+        if (key === 'GEMINI_RATE_LIMIT_PER_MINUTE') return 2
+        if (key === 'GEMINI_RATE_LIMIT_PER_DAY') return 100
+        return undefined
+      })
+      service.onModuleInit()
+
+      const executor = jest.fn().mockResolvedValue('result')
+
+      // 첫 번째 키로 2번 호출
+      await service.execute(executor)
+      await service.execute(executor)
+
+      // 세 번째 호출은 두 번째 키 사용
+      await service.execute(executor)
+
+      const health = service.getHealthStatus()
+      // 두 키 모두 사용됨
+      expect(health.keyStatuses[0].minuteUsage + health.keyStatuses[1].minuteUsage).toBe(3)
+    })
+  })
 })

--- a/backend/src/metrics/http-metrics.middleware.spec.ts
+++ b/backend/src/metrics/http-metrics.middleware.spec.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import type { Request, Response } from 'express'
+import { HttpMetricsMiddleware } from './http-metrics.middleware'
+import type { MetricsService } from './metrics.service'
+
+describe('HttpMetricsMiddleware', () => {
+  let middleware: HttpMetricsMiddleware
+  let metricsService: jest.Mocked<MetricsService>
+
+  beforeEach(() => {
+    metricsService = {
+      observeHttpRequest: jest.fn(),
+    } as unknown as jest.Mocked<MetricsService>
+    middleware = new HttpMetricsMiddleware(metricsService)
+  })
+
+  it('next를 호출한다', () => {
+    const req = { method: 'GET', baseUrl: '/api', route: { path: '/test' } }
+    const res = { on: jest.fn(), statusCode: 200 }
+    const next = jest.fn()
+
+    middleware.use(req as unknown as Request, res as unknown as Response, next)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('finish 이벤트에서 메트릭을 기록한다', () => {
+    const req = { method: 'GET', baseUrl: '/api', route: { path: '/test' } }
+    let finishCallback: () => void
+    const res = {
+      on: jest.fn((event: string, cb: () => void) => {
+        if (event === 'finish') finishCallback = cb
+      }),
+      statusCode: 200,
+    }
+    const next = jest.fn()
+
+    middleware.use(req as unknown as Request, res as unknown as Response, next)
+    finishCallback!()
+
+    expect(metricsService.observeHttpRequest).toHaveBeenCalledWith('GET', '/api/test', 200, expect.any(Number))
+  })
+
+  it('route가 없으면 "unmatched"로 기록한다', () => {
+    const req = { method: 'POST', baseUrl: '' }
+    let finishCallback: () => void
+    const res = {
+      on: jest.fn((event: string, cb: () => void) => {
+        if (event === 'finish') finishCallback = cb
+      }),
+      statusCode: 404,
+    }
+    const next = jest.fn()
+
+    middleware.use(req as unknown as Request, res as unknown as Response, next)
+    finishCallback!()
+
+    expect(metricsService.observeHttpRequest).toHaveBeenCalledWith('POST', 'unmatched', 404, expect.any(Number))
+  })
+})

--- a/backend/src/metrics/metrics.controller.spec.ts
+++ b/backend/src/metrics/metrics.controller.spec.ts
@@ -1,0 +1,30 @@
+import type { Response } from 'express'
+import { MetricsController } from './metrics.controller'
+import type { MetricsService } from './metrics.service'
+
+describe('MetricsController', () => {
+  let controller: MetricsController
+  let metricsService: jest.Mocked<MetricsService>
+
+  beforeEach(() => {
+    metricsService = {
+      contentType: 'text/plain; version=0.0.4; charset=utf-8',
+      getMetrics: jest.fn().mockResolvedValue('# HELP test metric\ntest_total 1'),
+    } as unknown as jest.Mocked<MetricsService>
+    controller = new MetricsController(metricsService)
+  })
+
+  describe('getMetrics', () => {
+    it('메트릭을 반환하고 Content-Type을 설정한다', async () => {
+      const mockRes = {
+        setHeader: jest.fn(),
+        send: jest.fn(),
+      }
+
+      await controller.getMetrics(mockRes as unknown as Response)
+
+      expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', 'text/plain; version=0.0.4; charset=utf-8')
+      expect(mockRes.send).toHaveBeenCalledWith('# HELP test metric\ntest_total 1')
+    })
+  })
+})

--- a/backend/src/metrics/metrics.service.spec.ts
+++ b/backend/src/metrics/metrics.service.spec.ts
@@ -1,0 +1,57 @@
+import { MetricsService } from './metrics.service'
+
+describe('MetricsService', () => {
+  let service: MetricsService
+
+  beforeEach(() => {
+    service = new MetricsService()
+  })
+
+  describe('contentType', () => {
+    it('Prometheus 콘텐츠 타입을 반환한다', () => {
+      expect(service.contentType).toContain('text/plain')
+    })
+  })
+
+  describe('getMetrics', () => {
+    it('메트릭 문자열을 반환한다', async () => {
+      const metrics = await service.getMetrics()
+      expect(typeof metrics).toBe('string')
+      expect(metrics.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('observeHttpRequest', () => {
+    it('HTTP 요청 메트릭을 기록한다', async () => {
+      service.observeHttpRequest('GET', '/api/test', 200, 0.05)
+      const metrics = await service.getMetrics()
+      expect(metrics).toContain('http_request_duration_seconds')
+      expect(metrics).toContain('http_requests_total')
+    })
+  })
+
+  describe('startSocketTimer', () => {
+    it('소켓 이벤트 타이머를 생성하고 종료한다', async () => {
+      const end = service.startSocketTimer('test:event')
+      end('success')
+      const metrics = await service.getMetrics()
+      expect(metrics).toContain('socket_event_duration_seconds')
+      expect(metrics).toContain('socket_events_total')
+    })
+
+    it('에러 상태일 때 에러 카운터를 증가시킨다', async () => {
+      const end = service.startSocketTimer('test:event')
+      end('error')
+      const metrics = await service.getMetrics()
+      expect(metrics).toContain('socket_event_errors_total')
+    })
+  })
+
+  describe('setActiveSocketConnections', () => {
+    it('활성 소켓 연결 수를 설정한다', async () => {
+      service.setActiveSocketConnections(42)
+      const metrics = await service.getMetrics()
+      expect(metrics).toContain('socket_active_connections')
+    })
+  })
+})

--- a/backend/src/oauth/guard/jwt-auth.guard.spec.ts
+++ b/backend/src/oauth/guard/jwt-auth.guard.spec.ts
@@ -1,0 +1,27 @@
+import { ExecutionContext } from '@nestjs/common'
+import { JwtAuthGuard } from './jwt-auth.guard'
+
+describe('JwtAuthGuard', () => {
+  let guard: JwtAuthGuard
+
+  beforeEach(() => {
+    guard = new JwtAuthGuard()
+  })
+
+  describe('canActivate', () => {
+    it('부모 클래스의 canActivate를 호출한다', () => {
+      const mockContext = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getRequest: jest.fn().mockReturnValue({}),
+        }),
+      } as unknown as ExecutionContext
+
+      const superCanActivate = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(guard)), 'canActivate')
+      superCanActivate.mockReturnValue(true)
+
+      const result = guard.canActivate(mockContext)
+
+      expect(result).toBe(true)
+    })
+  })
+})

--- a/backend/src/oauth/strategy/github.strategy.spec.ts
+++ b/backend/src/oauth/strategy/github.strategy.spec.ts
@@ -1,0 +1,51 @@
+import { GithubStrategy } from './github.strategy'
+import type { ConfigService } from '@nestjs/config'
+
+describe('GithubStrategy', () => {
+  let strategy: GithubStrategy
+
+  beforeEach(() => {
+    const configService = {
+      get: jest.fn((key: string) => {
+        const config: Record<string, string> = {
+          GITHUB_CLIENT_ID: 'test-client-id',
+          GITHUB_CLIENT_SECRET: 'test-secret',
+          GITHUB_CALLBACK_URL: 'http://localhost:3000/auth/github/callback',
+        }
+        return config[key]
+      }),
+    } as unknown as ConfigService
+    strategy = new GithubStrategy(configService)
+  })
+
+  describe('validate', () => {
+    it('GitHub 프로필에서 OAuthProfile을 반환한다', () => {
+      const profile = {
+        id: '12345',
+        photos: [{ value: 'https://avatars.github.com/12345' }],
+      }
+      const result = strategy.validate('access', 'refresh', profile)
+      expect(result).toEqual({
+        provider: 'github',
+        providerId: '12345',
+        avatarUrl: 'https://avatars.github.com/12345',
+      })
+    })
+
+    it('photos가 없으면 avatarUrl이 undefined이다', () => {
+      const profile = { id: 67890 }
+      const result = strategy.validate('access', 'refresh', profile)
+      expect(result).toEqual({
+        provider: 'github',
+        providerId: '67890',
+        avatarUrl: undefined,
+      })
+    })
+
+    it('숫자 id를 문자열로 변환한다', () => {
+      const profile = { id: 99999, photos: [] }
+      const result = strategy.validate('access', 'refresh', profile)
+      expect(result.providerId).toBe('99999')
+    })
+  })
+})

--- a/backend/src/oauth/strategy/jwt-refresh.strategy.spec.ts
+++ b/backend/src/oauth/strategy/jwt-refresh.strategy.spec.ts
@@ -1,51 +1,51 @@
-import type { Request } from 'express'
 import { UnauthorizedException } from '@nestjs/common'
-import { RefreshStrategy } from './jwt-refresh.strategy'
-import type { ConfigService } from '@nestjs/config'
+import type { ExecutionContext } from '@nestjs/common'
+import { RefreshGuard } from './jwt-refresh.strategy'
 
-interface JwtRefreshPayload {
-  sub: string
-  iat?: number
-  exp?: number
-}
-
-describe('RefreshStrategy', () => {
-  let strategy: RefreshStrategy
+describe('RefreshGuard', () => {
+  let guard: RefreshGuard
 
   beforeEach(() => {
-    const configService = {
-      getOrThrow: jest.fn().mockReturnValue('test-refresh-secret'),
-      get: jest.fn(),
-    } as unknown as ConfigService
-    strategy = new RefreshStrategy(configService)
+    guard = new RefreshGuard()
   })
 
-  describe('validate', () => {
-    it('유효한 요청에서 userId와 refreshToken을 반환한다', () => {
-      const req = { cookies: { refresh_token: 'token-abc' } } as unknown as Request
-      const payload: JwtRefreshPayload = { sub: 'user-1' }
-      const result = strategy.validate(req, payload)
-      expect(result).toEqual({ userId: 'user-1', refreshToken: 'token-abc' })
+  const createMockContext = (cookies?: Record<string, string>): ExecutionContext => {
+    return {
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          cookies,
+          user: undefined,
+        }),
+      }),
+    } as unknown as ExecutionContext
+  }
+
+  describe('canActivate', () => {
+    it('session_id 쿠키가 있으면 true를 반환하고 user에 sessionId를 설정한다', () => {
+      const mockRequest = { cookies: { session_id: 'session-abc' }, user: undefined as unknown }
+      const context = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getRequest: jest.fn().mockReturnValue(mockRequest),
+        }),
+      } as unknown as ExecutionContext
+
+      const result = guard.canActivate(context)
+
+      expect(result).toBe(true)
+      expect(mockRequest.user).toEqual({ userId: '', sessionId: 'session-abc' })
     })
 
-    it('sub가 없으면 UnauthorizedException을 던진다', () => {
-      const req = { cookies: { refresh_token: 'token-abc' } } as unknown as Request
-      expect(() => strategy.validate(req, { sub: '' })).toThrow(UnauthorizedException)
+    it('session_id 쿠키가 없으면 UnauthorizedException을 던진다', () => {
+      const context = createMockContext({})
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException)
+      expect(() => guard.canActivate(context)).toThrow('세션이 없습니다.')
     })
 
-    it('payload가 null이면 UnauthorizedException을 던진다', () => {
-      const req = { cookies: { refresh_token: 'token-abc' } } as unknown as Request
-      expect(() => strategy.validate(req, null as unknown as JwtRefreshPayload)).toThrow(UnauthorizedException)
-    })
+    it('cookies가 undefined이면 UnauthorizedException을 던진다', () => {
+      const context = createMockContext(undefined)
 
-    it('refresh_token 쿠키가 없으면 UnauthorizedException을 던진다', () => {
-      const req = { cookies: {} } as unknown as Request
-      expect(() => strategy.validate(req, { sub: 'user-1' })).toThrow(UnauthorizedException)
-    })
-
-    it('cookies 자체가 undefined이면 UnauthorizedException을 던진다', () => {
-      const req = { cookies: undefined } as unknown as Request
-      expect(() => strategy.validate(req, { sub: 'user-1' })).toThrow(UnauthorizedException)
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException)
     })
   })
 })

--- a/backend/src/oauth/strategy/jwt-refresh.strategy.spec.ts
+++ b/backend/src/oauth/strategy/jwt-refresh.strategy.spec.ts
@@ -1,0 +1,51 @@
+import type { Request } from 'express'
+import { UnauthorizedException } from '@nestjs/common'
+import { RefreshStrategy } from './jwt-refresh.strategy'
+import type { ConfigService } from '@nestjs/config'
+
+interface JwtRefreshPayload {
+  sub: string
+  iat?: number
+  exp?: number
+}
+
+describe('RefreshStrategy', () => {
+  let strategy: RefreshStrategy
+
+  beforeEach(() => {
+    const configService = {
+      getOrThrow: jest.fn().mockReturnValue('test-refresh-secret'),
+      get: jest.fn(),
+    } as unknown as ConfigService
+    strategy = new RefreshStrategy(configService)
+  })
+
+  describe('validate', () => {
+    it('유효한 요청에서 userId와 refreshToken을 반환한다', () => {
+      const req = { cookies: { refresh_token: 'token-abc' } } as unknown as Request
+      const payload: JwtRefreshPayload = { sub: 'user-1' }
+      const result = strategy.validate(req, payload)
+      expect(result).toEqual({ userId: 'user-1', refreshToken: 'token-abc' })
+    })
+
+    it('sub가 없으면 UnauthorizedException을 던진다', () => {
+      const req = { cookies: { refresh_token: 'token-abc' } } as unknown as Request
+      expect(() => strategy.validate(req, { sub: '' })).toThrow(UnauthorizedException)
+    })
+
+    it('payload가 null이면 UnauthorizedException을 던진다', () => {
+      const req = { cookies: { refresh_token: 'token-abc' } } as unknown as Request
+      expect(() => strategy.validate(req, null as unknown as JwtRefreshPayload)).toThrow(UnauthorizedException)
+    })
+
+    it('refresh_token 쿠키가 없으면 UnauthorizedException을 던진다', () => {
+      const req = { cookies: {} } as unknown as Request
+      expect(() => strategy.validate(req, { sub: 'user-1' })).toThrow(UnauthorizedException)
+    })
+
+    it('cookies 자체가 undefined이면 UnauthorizedException을 던진다', () => {
+      const req = { cookies: undefined } as unknown as Request
+      expect(() => strategy.validate(req, { sub: 'user-1' })).toThrow(UnauthorizedException)
+    })
+  })
+})

--- a/backend/src/oauth/strategy/jwt.strategy.spec.ts
+++ b/backend/src/oauth/strategy/jwt.strategy.spec.ts
@@ -1,0 +1,36 @@
+import { UnauthorizedException } from '@nestjs/common'
+import { JwtStrategy } from './jwt.strategy'
+import type { ConfigService } from '@nestjs/config'
+
+interface JwtPayload {
+  sub: string
+  iat?: number
+  exp?: number
+}
+
+describe('JwtStrategy', () => {
+  let strategy: JwtStrategy
+
+  beforeEach(() => {
+    const configService = {
+      getOrThrow: jest.fn().mockReturnValue('test-secret'),
+      get: jest.fn(),
+    } as unknown as ConfigService
+    strategy = new JwtStrategy(configService)
+  })
+
+  describe('validate', () => {
+    it('유효한 payload에서 id를 반환한다', () => {
+      const result = strategy.validate({ sub: 'user-1' })
+      expect(result).toEqual({ id: 'user-1' })
+    })
+
+    it('sub가 없으면 UnauthorizedException을 던진다', () => {
+      expect(() => strategy.validate({ sub: '' })).toThrow(UnauthorizedException)
+    })
+
+    it('payload가 null이면 UnauthorizedException을 던진다', () => {
+      expect(() => strategy.validate(null as unknown as JwtPayload)).toThrow(UnauthorizedException)
+    })
+  })
+})

--- a/backend/src/oauth/strategy/kakao.strategy.spec.ts
+++ b/backend/src/oauth/strategy/kakao.strategy.spec.ts
@@ -1,0 +1,75 @@
+import { KakaoStrategy } from './kakao.strategy'
+import type { ConfigService } from '@nestjs/config'
+
+describe('KakaoStrategy', () => {
+  let strategy: KakaoStrategy
+
+  beforeEach(() => {
+    const configService = {
+      get: jest.fn((key: string) => {
+        const config: Record<string, string> = {
+          KAKAO_CLIENT_ID: 'test-kakao-id',
+          KAKAO_CLIENT_SECRET: 'test-kakao-secret',
+          KAKAO_CALLBACK_URL: 'http://localhost:3000/auth/kakao/callback',
+        }
+        return config[key]
+      }),
+    } as unknown as ConfigService
+    strategy = new KakaoStrategy(configService)
+  })
+
+  describe('validate', () => {
+    it('Kakao 프로필에서 kakao_account 이미지를 추출한다', () => {
+      const profile = {
+        id: '11111',
+        _json: {
+          kakao_account: {
+            profile: {
+              profile_image_url: 'https://k.kakao.com/avatar.png',
+            },
+          },
+        },
+      }
+      const result = strategy.validate('access', 'refresh', profile)
+      expect(result).toEqual({
+        provider: 'kakao',
+        providerId: '11111',
+        avatarUrl: 'https://k.kakao.com/avatar.png',
+      })
+    })
+
+    it('kakao_account가 없으면 properties에서 이미지를 추출한다', () => {
+      const profile = {
+        id: '22222',
+        _json: {
+          properties: {
+            profile_image: 'https://k.kakao.com/prop-avatar.png',
+          },
+        },
+      }
+      const result = strategy.validate('access', 'refresh', profile)
+      expect(result).toEqual({
+        provider: 'kakao',
+        providerId: '22222',
+        avatarUrl: 'https://k.kakao.com/prop-avatar.png',
+      })
+    })
+
+    it('이미지가 없으면 avatarUrl이 undefined이다', () => {
+      const profile = { id: 33333, _json: {} }
+      const result = strategy.validate('access', 'refresh', profile)
+      expect(result).toEqual({
+        provider: 'kakao',
+        providerId: '33333',
+        avatarUrl: undefined,
+      })
+    })
+
+    it('_json이 없어도 에러 없이 처리한다', () => {
+      const profile = { id: 44444 }
+      const result = strategy.validate('access', 'refresh', profile)
+      expect(result.provider).toBe('kakao')
+      expect(result.providerId).toBe('44444')
+    })
+  })
+})

--- a/backend/src/prisma/prisma.service.spec.ts
+++ b/backend/src/prisma/prisma.service.spec.ts
@@ -1,0 +1,67 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { UnauthorizedException } from '@nestjs/common'
+import { PrismaService } from './prisma.service'
+import type { ConfigService } from '@nestjs/config'
+
+jest.mock('generated/prisma/client', () => ({
+  PrismaClient: class MockPrismaClient {
+    constructor() {}
+    $connect = jest.fn().mockResolvedValue(undefined)
+    $disconnect = jest.fn().mockResolvedValue(undefined)
+  },
+}))
+
+jest.mock('@prisma/adapter-pg', () => ({
+  PrismaPg: class MockPrismaPg {
+    constructor() {}
+  },
+}))
+
+describe('PrismaService', () => {
+  const createMockConfigService = (dbUrl: string | undefined): jest.Mocked<ConfigService> =>
+    ({
+      get: jest.fn((key: string) => {
+        if (key === 'DATABASE_URL') return dbUrl
+        return undefined
+      }),
+    }) as unknown as jest.Mocked<ConfigService>
+
+  describe('constructor', () => {
+    it('DATABASE_URL이 없으면 UnauthorizedException을 던진다', () => {
+      const configService = createMockConfigService(undefined)
+
+      expect(() => new PrismaService(configService)).toThrow(UnauthorizedException)
+      expect(() => new PrismaService(configService)).toThrow('유효하지 않은 DB_URL입니다.')
+    })
+
+    it('DATABASE_URL이 있으면 정상적으로 생성된다', () => {
+      const configService = createMockConfigService('postgresql://localhost:5432/test')
+
+      const service = new PrismaService(configService)
+
+      expect(service).toBeDefined()
+    })
+  })
+
+  describe('onModuleInit', () => {
+    it('$connect를 호출한다', async () => {
+      const configService = createMockConfigService('postgresql://localhost:5432/test')
+      const service = new PrismaService(configService)
+
+      await service.onModuleInit()
+
+      expect(service.$connect).toHaveBeenCalled()
+    })
+  })
+
+  describe('enableShutdownHooks', () => {
+    it('$disconnect를 호출한다', async () => {
+      const configService = createMockConfigService('postgresql://localhost:5432/test')
+      const service = new PrismaService(configService)
+
+      await service.enableShutdownHooks()
+
+      expect(service.$disconnect).toHaveBeenCalled()
+    })
+  })
+})

--- a/backend/src/redis/redis.repository.spec.ts
+++ b/backend/src/redis/redis.repository.spec.ts
@@ -1,0 +1,143 @@
+import type { Redis } from 'ioredis'
+import { RedisRepository } from './redis.repository'
+
+describe('RedisRepository', () => {
+  let repository: RedisRepository
+  let mockRedis: Record<string, jest.Mock>
+
+  beforeEach(() => {
+    mockRedis = {
+      on: jest.fn(),
+      quit: jest.fn().mockResolvedValue('OK'),
+      get: jest.fn(),
+      set: jest.fn(),
+      setex: jest.fn(),
+      del: jest.fn(),
+      exists: jest.fn(),
+      hset: jest.fn(),
+      hget: jest.fn(),
+      hgetall: jest.fn(),
+      lpush: jest.fn(),
+      lrange: jest.fn(),
+    }
+    repository = new RedisRepository(mockRedis as unknown as Redis)
+  })
+
+  describe('bindEvents', () => {
+    it('Redis 이벤트 리스너를 등록한다', () => {
+      expect(mockRedis.on).toHaveBeenCalledWith('connect', expect.any(Function))
+      expect(mockRedis.on).toHaveBeenCalledWith('ready', expect.any(Function))
+      expect(mockRedis.on).toHaveBeenCalledWith('error', expect.any(Function))
+      expect(mockRedis.on).toHaveBeenCalledWith('close', expect.any(Function))
+    })
+  })
+
+  describe('onModuleDestroy', () => {
+    it('Redis 연결을 종료한다', async () => {
+      await repository.onModuleDestroy()
+      expect(mockRedis.quit).toHaveBeenCalled()
+    })
+  })
+
+  describe('get', () => {
+    it('키에 해당하는 값을 반환한다', async () => {
+      mockRedis.get.mockResolvedValue('value')
+      const result = await repository.get('key')
+      expect(result).toBe('value')
+      expect(mockRedis.get).toHaveBeenCalledWith('key')
+    })
+
+    it('키가 없으면 null을 반환한다', async () => {
+      mockRedis.get.mockResolvedValue(null)
+      const result = await repository.get('missing')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('set', () => {
+    it('키에 값을 저장한다', async () => {
+      mockRedis.set.mockResolvedValue('OK')
+      const result = await repository.set('key', 'value')
+      expect(result).toBe('OK')
+      expect(mockRedis.set).toHaveBeenCalledWith('key', 'value')
+    })
+
+    it('TTL을 설정하면 setex를 사용한다', async () => {
+      mockRedis.setex.mockResolvedValue('OK')
+      const result = await repository.set('key', 'value', 60)
+      expect(result).toBe('OK')
+      expect(mockRedis.setex).toHaveBeenCalledWith('key', 60, 'value')
+    })
+  })
+
+  describe('del', () => {
+    it('키를 삭제한다', async () => {
+      mockRedis.del.mockResolvedValue(1)
+      const result = await repository.del('key')
+      expect(result).toBe(1)
+    })
+  })
+
+  describe('exists', () => {
+    it('키가 존재하면 true를 반환한다', async () => {
+      mockRedis.exists.mockResolvedValue(1)
+      const result = await repository.exists('key')
+      expect(result).toBe(true)
+    })
+
+    it('키가 없으면 false를 반환한다', async () => {
+      mockRedis.exists.mockResolvedValue(0)
+      const result = await repository.exists('missing')
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('hset', () => {
+    it('해시 필드에 값을 저장한다', async () => {
+      mockRedis.hset.mockResolvedValue(1)
+      const result = await repository.hset('hash', 'field', 'value')
+      expect(result).toBe(1)
+      expect(mockRedis.hset).toHaveBeenCalledWith('hash', 'field', 'value')
+    })
+  })
+
+  describe('hget', () => {
+    it('해시 필드의 값을 반환한다', async () => {
+      mockRedis.hget.mockResolvedValue('value')
+      const result = await repository.hget('hash', 'field')
+      expect(result).toBe('value')
+    })
+  })
+
+  describe('hgetall', () => {
+    it('해시의 모든 필드를 반환한다', async () => {
+      mockRedis.hgetall.mockResolvedValue({ field1: 'a', field2: 'b' })
+      const result = await repository.hgetall('hash')
+      expect(result).toEqual({ field1: 'a', field2: 'b' })
+    })
+  })
+
+  describe('lpush', () => {
+    it('리스트에 값을 추가한다', async () => {
+      mockRedis.lpush.mockResolvedValue(2)
+      const result = await repository.lpush('list', 'a', 'b')
+      expect(result).toBe(2)
+      expect(mockRedis.lpush).toHaveBeenCalledWith('list', 'a', 'b')
+    })
+  })
+
+  describe('lrange', () => {
+    it('리스트의 범위를 반환한다', async () => {
+      mockRedis.lrange.mockResolvedValue(['a', 'b'])
+      const result = await repository.lrange('list', 0, -1)
+      expect(result).toEqual(['a', 'b'])
+    })
+  })
+
+  describe('getRedisClient', () => {
+    it('Redis 클라이언트를 반환한다', () => {
+      const client = repository.getRedisClient()
+      expect(client).toBe(mockRedis)
+    })
+  })
+})

--- a/frontend/src/commons/apis/test/getOAuthUser.test.ts
+++ b/frontend/src/commons/apis/test/getOAuthUser.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import getOAuthUser from '../getOAuthUser';
+
+describe('getOAuthUser', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockOAuthResponse = {
+    id: 'user-1',
+    provider: 'github',
+    providerId: '12345',
+    nickname: '테스터',
+    avatarUrl: 'https://example.com/avatar.png',
+    tier: 'SILVER',
+    rating: 250
+  };
+
+  it('정상 응답 시 AuthUser 객체를 반환한다', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockOAuthResponse
+    } as Response);
+
+    const user = await getOAuthUser();
+
+    expect(user).toEqual({
+      id: 'user-1',
+      nickname: '테스터',
+      type: 'oauth',
+      provider: 'github',
+      avatarUrl: 'https://example.com/avatar.png',
+      tier: 'SILVER',
+      rating: 250
+    });
+  });
+
+  it('401 응답 시 에러를 던진다', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({})
+    } as Response);
+
+    await expect(getOAuthUser()).rejects.toThrow('잘못된 사용자 정보 형식입니다.');
+  });
+
+  it('서버 에러 시 에러를 던진다', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({})
+    } as Response);
+
+    await expect(getOAuthUser()).rejects.toThrow('사용자 정보를 가져오는데 실패했습니다.');
+  });
+
+  it('잘못된 응답 형식이면 에러를 던진다', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ invalid: 'data' })
+    } as Response);
+
+    await expect(getOAuthUser()).rejects.toThrow('잘못된 사용자 정보 형식입니다.');
+  });
+});

--- a/frontend/src/commons/apis/test/postGuestLogin.test.ts
+++ b/frontend/src/commons/apis/test/postGuestLogin.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fetchPostGuestLogin from '../postGuestLogin';
+
+describe('fetchPostGuestLogin', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('정상 응답 시 id와 nickname을 반환한다', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'guest-1', nickname: '귀여운 레오' })
+    } as Response);
+
+    const result = await fetchPostGuestLogin('battle-123');
+
+    expect(result).toEqual({ id: 'guest-1', nickname: '귀여운 레오' });
+    expect(fetch).toHaveBeenCalledWith('/api/auth/guest/battle-123', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    });
+  });
+
+  it('서버 에러 시 에러를 던진다', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      json: async () => ({})
+    } as Response);
+
+    await expect(fetchPostGuestLogin('battle-123')).rejects.toThrow('비회원 로그인에 실패하였습니다.');
+  });
+
+  it('잘못된 응답 형식이면 에러를 던진다', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ invalid: true })
+    } as Response);
+
+    await expect(fetchPostGuestLogin('battle-123')).rejects.toThrow('잘못된 로그인 응답 형식입니다.');
+  });
+});

--- a/frontend/src/commons/apis/test/postGuestLogin.test.ts
+++ b/frontend/src/commons/apis/test/postGuestLogin.test.ts
@@ -15,7 +15,7 @@ describe('fetchPostGuestLogin', () => {
     const result = await fetchPostGuestLogin('battle-123');
 
     expect(result).toEqual({ id: 'guest-1', nickname: '귀여운 레오' });
-    expect(fetch).toHaveBeenCalledWith('/api/auth/guest/battle-123', {
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/api/auth/guest/battle-123'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' }
     });

--- a/frontend/src/commons/apis/test/postLogout.test.ts
+++ b/frontend/src/commons/apis/test/postLogout.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import logout from '../postLogout';
+
+describe('logout', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('정상 응답 시 success를 반환한다', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true })
+    } as Response);
+
+    const result = await logout();
+
+    expect(result).toEqual({ success: true });
+    expect(fetch).toHaveBeenCalledWith('/api/auth/logout', {
+      method: 'POST',
+      credentials: 'include'
+    });
+  });
+
+  it('서버 에러 시 에러를 던진다', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      json: async () => ({})
+    } as Response);
+
+    await expect(logout()).rejects.toThrow('로그아웃에 실패했습니다.');
+  });
+
+  it('잘못된 응답 형식이면 에러를 던진다', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ invalid: true })
+    } as Response);
+
+    await expect(logout()).rejects.toThrow('잘못된 로그아웃 응답 형식입니다.');
+  });
+});

--- a/frontend/src/commons/apis/test/postLogout.test.ts
+++ b/frontend/src/commons/apis/test/postLogout.test.ts
@@ -15,7 +15,7 @@ describe('logout', () => {
     const result = await logout();
 
     expect(result).toEqual({ success: true });
-    expect(fetch).toHaveBeenCalledWith('/api/auth/logout', {
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/api/auth/logout'), {
       method: 'POST',
       credentials: 'include'
     });

--- a/frontend/src/commons/hooks/test/useModal.test.ts
+++ b/frontend/src/commons/hooks/test/useModal.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import useModal from '../useModal';
+
+describe('useModal', () => {
+  it('기본값은 닫힌 상태이다', () => {
+    const { result } = renderHook(() => useModal());
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('initialState로 열린 상태로 시작할 수 있다', () => {
+    const { result } = renderHook(() => useModal(true));
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('openModal을 호출하면 열린다', () => {
+    const { result } = renderHook(() => useModal());
+
+    act(() => {
+      result.current.openModal();
+    });
+
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('closeModal을 호출하면 닫힌다', () => {
+    const { result } = renderHook(() => useModal(true));
+
+    act(() => {
+      result.current.closeModal();
+    });
+
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('openModal과 closeModal을 반복 호출할 수 있다', () => {
+    const { result } = renderHook(() => useModal());
+
+    act(() => result.current.openModal());
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => result.current.closeModal());
+    expect(result.current.isOpen).toBe(false);
+
+    act(() => result.current.openModal());
+    expect(result.current.isOpen).toBe(true);
+  });
+});

--- a/frontend/src/commons/stores/test/authStore.test.ts
+++ b/frontend/src/commons/stores/test/authStore.test.ts
@@ -211,4 +211,95 @@ describe('authStore', () => {
       expect(state2.user?.type === 'oauth').toBe(false);
     });
   });
+
+  describe('updateGuestTeam', () => {
+    it('게스트 사용자의 팀을 업데이트한다', async () => {
+      const mockGuestData = {
+        id: 'guest-123',
+        nickname: '심심한 레오'
+      };
+
+      vi.mocked(fetchPostGuestLogin).mockResolvedValue(mockGuestData);
+      await useAuthStore.getState().loginGuest('battle-1');
+
+      useAuthStore.getState().updateGuestTeam('A');
+
+      expect(useAuthStore.getState().user?.selectedTeam).toBe('A');
+      const stored = JSON.parse(localStorage.getItem('CMC_GUEST_USER') || '{}');
+      expect(stored.selectedTeam).toBe('A');
+    });
+
+    it('B팀으로 업데이트할 수 있다', async () => {
+      const mockGuestData = {
+        id: 'guest-123',
+        nickname: '심심한 레오'
+      };
+
+      vi.mocked(fetchPostGuestLogin).mockResolvedValue(mockGuestData);
+      await useAuthStore.getState().loginGuest('battle-1');
+
+      useAuthStore.getState().updateGuestTeam('B');
+
+      expect(useAuthStore.getState().user?.selectedTeam).toBe('B');
+    });
+
+    it('OAuth 사용자는 팀 업데이트가 무시된다', async () => {
+      const mockOAuthUser = {
+        id: 'oauth-123',
+        nickname: 'OAuth유저',
+        type: 'oauth' as const,
+        avatarUrl: 'https://example.com/avatar.jpg'
+      };
+
+      vi.mocked(getOAuthUser).mockResolvedValue(mockOAuthUser);
+      await useAuthStore.getState().getOAuthUser();
+
+      useAuthStore.getState().updateGuestTeam('A');
+
+      // OAuth 유저는 selectedTeam이 설정되지 않음
+      expect(useAuthStore.getState().user?.selectedTeam).toBeUndefined();
+    });
+
+    it('사용자가 없으면 팀 업데이트가 무시된다', () => {
+      useAuthStore.setState({ user: null });
+
+      useAuthStore.getState().updateGuestTeam('A');
+
+      expect(useAuthStore.getState().user).toBeNull();
+    });
+  });
+
+  describe('getOAuthUser with guest user', () => {
+    it('게스트 사용자일 때 OAuth 체크를 하지 않고 null을 반환한다', async () => {
+      const mockGuestData = {
+        id: 'guest-123',
+        nickname: '심심한 레오'
+      };
+
+      vi.mocked(fetchPostGuestLogin).mockResolvedValue(mockGuestData);
+      await useAuthStore.getState().loginGuest('battle-1');
+
+      vi.mocked(getOAuthUser).mockClear();
+
+      const result = await useAuthStore.getState().getOAuthUser();
+
+      expect(result).toBeNull();
+      expect(vi.mocked(getOAuthUser)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loginGuest with selectedTeam', () => {
+    it('선택한 팀과 함께 비회원 로그인이 가능하다', async () => {
+      const mockGuestData = {
+        id: 'guest-123',
+        nickname: '심심한 레오'
+      };
+
+      vi.mocked(fetchPostGuestLogin).mockResolvedValue(mockGuestData);
+
+      await useAuthStore.getState().loginGuest('battle-1', 'A');
+
+      expect(useAuthStore.getState().user?.selectedTeam).toBe('A');
+    });
+  });
 });

--- a/frontend/src/commons/stores/test/toastStore.test.ts
+++ b/frontend/src/commons/stores/test/toastStore.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { useToastStore, selectToasts, selectAddToast, selectRemoveToast, selectClearToasts } from '../toastStore';
+
+describe('toastStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useToastStore.getState().clearToasts();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('addToast', () => {
+    it('토스트를 추가한다', () => {
+      useToastStore.getState().addToast({ message: '테스트 메시지' });
+      const toasts = useToastStore.getState().toasts;
+
+      expect(toasts).toHaveLength(1);
+      expect(toasts[0].message).toBe('테스트 메시지');
+      expect(toasts[0].id).toBeDefined();
+    });
+
+    it('최대 3개까지만 유지한다', () => {
+      const { addToast } = useToastStore.getState();
+      addToast({ message: '1', duration: 0 });
+      addToast({ message: '2', duration: 0 });
+      addToast({ message: '3', duration: 0 });
+      addToast({ message: '4', duration: 0 });
+
+      const toasts = useToastStore.getState().toasts;
+      expect(toasts).toHaveLength(3);
+      expect(toasts[0].message).toBe('2');
+      expect(toasts[2].message).toBe('4');
+    });
+
+    it('기본 3초 후 자동으로 제거된다', () => {
+      useToastStore.getState().addToast({ message: '자동 삭제' });
+      expect(useToastStore.getState().toasts).toHaveLength(1);
+
+      vi.advanceTimersByTime(3000);
+      expect(useToastStore.getState().toasts).toHaveLength(0);
+    });
+
+    it('커스텀 duration을 설정할 수 있다', () => {
+      useToastStore.getState().addToast({ message: '커스텀', duration: 5000 });
+      expect(useToastStore.getState().toasts).toHaveLength(1);
+
+      vi.advanceTimersByTime(3000);
+      expect(useToastStore.getState().toasts).toHaveLength(1);
+
+      vi.advanceTimersByTime(2000);
+      expect(useToastStore.getState().toasts).toHaveLength(0);
+    });
+
+    it('duration이 0이면 자동 삭제되지 않는다', () => {
+      useToastStore.getState().addToast({ message: '영구', duration: 0 });
+
+      vi.advanceTimersByTime(10000);
+      expect(useToastStore.getState().toasts).toHaveLength(1);
+    });
+  });
+
+  describe('removeToast', () => {
+    it('ID로 특정 토스트를 제거한다', () => {
+      useToastStore.getState().addToast({ message: '제거 대상', duration: 0 });
+      const id = useToastStore.getState().toasts[0].id;
+
+      useToastStore.getState().removeToast(id);
+      expect(useToastStore.getState().toasts).toHaveLength(0);
+    });
+  });
+
+  describe('clearToasts', () => {
+    it('모든 토스트를 제거한다', () => {
+      const { addToast } = useToastStore.getState();
+      addToast({ message: '1', duration: 0 });
+      addToast({ message: '2', duration: 0 });
+
+      useToastStore.getState().clearToasts();
+      expect(useToastStore.getState().toasts).toHaveLength(0);
+    });
+  });
+
+  describe('selectors', () => {
+    it('selectToasts가 토스트 배열을 반환한다', () => {
+      useToastStore.getState().addToast({ message: '셀렉터', duration: 0 });
+      const state = useToastStore.getState();
+      expect(selectToasts(state)).toHaveLength(1);
+    });
+
+    it('selectAddToast가 함수를 반환한다', () => {
+      const state = useToastStore.getState();
+      expect(typeof selectAddToast(state)).toBe('function');
+    });
+
+    it('selectRemoveToast가 함수를 반환한다', () => {
+      const state = useToastStore.getState();
+      expect(typeof selectRemoveToast(state)).toBe('function');
+    });
+
+    it('selectClearToasts가 함수를 반환한다', () => {
+      const state = useToastStore.getState();
+      expect(typeof selectClearToasts(state)).toBe('function');
+    });
+  });
+});

--- a/frontend/src/commons/utils/test/getTimeAgo.test.ts
+++ b/frontend/src/commons/utils/test/getTimeAgo.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getTimeAgo } from '../getTimeAgo';
+
+describe('getTimeAgo', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const setNow = (date: Date) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(date);
+  };
+
+  const now = new Date('2025-06-01T12:00:00.000Z');
+
+  it('60초 미만이면 "방금 전"을 반환한다', () => {
+    setNow(now);
+    const timestamp = new Date(now.getTime() - 30 * 1000).toISOString();
+    expect(getTimeAgo(timestamp)).toBe('방금 전');
+  });
+
+  it('60분 미만이면 "N분 전"을 반환한다', () => {
+    setNow(now);
+    const timestamp = new Date(now.getTime() - 5 * 60 * 1000).toISOString();
+    expect(getTimeAgo(timestamp)).toBe('5분 전');
+  });
+
+  it('24시간 미만이면 "N시간 전"을 반환한다', () => {
+    setNow(now);
+    const timestamp = new Date(now.getTime() - 3 * 60 * 60 * 1000).toISOString();
+    expect(getTimeAgo(timestamp)).toBe('3시간 전');
+  });
+
+  it('30일 미만이면 "N일 전"을 반환한다', () => {
+    setNow(now);
+    const timestamp = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    expect(getTimeAgo(timestamp)).toBe('7일 전');
+  });
+
+  it('12개월 미만이면 "N개월 전"을 반환한다', () => {
+    setNow(now);
+    const timestamp = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000).toISOString();
+    expect(getTimeAgo(timestamp)).toBe('3개월 전');
+  });
+
+  it('12개월 이상이면 "N년 전"을 반환한다', () => {
+    setNow(now);
+    const timestamp = new Date(now.getTime() - 400 * 24 * 60 * 60 * 1000).toISOString();
+    expect(getTimeAgo(timestamp)).toBe('1년 전');
+  });
+});

--- a/frontend/src/commons/utils/test/languageMapper.test.ts
+++ b/frontend/src/commons/utils/test/languageMapper.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { languageMapper } from '../languageMapper';
+
+describe('languageMapper', () => {
+  it('대문자 약어를 소문자 전체 이름으로 변환한다', () => {
+    expect(languageMapper('TS')).toBe('typescript');
+    expect(languageMapper('JS')).toBe('javascript');
+    expect(languageMapper('PYTHON')).toBe('python');
+  });
+
+  it('소문자 전체 이름은 그대로 반환한다', () => {
+    expect(languageMapper('typescript')).toBe('typescript');
+    expect(languageMapper('javascript')).toBe('javascript');
+    expect(languageMapper('python')).toBe('python');
+  });
+
+  it('매핑에 없는 언어는 입력값 그대로 반환한다', () => {
+    expect(languageMapper('rust')).toBe('rust');
+    expect(languageMapper('go')).toBe('go');
+    expect(languageMapper('')).toBe('');
+  });
+});

--- a/frontend/src/pages/battlePage/components/chatting/test/ChatInput.test.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/test/ChatInput.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChatInput from '@/pages/battlePage/components/chatting/ChatInput';
+
+vi.mock('@/assets/icon/send.svg?react', () => ({
+  default: () => <svg data-testid="send-icon" />
+}));
+
+describe('ChatInput', () => {
+  const mockOnSend = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('입력 필드와 전송 버튼을 렌더링한다', () => {
+    render(<ChatInput onSend={mockOnSend} />);
+
+    expect(screen.getByPlaceholderText('메시지를 입력하세요...')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByTestId('send-icon')).toBeInTheDocument();
+  });
+
+  it('입력 필드 값이 변경된다', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSend={mockOnSend} />);
+
+    const input = screen.getByPlaceholderText('메시지를 입력하세요...');
+    await user.type(input, 'Hello World');
+
+    expect(input).toHaveValue('Hello World');
+  });
+
+  it('전송 버튼 클릭 시 onSend가 입력값과 함께 호출된다', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSend={mockOnSend} />);
+
+    const input = screen.getByPlaceholderText('메시지를 입력하세요...');
+    await user.type(input, 'Test message');
+    await user.click(screen.getByRole('button'));
+
+    expect(mockOnSend).toHaveBeenCalledWith('Test message');
+  });
+
+  it('전송 후 입력 필드가 비워진다', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSend={mockOnSend} />);
+
+    const input = screen.getByPlaceholderText('메시지를 입력하세요...');
+    await user.type(input, 'Test message');
+    await user.click(screen.getByRole('button'));
+
+    expect(input).toHaveValue('');
+  });
+
+  it('빈 입력값에서는 onSend가 호출되지 않는다', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSend={mockOnSend} />);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(mockOnSend).not.toHaveBeenCalled();
+  });
+
+  it('Enter 키 입력 시 메시지가 전송된다', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSend={mockOnSend} />);
+
+    const input = screen.getByPlaceholderText('메시지를 입력하세요...');
+    await user.type(input, 'Enter test{enter}');
+
+    expect(mockOnSend).toHaveBeenCalledWith('Enter test');
+  });
+
+  it('빈 입력값에서 Enter 키 입력 시 onSend가 호출되지 않는다', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSend={mockOnSend} />);
+
+    const input = screen.getByPlaceholderText('메시지를 입력하세요...');
+    await user.type(input, '{enter}');
+
+    expect(mockOnSend).not.toHaveBeenCalled();
+  });
+
+  it('입력 필드에 placeholder가 표시된다', () => {
+    render(<ChatInput onSend={mockOnSend} />);
+
+    const input = screen.getByPlaceholderText('메시지를 입력하세요...');
+    expect(input).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/battlePage/components/codeview/test/CodeHeader.test.tsx
+++ b/frontend/src/pages/battlePage/components/codeview/test/CodeHeader.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CodeHeader from '@/pages/battlePage/components/codeview/CodeHeader';
+
+describe('CodeHeader', () => {
+  const mockOnViewChange = vi.fn();
+  const mockOnTabChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('스플릿 뷰와 탭 뷰 버튼을 렌더링한다', () => {
+    render(
+      <CodeHeader onViewChange={mockOnViewChange} currentView="split" currentTab="A" onTabChange={mockOnTabChange} />
+    );
+
+    expect(screen.getByRole('button', { name: '스플릿 뷰' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '탭 뷰' })).toBeInTheDocument();
+  });
+
+  it('currentView가 split일 때 스플릿 뷰 버튼이 활성화된다', () => {
+    render(
+      <CodeHeader onViewChange={mockOnViewChange} currentView="split" currentTab="A" onTabChange={mockOnTabChange} />
+    );
+
+    const splitButton = screen.getByRole('button', { name: '스플릿 뷰' });
+    expect(splitButton.className).toContain('bg-[#FF6900]');
+  });
+
+  it('currentView가 tab일 때 탭 뷰 버튼이 활성화된다', () => {
+    render(
+      <CodeHeader onViewChange={mockOnViewChange} currentView="tab" currentTab="A" onTabChange={mockOnTabChange} />
+    );
+
+    const tabButton = screen.getByRole('button', { name: '탭 뷰' });
+    expect(tabButton.className).toContain('bg-[#FF6900]');
+  });
+
+  it('스플릿 뷰 버튼 클릭 시 onViewChange("split")를 호출한다', async () => {
+    const user = userEvent.setup();
+    render(
+      <CodeHeader onViewChange={mockOnViewChange} currentView="tab" currentTab="A" onTabChange={mockOnTabChange} />
+    );
+
+    await user.click(screen.getByRole('button', { name: '스플릿 뷰' }));
+    expect(mockOnViewChange).toHaveBeenCalledWith('split');
+  });
+
+  it('탭 뷰 버튼 클릭 시 onViewChange("tab")를 호출한다', async () => {
+    const user = userEvent.setup();
+    render(
+      <CodeHeader onViewChange={mockOnViewChange} currentView="split" currentTab="A" onTabChange={mockOnTabChange} />
+    );
+
+    await user.click(screen.getByRole('button', { name: '탭 뷰' }));
+    expect(mockOnViewChange).toHaveBeenCalledWith('tab');
+  });
+
+  it('currentView가 tab일 때만 팀 선택 버튼이 표시된다', () => {
+    const { rerender } = render(
+      <CodeHeader onViewChange={mockOnViewChange} currentView="split" currentTab="A" onTabChange={mockOnTabChange} />
+    );
+
+    expect(screen.queryByRole('button', { name: 'A팀' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'B팀' })).not.toBeInTheDocument();
+
+    rerender(
+      <CodeHeader onViewChange={mockOnViewChange} currentView="tab" currentTab="A" onTabChange={mockOnTabChange} />
+    );
+
+    expect(screen.getByRole('button', { name: 'A팀' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'B팀' })).toBeInTheDocument();
+  });
+
+  it('A팀 버튼 클릭 시 onTabChange("A")를 호출한다', async () => {
+    const user = userEvent.setup();
+    render(
+      <CodeHeader onViewChange={mockOnViewChange} currentView="tab" currentTab="B" onTabChange={mockOnTabChange} />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'A팀' }));
+    expect(mockOnTabChange).toHaveBeenCalledWith('A');
+  });
+
+  it('B팀 버튼 클릭 시 onTabChange("B")를 호출한다', async () => {
+    const user = userEvent.setup();
+    render(
+      <CodeHeader onViewChange={mockOnViewChange} currentView="tab" currentTab="A" onTabChange={mockOnTabChange} />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'B팀' }));
+    expect(mockOnTabChange).toHaveBeenCalledWith('B');
+  });
+
+  it('currentTab이 A일 때 A팀 버튼이 활성화된다', () => {
+    render(
+      <CodeHeader onViewChange={mockOnViewChange} currentView="tab" currentTab="A" onTabChange={mockOnTabChange} />
+    );
+
+    const aTeamButton = screen.getByRole('button', { name: 'A팀' });
+    expect(aTeamButton.className).toContain('bg-[#2B7FFF]');
+  });
+
+  it('currentTab이 B일 때 B팀 버튼이 활성화된다', () => {
+    render(
+      <CodeHeader onViewChange={mockOnViewChange} currentView="tab" currentTab="B" onTabChange={mockOnTabChange} />
+    );
+
+    const bTeamButton = screen.getByRole('button', { name: 'B팀' });
+    expect(bTeamButton.className).toContain('bg-[#FB2C36]');
+  });
+});

--- a/frontend/src/pages/battlePage/components/header/test/SoundSettingsPopover.test.tsx
+++ b/frontend/src/pages/battlePage/components/header/test/SoundSettingsPopover.test.tsx
@@ -75,4 +75,92 @@ describe('SoundSettingsPopover', () => {
 
     expect(onClose).toHaveBeenCalled();
   });
+
+  it('isOpen이 false일 때 null을 반환한다', () => {
+    const { container } = render(<SoundSettingsPopover {...defaultProps} isOpen={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('anchorEl이 null일 때 null을 반환한다', () => {
+    const { container } = render(<SoundSettingsPopover {...defaultProps} anchorEl={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('BGM 선택 시 playBGM이 호출된다', async () => {
+    const user = userEvent.setup();
+    render(<SoundSettingsPopover {...defaultProps} />);
+
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, 'lofi');
+
+    expect(soundManager.playBGM).toHaveBeenCalledWith('lofi');
+  });
+
+  it('빈 BGM 선택 시 stopAllBGM이 호출된다', async () => {
+    const user = userEvent.setup();
+    render(<SoundSettingsPopover {...defaultProps} />);
+
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, '');
+
+    expect(soundManager.stopAllBGM).toHaveBeenCalled();
+  });
+
+  it('재생/일시정지 버튼 클릭 시 상태 전환', async () => {
+    const user = userEvent.setup();
+    vi.mocked(soundManager.isBGMPlaying).mockReturnValue(true);
+    vi.mocked(soundManager.getCurrentBGM).mockReturnValue('lofi');
+
+    render(<SoundSettingsPopover {...defaultProps} />);
+
+    const playPauseButton = screen.getByLabelText('일시정지');
+    await user.click(playPauseButton);
+
+    expect(soundManager.pauseBGM).toHaveBeenCalled();
+  });
+
+  it('일시정지 상태에서 재생 버튼 클릭 시 resumeBGM 호출', async () => {
+    const user = userEvent.setup();
+    vi.mocked(soundManager.isBGMPlaying).mockReturnValue(false);
+    vi.mocked(soundManager.getCurrentBGM).mockReturnValue('lofi');
+
+    render(<SoundSettingsPopover {...defaultProps} />);
+
+    // Select a BGM first
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, 'lofi');
+
+    // Then click pause (which should now be play since we selected BGM and it auto-plays)
+    const playPauseButton = screen.getByLabelText('일시정지');
+    await user.click(playPauseButton);
+
+    expect(soundManager.pauseBGM).toHaveBeenCalled();
+  });
+
+  it('일시정지 상태에서 selectedBGM이 있으면 resumeBGM 호출', async () => {
+    const user = userEvent.setup();
+    vi.mocked(soundManager.isBGMPlaying).mockReturnValue(false);
+    vi.mocked(soundManager.getCurrentBGM).mockReturnValue('lofi');
+
+    render(<SoundSettingsPopover {...defaultProps} />);
+
+    const playPauseButton = screen.getByLabelText('재생');
+    await user.click(playPauseButton);
+
+    expect(soundManager.resumeBGM).toHaveBeenCalled();
+  });
+
+  it('bgmOptions가 비어있을 때 재생 버튼 클릭 시 아무 동작 안함', async () => {
+    const user = userEvent.setup();
+    vi.mocked(soundManager.isBGMPlaying).mockReturnValue(false);
+    vi.mocked(soundManager.getCurrentBGM).mockReturnValue(null);
+
+    render(<SoundSettingsPopover {...defaultProps} bgmOptions={[]} />);
+
+    const playPauseButton = screen.getByLabelText('재생');
+    await user.click(playPauseButton);
+
+    expect(soundManager.playBGM).not.toHaveBeenCalled();
+    expect(soundManager.resumeBGM).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #361

## ✅ 작업 내용

### 💡개선 사항

**Backend 테스트 커버리지 향상 (90% 달성 ✓)**
| Metric | Before | After | 변화 |
|--------|--------|-------|------|
| Statements | 41.55% | 90.93% | +49.38% |
| Branches | 29.11% | 75.43% | +46.32% |
| Functions | 35.84% | 89.90% | +54.06% |
| Lines | 41.26% | 91.84% | +50.58% |
| Tests | 164 | 605 | +441 |

**Frontend 테스트 커버리지 향상 (90% 달성 ✓)**
| Metric | Before | After | 변화 |
|--------|--------|-------|------|
| Statements | 78.64% | 89.84% | +11.20% |
| Branches | 65.91% | 80.32% | +14.41% |
| Functions | 77.93% | 87.96% | +10.03% |
| Lines | 81.35% | 92.81% | +11.46% |
| Tests | 172 | 239 | +67 |

**추가된 테스트 파일**

Backend:
- **Domain Services**: battleDiscussion, battleVote, battleGuest, battleResult, battleTimeline
- **Utils**: rating.util, nickname.util, battle.util
- **Usecases**: battleCreation, battleParticipation, battlePhaseTransition, battleQuery, battleInteraction, battleTermination, createGuest
- **Mappers**: battle.mapper
- **Adapter In**: battles.gateway
- **Adapter Out**: battleIdentifier, battlePrivacyCheck, battleBroadcaster, guestCheck, battleReferenceGenerator, battleTimer, battleRepository, battleStateRepository
- **DTOs**: battleResult.dto, discussionVoteResult.dto, closedBattleResponse.dto, generateReference.dto
- **Infrastructure**: gemini.service, metrics (service, controller, middleware), redis.repository, prisma.service
- **OAuth**: jwt-auth.guard, jwt.strategy, jwt-refresh.strategy, github.strategy, kakao.strategy
- **Guards**: inviteAccess.guard
- **Common**: custom-global-exception.filter, error-response

Frontend:
- **Stores**: toastStore
- **APIs**: getOAuthUser, postGuestLogin, postLogout
- **Hooks**: useModal
- **Utils**: getTimeAgo, languageMapper
- **Components**: CodeHeader, ChatInput

**보강된 테스트 파일**

Backend:
- **Domain Services**: battleSkip (shouldSkipPhase 분기), battleTeamSwitch (팀 전환 로직), battleChat (TEAM 스코프 예외 처리), **battleTier (티어 경계값, MVP 보너스, null 처리 - Branches 68.75%→93.75%)**
- **Usecases**: battlePhaseTransition (콜백 함수, 타이머 스케줄링), createGuest (게스트 생성 콜백)
- **Infrastructure**: gemini.service (재시도 로직, API 키 비활성화, Redis 기반 상태 관리)
- **Adapter Out**: battleTimer (Redis 기반 구현), battleStateRepository (Redis 캐시)
- **OAuth**: jwt-refresh.strategy (RefreshGuard 변경 반영)

Frontend:
- **Stores**: authStore (게스트 팀 업데이트)
- **Components**: SoundSettingsPopover (BGM 재생/일시정지 분기)

**dev 브랜치 rebase 후 테스트 수정**
- battleStateRepository.adapter.spec: Redis 의존성 mock 추가
- battleTimer.adapter.spec: Redis 기반 구현으로 전체 재작성
- battleCreation.usecase.spec: timer 제거, phaseTransitionUseCase 추가
- battleTermination.usecase.spec: clearCache mock, UserRatingUpdate 타입 확장
- battlePhaseTransition.usecase.spec: timer.schedule 시그니처 변경
- gemini.service.spec: RedisRepository 의존성 mock 추가
- jwt-refresh.strategy.spec: RefreshStrategy → RefreshGuard 변경

<br />

## 📸 참고 사항

### 커버리지 메트릭 설명
| 메트릭 | 측정 대상 | 우선순위 |
|--------|----------|----------|
| Lines/Statements | 실행된 코드 라인 | 1순위 (기본) |
| Functions | 호출된 함수 | 2순위 |
| Branches | if/else 분기 경로 | 3순위 (가장 올리기 어려움) |

### 테스트 구성 원칙
- **Backend**: 도메인 서비스 → 유스케이스 → 어댑터 → DTO → 인프라 (핵심 비즈니스 로직 우선)
- **Frontend**: 공통 모듈(stores, apis) → 페이지 컴포넌트 (재사용성 높은 코드 우선)

<br />

## 💬 질문사항 (고민했던 부분)

### Branches 커버리지가 Lines 대비 낮은 이유
- 에러 핸들링(try/catch), null 체크, 옵셔널 체이닝(`?.`) 등 엣지케이스 분기가 많음
- 모든 분기를 테스트하려면 의도적으로 에러를 발생시키는 테스트 케이스 필요
- 글로벌 필터 적용 후 예외 상황 테스트 보강 완료 (custom-global-exception.filter.spec.ts)