### PR TITLE
[Fix] 새로고침 시, 자신의 팀이 NONE으로 변경되는 문제 수정

### DIFF
--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -156,5 +156,5 @@ export function useBattleSocket() {
       setIsConnected(false);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [selectedTeam]);
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #375 

## ✅ 작업 내용

클라이언트에서 갱신된 정보를 가져오기 전에 서버에게 먼저 기본값인 `NONE`을 뿌려줘서 새로고침 전, 후의 클라이언트 팀 정보가 상이하여 오류가 발생하였습니다.

클라이언트에서 팀 정보가 갱신되면 다시 한 번 join하여 서버에게 갱신하도록 수정하였습니다.

- [x] 소속팀이 수정되면 최신 팀으로 서버에 정보를 갱신한다.

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

![123](https://github.com/user-attachments/assets/3cf1a9a5-f8da-40b9-925e-0f11564fb9fb)

새로고침하는 브라우저의 반대편을 확인하면 " 중립 -> 팀 " 이렇게 적용되는 것을 확인할 수 있습니다.

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->

1. 동 계정으로 두 개의 브라우저, 다른 팀으로 접속하면 접속 인원은 1명으로 파악하지만 각 팀의 라운지에서 채팅 작성 및 조회가 가능하다.
2. 두 개의 브라우저에서 배틀 중 로그인 여부가 변경되면  NONE 상태의 좀비 참여자가 발생한다.
3. 진영 변경 상태에서 새로고침을 하면 이전 투표를 무르고(?) 다시 한 번 더 투표가 가능하다( 마지막 투표가 적용) 
4. 저 이제 진짜 팀위키랑 아키텍처 그리러 가요!!!