### PR TITLE
[Feature] TanstackQuery & Suspense 기반 APi 페칭 로딩 UI 적용 

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,8 @@ RUN corepack enable
 # Copy workspace 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY backend/package.json ./backend/package.json
+COPY frontend/package.json ./frontend/package.json
+COPY packages ./packages
 
 # 의존성 설치
 ENV HUSKY=0
@@ -36,6 +38,7 @@ RUN corepack enable
 # Copy workspace files
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY backend/package.json ./backend/package.json
+COPY packages ./packages
 
 # 의존성 설치 (프로덕션용, husky 스크립트 무시)
 ENV HUSKY=0

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,8 @@ RUN corepack enable
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY frontend/package.json ./frontend/package.json
+COPY backend/package.json ./backend/package.json
+COPY packages ./packages
 
 # Install
 ENV HUSKY=0

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ import ErrorPage from './pages/errorPage';
 import TutorialBattlePage from './pages/tutorialBattlePage';
 import { TUTORIAL_BATTLE_INFO } from './pages/tutorial/const/tutorialBattle';
 import { ToastContainer } from './commons/components/toast/ToastContainer';
-import LoadingModal from './commons/components/LoadingModal';
+import LoadingOverlay from './commons/components/LoadingOverlay';
 import { useAuthStore } from './commons/stores/authStore';
 import './App.css';
 
@@ -39,7 +39,7 @@ const router = sentryCreateBrowserRouter([
       {
         path: 'battle/:id',
         element: (
-          <Suspense fallback={<LoadingModal isOpen={true} message="배틀 정보를 불러오는 중..." />}>
+          <Suspense fallback={<LoadingOverlay isOpen={true} message="배틀 정보를 불러오는 중..." />}>
             <BattlePage />
           </Suspense>
         )
@@ -55,7 +55,7 @@ const router = sentryCreateBrowserRouter([
       {
         path: 'battles/:id/result',
         element: (
-          <Suspense fallback={<LoadingModal isOpen={true} message="배틀 결과를 불러오는 중..." />}>
+          <Suspense fallback={<LoadingOverlay isOpen={true} message="배틀 결과를 불러오는 중..." />}>
             <BattleResultPage />
           </Suspense>
         )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useEffect, Suspense } from 'react';
 import * as Sentry from '@sentry/react';
 import BattleCreatePage from './pages/battleCreatePage';
 import MainPage from './pages/mainPage';
@@ -15,6 +15,7 @@ import ErrorPage from './pages/errorPage';
 import TutorialBattlePage from './pages/tutorialBattlePage';
 import { TUTORIAL_BATTLE_INFO } from './pages/tutorial/const/tutorialBattle';
 import { ToastContainer } from './commons/components/toast/ToastContainer';
+import LoadingModal from './commons/components/LoadingModal';
 import { useAuthStore } from './commons/stores/authStore';
 import './App.css';
 
@@ -35,7 +36,14 @@ const router = sentryCreateBrowserRouter([
         path: 'battle/create',
         element: <BattleCreatePage />
       },
-      { path: 'battle/:id', element: <BattlePage /> },
+      {
+        path: 'battle/:id',
+        element: (
+          <Suspense fallback={<LoadingModal isOpen={true} message="배틀 정보를 불러오는 중..." />}>
+            <BattlePage />
+          </Suspense>
+        )
+      },
       { path: 'battle/:id/team-select', element: <TeamSelectPage /> },
       {
         path: 'tutorial/team-select',
@@ -44,7 +52,14 @@ const router = sentryCreateBrowserRouter([
       },
       { path: 'tutorial/battle', element: <TutorialBattlePage />, loader: () => TUTORIAL_BATTLE_INFO },
       { path: 'battles/:inviteCode', element: <InvitePage /> },
-      { path: 'battles/:id/result', element: <BattleResultPage /> }
+      {
+        path: 'battles/:id/result',
+        element: (
+          <Suspense fallback={<LoadingModal isOpen={true} message="배틀 결과를 불러오는 중..." />}>
+            <BattleResultPage />
+          </Suspense>
+        )
+      }
     ]
   }
 ]);

--- a/frontend/src/commons/components/ErrorBoundary/SectionErrorFallback.tsx
+++ b/frontend/src/commons/components/ErrorBoundary/SectionErrorFallback.tsx
@@ -5,7 +5,7 @@ interface SectionErrorFallbackProps {
   reset: () => void;
   title?: string;
   className?: string;
-  minHeight?: string;
+  height?: string;
 }
 
 export default function SectionErrorFallback({
@@ -13,11 +13,11 @@ export default function SectionErrorFallback({
   reset,
   title = '데이터를 불러올 수 없습니다',
   className = '',
-  minHeight = '18.75rem'
+  height = '18.75rem'
 }: SectionErrorFallbackProps) {
   return (
     <div
-      style={{ minHeight }}
+      style={{ height }}
       className={`w-full bg-[#1A1A2E] border border-[#364153] rounded-xl p-8 flex flex-col items-center justify-center animate-fadeIn ${className}`}
     >
       <div className="flex flex-col items-center gap-4 text-center">

--- a/frontend/src/commons/components/LoadingModal.tsx
+++ b/frontend/src/commons/components/LoadingModal.tsx
@@ -1,0 +1,34 @@
+interface LoadingModalProps {
+  isOpen: boolean;
+  message?: string;
+}
+
+export default function LoadingModal({ isOpen, message = '처리 중입니다...' }: LoadingModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-md animate-in fade-in duration-200">
+      <div className="relative rounded-3xl border border-orange-500/20 bg-gradient-to-br from-[#1a1a2e] to-[#121226] p-10 shadow-[0_20px_60px_rgba(255,105,0,0.3)] animate-in zoom-in-95 duration-300">
+        <div className="absolute inset-0 rounded-3xl bg-gradient-to-br from-orange-500/10 to-transparent blur-xl"></div>
+
+        <div className="relative flex flex-col items-center gap-6">
+          <div className="relative">
+            <div className="h-16 w-16 animate-spin rounded-full border-4 border-orange-500/20 border-t-orange-500 shadow-[0_0_20px_rgba(255,105,0,0.5)]"></div>
+            <div className="absolute inset-0 h-16 w-16 animate-ping rounded-full border-4 border-orange-500/30 opacity-20"></div>
+          </div>
+
+          <div className="flex flex-col items-center gap-2">
+            <p className="text-xl font-bold bg-gradient-to-r from-orange-400 to-orange-600 bg-clip-text text-transparent">
+              {message}
+            </p>
+            <div className="flex gap-1">
+              <span className="h-2 w-2 animate-bounce rounded-full bg-orange-500 [animation-delay:-0.3s]"></span>
+              <span className="h-2 w-2 animate-bounce rounded-full bg-orange-500 [animation-delay:-0.15s]"></span>
+              <span className="h-2 w-2 animate-bounce rounded-full bg-orange-500"></span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/commons/components/LoadingOverlay.tsx
+++ b/frontend/src/commons/components/LoadingOverlay.tsx
@@ -1,0 +1,34 @@
+interface LoadingOverlayProps {
+  isOpen: boolean;
+  message?: string;
+}
+
+export default function LoadingOverlay({ isOpen, message = '처리 중입니다...' }: LoadingOverlayProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-md animate-in fade-in duration-200">
+      <div className="relative rounded-3xl border border-orange-500/20 bg-gradient-to-br from-[#1a1a2e] to-[#121226] p-10 shadow-[0_20px_60px_rgba(255,105,0,0.3)] animate-in zoom-in-95 duration-300">
+        <div className="absolute inset-0 rounded-3xl bg-gradient-to-br from-orange-500/10 to-transparent blur-xl"></div>
+
+        <div className="relative flex flex-col items-center gap-6">
+          <div className="relative">
+            <div className="h-16 w-16 animate-spin rounded-full border-4 border-orange-500/20 border-t-orange-500 shadow-[0_0_20px_rgba(255,105,0,0.5)]"></div>
+            <div className="absolute inset-0 h-16 w-16 animate-ping rounded-full border-4 border-orange-500/30 opacity-20"></div>
+          </div>
+
+          <div className="flex flex-col items-center gap-2">
+            <p className="text-xl font-bold bg-gradient-to-r from-orange-400 to-orange-600 bg-clip-text text-transparent">
+              {message}
+            </p>
+            <div className="flex gap-1">
+              <span className="h-2 w-2 animate-bounce rounded-full bg-orange-500 [animation-delay:-0.3s]"></span>
+              <span className="h-2 w-2 animate-bounce rounded-full bg-orange-500 [animation-delay:-0.15s]"></span>
+              <span className="h-2 w-2 animate-bounce rounded-full bg-orange-500"></span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/commons/components/Skeleton.tsx
+++ b/frontend/src/commons/components/Skeleton.tsx
@@ -1,0 +1,14 @@
+interface SkeletonProps {
+  width?: string;
+  height?: string;
+  className?: string;
+}
+
+export default function Skeleton({ width, height, className = '' }: SkeletonProps) {
+  return (
+    <div
+      className={`bg-gradient-to-r from-[#1a1a2e] via-[#252540] to-[#1a1a2e] bg-[length:200%_100%] animate-pulse  ${className}`}
+      style={{ width: width, height: height }}
+    />
+  );
+}

--- a/frontend/src/commons/hooks/useGetBattleInfo.ts
+++ b/frontend/src/commons/hooks/useGetBattleInfo.ts
@@ -1,14 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import getBattleInfo from '@/commons/apis/getBattleInfo';
 
 export function useGetBattleInfo(battleId: string) {
-  const { data, ...rest } = useQuery({
+  const { data, ...rest } = useSuspenseQuery({
     queryKey: ['battle', 'info', battleId],
     queryFn: () => getBattleInfo(battleId),
     staleTime: 0,
-    gcTime: 1000 * 60 * 5,
-    enabled: !!battleId,
-    throwOnError: true
+    gcTime: 1000 * 60 * 5
   });
 
   return {

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -5,7 +5,7 @@ import { formatCode } from '@/commons/utils/codeFormatter';
 import { selectUser, useAuthStore } from '@/commons/stores/authStore';
 import { useToastStore, selectAddToast } from '@/commons/stores/toastStore';
 import { useCreateBattle } from './hooks/useCreateBattle';
-import LoadingModal from '@/commons/components/LoadingModal';
+import LoadingOverlay from '@/commons/components/LoadingOverlay';
 import type { BattleType, BattleLanguage, BattlePlayTime } from './api/types';
 
 const LANGUAGE_OPTIONS: Array<{ label: string; value: BattleLanguage }> = [
@@ -88,7 +88,7 @@ export default function BattleCreatePage() {
 
   return (
     <main>
-      <LoadingModal isOpen={isPending} message="배틀 생성 중입니다..." />
+      <LoadingOverlay isOpen={isPending} message="배틀 생성 중입니다..." />
       <div className="min-h-screen w-full px-6 py-8">
         <div className="mx-auto create-max-width">
           <div className="flex items-center justify-start gap-4 mt-10 mb-8">

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react';
-import PlusIcon from '@/assets/icon/plus.svg?react';
 import { BATTLE_CATEGORY_CONFIG } from '../mainPage/types/battle';
 import BattleTopicInput from './components/BattleTopicInput';
 import { formatCode } from '@/commons/utils/codeFormatter';
@@ -242,7 +241,7 @@ export default function BattleCreatePage() {
                   data-testid="create-battle-button"
                   className="inline-flex items-center gap-2 rounded-xl bg-orange-500 px-5 py-3 font-semibold text-white shadow-[0_12px_24px_rgba(255,105,0,0.25)] hover:bg-orange-400 disabled:cursor-not-allowed disabled:bg-orange-500/50 transition-colors"
                 >
-                  <PlusIcon className="h-4 w-4" />
+                  배틀 생성하기
                 </button>
               </div>
             </div>

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -5,6 +5,7 @@ import { formatCode } from '@/commons/utils/codeFormatter';
 import { selectUser, useAuthStore } from '@/commons/stores/authStore';
 import { useToastStore, selectAddToast } from '@/commons/stores/toastStore';
 import { useCreateBattle } from './hooks/useCreateBattle';
+import LoadingModal from '@/commons/components/LoadingModal';
 import type { BattleType, BattleLanguage, BattlePlayTime } from './api/types';
 
 const LANGUAGE_OPTIONS: Array<{ label: string; value: BattleLanguage }> = [
@@ -71,7 +72,7 @@ export default function BattleCreatePage() {
       return;
     }
 
-    createBattle({
+    await createBattle({
       authorId,
       title: title.trim(),
       description: description.trim(),
@@ -86,168 +87,171 @@ export default function BattleCreatePage() {
   };
 
   return (
-    <div className="min-h-screen w-full px-6 py-8">
-      <div className="mx-auto create-max-width">
-        <div className="flex items-center justify-start gap-4 mt-10 mb-8">
-          <button
-            onClick={() => window.history.back()}
-            className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors shrink-0 text-sm w-[100px] sm:w-auto sm:min-w-[100px]"
-          >
-            ← 돌아가기
-          </button>
-        </div>
+    <main>
+      <LoadingModal isOpen={isPending} message="배틀 생성 중입니다..." />
+      <div className="min-h-screen w-full px-6 py-8">
+        <div className="mx-auto create-max-width">
+          <div className="flex items-center justify-start gap-4 mt-10 mb-8">
+            <button
+              onClick={() => window.history.back()}
+              className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors shrink-0 text-sm w-[100px] sm:w-auto sm:min-w-[100px]"
+            >
+              ← 돌아가기
+            </button>
+          </div>
 
-        <div className="mt-4 rounded-2xl border border-[#2b2b3e] bg-[#121226] shadow-[0_18px_35px_rgba(0,0,0,0.35)]">
-          <div className="h-1 w-full rounded-t-2xl bg-orange-500" />
+          <div className="mt-4 rounded-2xl border border-[#2b2b3e] bg-[#121226] shadow-[0_18px_35px_rgba(0,0,0,0.35)]">
+            <div className="h-1 w-full rounded-t-2xl bg-orange-500" />
 
-          <div className="create-padding">
-            <div className="mb-6">
-              <p className="text-xs tracking-[0.24em] text-orange-500">CREATE NEW BATTLE</p>
-              <h1 className="mt-2 create-title-size font-bold text-white">새 배틀 생성</h1>
-            </div>
-
-            <div className="space-y-6">
-              <div className="space-y-2">
-                <label className="text-sm text-gray-300">문제 제목</label>
-                <input
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  placeholder="예: 배열에서 중복 제거하기"
-                  className="w-full rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/60"
-                />
+            <div className="create-padding">
+              <div className="mb-6">
+                <p className="text-xs tracking-[0.24em] text-orange-500">CREATE NEW BATTLE</p>
+                <h1 className="mt-2 create-title-size font-bold text-white">새 배틀 생성</h1>
               </div>
 
-              <div className="space-y-2">
-                <label className="text-sm text-gray-300">문제 설명</label>
-                <textarea
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  placeholder="어떤 코드를 비교하고 싶으신가요?"
-                  className="min-h-28 w-full resize-y rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/60"
-                />
-              </div>
-
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="space-y-6">
                 <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-blue-500/20 text-xs font-bold text-blue-300">
-                      A
-                    </span>
-                    <label className="text-sm text-gray-300">구현 A</label>
-                  </div>
-                  <textarea
-                    value={aCode}
-                    onChange={(e) => setACode(e.target.value)}
-                    placeholder="첫 번째 코드를 입력하세요"
-                    className="create-textarea-height w-full resize-y rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 font-mono text-sm text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/60"
+                  <label className="text-sm text-gray-300">문제 제목</label>
+                  <input
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    placeholder="예: 배열에서 중복 제거하기"
+                    className="w-full rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/60"
                   />
                 </div>
 
                 <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-rose-500/20 text-xs font-bold text-rose-300">
-                      B
-                    </span>
-                    <label className="text-sm text-gray-300">구현 B</label>
-                  </div>
+                  <label className="text-sm text-gray-300">문제 설명</label>
                   <textarea
-                    value={bCode}
-                    onChange={(e) => setBCode(e.target.value)}
-                    placeholder="두 번째 코드를 입력하세요"
-                    className="create-textarea-height w-full resize-y rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 font-mono text-sm text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/60"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="어떤 코드를 비교하고 싶으신가요?"
+                    className="min-h-28 w-full resize-y rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/60"
                   />
                 </div>
-              </div>
 
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-                <div className="space-y-2">
-                  <label className="text-sm text-gray-300">언어</label>
-                  <select
-                    value={language}
-                    onChange={(e) => setLanguage(e.target.value as BattleLanguage)}
-                    className="w-full rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-orange-500/60"
-                  >
-                    {LANGUAGE_OPTIONS.map((o) => (
-                      <option key={o.value} value={o.value}>
-                        {o.label}
-                      </option>
-                    ))}
-                  </select>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-blue-500/20 text-xs font-bold text-blue-300">
+                        A
+                      </span>
+                      <label className="text-sm text-gray-300">구현 A</label>
+                    </div>
+                    <textarea
+                      value={aCode}
+                      onChange={(e) => setACode(e.target.value)}
+                      placeholder="첫 번째 코드를 입력하세요"
+                      className="create-textarea-height w-full resize-y rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 font-mono text-sm text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/60"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-rose-500/20 text-xs font-bold text-rose-300">
+                        B
+                      </span>
+                      <label className="text-sm text-gray-300">구현 B</label>
+                    </div>
+                    <textarea
+                      value={bCode}
+                      onChange={(e) => setBCode(e.target.value)}
+                      placeholder="두 번째 코드를 입력하세요"
+                      className="create-textarea-height w-full resize-y rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 font-mono text-sm text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/60"
+                    />
+                  </div>
                 </div>
 
-                <div className="space-y-2">
-                  <label className="text-sm text-gray-300">카테고리</label>
-                  <select
-                    value={category}
-                    onChange={(e) => setCategory(e.target.value as typeof category)}
-                    className="w-full rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-orange-500/60"
-                  >
-                    {categoryOptions.map((o) => (
-                      <option key={o.value} value={o.value}>
-                        {o.label}
-                      </option>
-                    ))}
-                  </select>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                  <div className="space-y-2">
+                    <label className="text-sm text-gray-300">언어</label>
+                    <select
+                      value={language}
+                      onChange={(e) => setLanguage(e.target.value as BattleLanguage)}
+                      className="w-full rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-orange-500/60"
+                    >
+                      {LANGUAGE_OPTIONS.map((o) => (
+                        <option key={o.value} value={o.value}>
+                          {o.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="space-y-2">
+                    <label className="text-sm text-gray-300">카테고리</label>
+                    <select
+                      value={category}
+                      onChange={(e) => setCategory(e.target.value as typeof category)}
+                      className="w-full rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-orange-500/60"
+                    >
+                      {categoryOptions.map((o) => (
+                        <option key={o.value} value={o.value}>
+                          {o.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="space-y-2">
+                    <label className="text-sm text-gray-300">배틀 시간</label>
+                    <select
+                      value={playTime}
+                      onChange={(e) => setPlayTime(e.target.value as BattlePlayTime)}
+                      className="w-full rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-orange-500/60"
+                    >
+                      {PLAYTIME_OPTIONS.map((o) => (
+                        <option key={o.value} value={o.value}>
+                          {o.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
                 </div>
 
-                <div className="space-y-2">
-                  <label className="text-sm text-gray-300">배틀 시간</label>
-                  <select
-                    value={playTime}
-                    onChange={(e) => setPlayTime(e.target.value as BattlePlayTime)}
-                    className="w-full rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-orange-500/60"
-                  >
-                    {PLAYTIME_OPTIONS.map((o) => (
-                      <option key={o.value} value={o.value}>
-                        {o.label}
-                      </option>
-                    ))}
-                  </select>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                  <div className="space-y-2">
+                    <label className="text-sm text-gray-300">배틀 공개 여부</label>
+                    <select
+                      value={type}
+                      onChange={(e) => setType(e.target.value as BattleType)}
+                      className="w-full rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-orange-500/60"
+                    >
+                      {VISIBILITY_OPTIONS.map((o: { label: string; value: BattleType }) => (
+                        <option key={o.value} value={o.value}>
+                          {o.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
                 </div>
-              </div>
 
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-                <div className="space-y-2">
-                  <label className="text-sm text-gray-300">배틀 공개 여부</label>
-                  <select
-                    value={type}
-                    onChange={(e) => setType(e.target.value as BattleType)}
-                    className="w-full rounded-xl border border-[#2b2b3e] bg-[#0f0f1f] px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-orange-500/60"
+                <BattleTopicInput rounds={rounds} selectedTopics={topics} onTopicsChange={setTopics} />
+
+                <div className="flex items-center justify-end gap-3 pt-2">
+                  <button
+                    type="button"
+                    onClick={() => (window.location.href = '/')}
+                    className="rounded-xl border border-[#2b2b3e] bg-transparent px-5 py-3 text-gray-200 hover:bg-[#1a1a2e] transition-colors"
                   >
-                    {VISIBILITY_OPTIONS.map((o: { label: string; value: BattleType }) => (
-                      <option key={o.value} value={o.value}>
-                        {o.label}
-                      </option>
-                    ))}
-                  </select>
+                    취소
+                  </button>
+
+                  <button
+                    type="button"
+                    disabled={!canSubmit || isPending}
+                    onClick={handleSubmit}
+                    data-testid="create-battle-button"
+                    className="inline-flex items-center gap-2 rounded-xl bg-orange-500 px-5 py-3 font-semibold text-white shadow-[0_12px_24px_rgba(255,105,0,0.25)] hover:bg-orange-400 disabled:cursor-not-allowed disabled:bg-orange-500/50 transition-colors"
+                  >
+                    배틀 생성하기
+                  </button>
                 </div>
-              </div>
-
-              <BattleTopicInput rounds={rounds} selectedTopics={topics} onTopicsChange={setTopics} />
-
-              <div className="flex items-center justify-end gap-3 pt-2">
-                <button
-                  type="button"
-                  onClick={() => (window.location.href = '/')}
-                  className="rounded-xl border border-[#2b2b3e] bg-transparent px-5 py-3 text-gray-200 hover:bg-[#1a1a2e] transition-colors"
-                >
-                  취소
-                </button>
-
-                <button
-                  type="button"
-                  disabled={!canSubmit || isPending}
-                  onClick={handleSubmit}
-                  data-testid="create-battle-button"
-                  className="inline-flex items-center gap-2 rounded-xl bg-orange-500 px-5 py-3 font-semibold text-white shadow-[0_12px_24px_rgba(255,105,0,0.25)] hover:bg-orange-400 disabled:cursor-not-allowed disabled:bg-orange-500/50 transition-colors"
-                >
-                  배틀 생성하기
-                </button>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -7,7 +7,6 @@ import { soundManager } from '@/commons/utils/soundManager';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from './stores/battleStore';
 import { isInputDisabled } from './utils/battlePhase';
 import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
-import LoadingModal from '@/commons/components/LoadingModal';
 
 import BattleHeader from './components/header';
 import CodeSection from './components/codeview/CodeSection';
@@ -33,7 +32,7 @@ type Tab = 'info' | 'timeline' | 'reference';
 export default function BattlePage() {
   const { id: battleId } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { battleInfo: battleInfoData, isLoading } = useGetBattleInfo(battleId!);
+  const { battleInfo: battleInfoData } = useGetBattleInfo(battleId!);
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
   const [activeSidebarTab, setActiveSidebarTab] = useState<Tab>('info');
@@ -139,8 +138,6 @@ export default function BattlePage() {
 
   return (
     <div className="text-white relative">
-      <LoadingModal isOpen={isLoading || !battleInfoData} message="배틀 정보를 불러오는 중..." />
-
       {/* 책갈피 버튼 */}
       <BookmarkButton
         onOpen={(tab) => {

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -7,6 +7,7 @@ import { soundManager } from '@/commons/utils/soundManager';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from './stores/battleStore';
 import { isInputDisabled } from './utils/battlePhase';
 import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
+import LoadingModal from '@/commons/components/LoadingModal';
 
 import BattleHeader from './components/header';
 import CodeSection from './components/codeview/CodeSection';
@@ -128,9 +129,6 @@ export default function BattlePage() {
   const phase = battleProgress?.phase;
   const shouldShowInput = !isInputDisabled(team, phase);
 
-  if (isLoading || !battleInfoData) {
-    return <div className="min-h-screen w-full flex items-center justify-center text-white">로딩 중...</div>;
-  }
   const battleInfo = battleInfoData;
 
   const handleLeaveBattle = () => {
@@ -141,6 +139,8 @@ export default function BattlePage() {
 
   return (
     <div className="text-white relative">
+      <LoadingModal isOpen={isLoading || !battleInfoData} message="배틀 정보를 불러오는 중..." />
+
       {/* 책갈피 버튼 */}
       <BookmarkButton
         onOpen={(tab) => {
@@ -148,19 +148,19 @@ export default function BattlePage() {
           handleOpenSidebar();
         }}
         isOpen={isSidebarOpen}
-        hasReferenceData={!!battleInfo.referenceData}
+        hasReferenceData={!!battleInfo?.referenceData}
       />
 
       {/* 사이드바 */}
       <BattleSidebar
         isOpen={isSidebarOpen}
         onClose={handleCloseSidebar}
-        title={battleInfo.title}
-        description={battleInfo.description}
-        language={battleInfo.language}
-        category={battleInfo.category}
-        topics={battleInfo.topics}
-        referenceData={battleInfo.referenceData}
+        title={battleInfo?.title || ''}
+        description={battleInfo?.description || ''}
+        language={battleInfo?.language || 'javascript'}
+        category={battleInfo?.category || 'ALGORITHM'}
+        topics={battleInfo?.topics || []}
+        referenceData={battleInfo?.referenceData}
         activeTab={activeSidebarTab}
         onActiveTabChange={setActiveSidebarTab}
       />
@@ -184,7 +184,7 @@ export default function BattlePage() {
               ← 돌아가기
             </button>
             <div className="shrink-0 flex items-center gap-2">
-              {battleInfo.inviteCode && <InviteLinkButton inviteCode={battleInfo.inviteCode} />}
+              {battleInfo?.inviteCode && <InviteLinkButton inviteCode={battleInfo.inviteCode} />}
             </div>
           </div>
           <div className="flex items-center justify-between">
@@ -198,9 +198,9 @@ export default function BattlePage() {
               <CodeSection
                 onViewChange={setViewMode}
                 currentView={viewMode}
-                language={battleInfo.language}
-                codeA={battleInfo.aCode}
-                codeB={battleInfo.bCode}
+                language={battleInfo?.language || 'javascript'}
+                codeA={battleInfo?.aCode || ''}
+                codeB={battleInfo?.bCode || ''}
               />
             </div>
             <aside
@@ -221,7 +221,7 @@ export default function BattlePage() {
             {shouldShowInput && <DiscussionInput key={phase} onSubmit={handleDiscussionSubmit} />}
           </div>
         </div>
-        {isTeamChangeModalOpen && (
+        {isTeamChangeModalOpen && battleInfo && (
           <TeamChangeModal
             topics={battleInfo.topics}
             handleTeamChange={handleTeamChange}

--- a/frontend/src/pages/battleResultPage/hooks/useGetBattleResult.ts
+++ b/frontend/src/pages/battleResultPage/hooks/useGetBattleResult.ts
@@ -1,14 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { getBattleResult } from '../apis/getBattleResult';
 
 export function useGetBattleResult(battleId: string) {
-  const { data, ...rest } = useQuery({
+  const { data, ...rest } = useSuspenseQuery({
     queryKey: ['battle', 'result', battleId],
     queryFn: () => getBattleResult(battleId),
     staleTime: 1000 * 60 * 10,
-    gcTime: 1000 * 60 * 30,
-    enabled: !!battleId,
-    throwOnError: true
+    gcTime: 1000 * 60 * 30
   });
 
   return {

--- a/frontend/src/pages/battleResultPage/index.tsx
+++ b/frontend/src/pages/battleResultPage/index.tsx
@@ -13,7 +13,7 @@ import { useGetBattleResult } from './hooks/useGetBattleResult';
 export default function BattleResultPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { battleResult: battleData, isLoading } = useGetBattleResult(id!);
+  const { battleResult: battleData } = useGetBattleResult(id!);
 
   const bestOpinion = useMemo(() => {
     if (!battleData?.mvps?.length || !battleData.timeline.length) return null;
@@ -22,10 +22,6 @@ export default function BattleResultPage() {
     if (!mvpOpinions.length) return null;
     return mvpOpinions.reduce((max, current) => (current.upvotes > max.upvotes ? current : max), mvpOpinions[0]);
   }, [battleData]);
-
-  if (isLoading || !battleData) {
-    return <div>로딩 중...</div>;
-  }
 
   const { result } = battleData;
 

--- a/frontend/src/pages/invitePage/index.tsx
+++ b/frontend/src/pages/invitePage/index.tsx
@@ -8,7 +8,7 @@ export default function InvitePage() {
     if (!inviteCode) {
       return;
     }
-    window.location.href = `/api/battles/${inviteCode}`;
+    window.location.href = `${import.meta.env.VITE_API_URL}/api/battles/${inviteCode}`;
   }, [inviteCode]);
 
   return (

--- a/frontend/src/pages/mainPage/components/EmptyBattlesState.tsx
+++ b/frontend/src/pages/mainPage/components/EmptyBattlesState.tsx
@@ -1,0 +1,49 @@
+import BattleIcon from '@/assets/icon/battle.svg?react';
+import ClockIcon from '@/assets/icon/clock.svg?react';
+
+interface EmptyBattlesStateProps {
+  type: 'live' | 'past';
+  height?: string;
+}
+
+export default function EmptyBattlesState({ type, height = '18rem' }: EmptyBattlesStateProps) {
+  const isLive = type === 'live';
+
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-[#2b2b3e] bg-[#121226]/50 backdrop-blur-sm"
+      style={{ height }}
+    >
+      <div className="relative">
+        <div
+          className={`h-20 w-20 rounded-full bg-gradient-to-br ${isLive ? 'from-orange-500/20 to-orange-600/20' : 'from-gray-500/20 to-gray-600/20'} flex items-center justify-center`}
+        >
+          {isLive ? (
+            <BattleIcon className="w-10 h-10 text-orange-500" />
+          ) : (
+            <ClockIcon className="w-10 h-10 text-gray-500" />
+          )}
+        </div>
+        {isLive && <div className="absolute inset-0 h-20 w-20 rounded-full bg-orange-500/30 animate-ping"></div>}
+      </div>
+
+      <div className="flex flex-col items-center gap-2">
+        <h3 className="text-xl font-bold text-gray-300">
+          {isLive ? '진행 중인 배틀이 없습니다' : '종료된 배틀이 없습니다'}
+        </h3>
+        <p className="text-sm text-gray-500">
+          {isLive ? '새로운 배틀을 만들어보세요!' : '배틀이 종료되면 여기에 표시됩니다'}
+        </p>
+      </div>
+
+      <div className="absolute inset-0 overflow-hidden rounded-2xl">
+        <div
+          className={`absolute top-0 right-0 w-32 h-32 bg-gradient-to-br ${isLive ? 'from-orange-500/10' : 'from-gray-500/10'} to-transparent blur-3xl`}
+        ></div>
+        <div
+          className={`absolute bottom-0 left-0 w-32 h-32 bg-gradient-to-tr ${isLive ? 'from-orange-500/10' : 'from-gray-500/10'} to-transparent blur-3xl`}
+        ></div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/mainPage/components/LiveBattlesList.tsx
+++ b/frontend/src/pages/mainPage/components/LiveBattlesList.tsx
@@ -1,11 +1,16 @@
 import { useGetOpenBattles } from '../hooks/useGetOpenBattles';
 import LiveBattleCard from './LiveBattleCard';
+import EmptyBattlesState from './EmptyBattlesState';
 
 export default function LiveBattlesList() {
   const { battles: openBattles } = useGetOpenBattles({ offset: 0, limit: 3 });
 
+  if (openBattles.length === 0) {
+    return <EmptyBattlesState type="live" height="18rem" />;
+  }
+
   return (
-    <div className="grid grid-cols-3 gap-4 h-[15rem]">
+    <div className="grid grid-cols-3 gap-4 h-[18rem]">
       {openBattles.map((battleItem, index) => (
         <LiveBattleCard key={battleItem.id} battleInform={battleItem} isHot={index === 0} />
       ))}

--- a/frontend/src/pages/mainPage/components/LiveBattlesList.tsx
+++ b/frontend/src/pages/mainPage/components/LiveBattlesList.tsx
@@ -2,15 +2,11 @@ import { useGetOpenBattles } from '../hooks/useGetOpenBattles';
 import LiveBattleCard from './LiveBattleCard';
 
 export default function LiveBattlesList() {
-  const { battles: openBattles, isError, error } = useGetOpenBattles({ offset: 0, limit: 3 });
-
-  if (isError) {
-    throw error;
-  }
+  const { battles: openBattles } = useGetOpenBattles({ offset: 0, limit: 3 });
 
   return (
     <div className="grid grid-cols-3 gap-4 h-[15rem]">
-      {openBattles?.map((battleItem, index) => (
+      {openBattles.map((battleItem, index) => (
         <LiveBattleCard key={battleItem.id} battleInform={battleItem} isHot={index === 0} />
       ))}
     </div>

--- a/frontend/src/pages/mainPage/components/LiveBattlesSection.tsx
+++ b/frontend/src/pages/mainPage/components/LiveBattlesSection.tsx
@@ -15,12 +15,12 @@ export default function LiveBattlesSection() {
       </div>
       <SectionErrorBoundary
         fallback={(error, reset) => (
-          <SectionErrorFallback error={error} reset={reset} title="실시간 배틀을 불러올 수 없습니다" height="15rem" />
+          <SectionErrorFallback error={error} reset={reset} title="실시간 배틀을 불러올 수 없습니다" height="18rem" />
         )}
       >
         <Suspense
           fallback={
-            <div className="grid grid-cols-3 gap-4 h-[15rem]">
+            <div className="grid grid-cols-3 gap-4 h-[18rem]">
               {[...Array(3)].map((_, i) => (
                 <Skeleton key={i} width="100%" height="100%" className="rounded-2xl" />
               ))}

--- a/frontend/src/pages/mainPage/components/LiveBattlesSection.tsx
+++ b/frontend/src/pages/mainPage/components/LiveBattlesSection.tsx
@@ -1,32 +1,34 @@
-import { useGetOpenBattles } from '../hooks/useGetOpenBattles';
+import { Suspense } from 'react';
 import LiveBattlesList from './LiveBattlesList';
+import Skeleton from '@/commons/components/Skeleton';
 import SectionErrorBoundary from '@/commons/components/ErrorBoundary/SectionErrorBoundary';
 import SectionErrorFallback from '@/commons/components/ErrorBoundary/SectionErrorFallback';
 
 export default function LiveBattlesSection() {
-  const { total: openTotal, isError } = useGetOpenBattles({ offset: 0, limit: 3 });
-
   return (
     <section>
       <div className="flex items-center justify-between mb-4">
         <div className="flex flex-col text-left gap-3">
           <span className="text-orange-500 text-sm uppercase tracking-wider">PLAY TO EARN GAMES</span>
-          <h2 className="text-3xl  font-bold">실시간 배틀</h2>
+          <h2 className="text-3xl font-bold">실시간 배틀</h2>
         </div>
-
-        <span className="text-sm text-gray-400">{isError ? '0' : openTotal}개 진행중</span>
       </div>
       <SectionErrorBoundary
         fallback={(error, reset) => (
-          <SectionErrorFallback
-            error={error}
-            reset={reset}
-            title="실시간 배틀을 불러올 수 없습니다"
-            minHeight="17.5rem"
-          />
+          <SectionErrorFallback error={error} reset={reset} title="실시간 배틀을 불러올 수 없습니다" height="15rem" />
         )}
       >
-        <LiveBattlesList />
+        <Suspense
+          fallback={
+            <div className="grid grid-cols-3 gap-4 h-[15rem]">
+              {[...Array(3)].map((_, i) => (
+                <Skeleton key={i} width="100%" height="100%" className="rounded-2xl" />
+              ))}
+            </div>
+          }
+        >
+          <LiveBattlesList />
+        </Suspense>
       </SectionErrorBoundary>
     </section>
   );

--- a/frontend/src/pages/mainPage/components/PastBattlesList.tsx
+++ b/frontend/src/pages/mainPage/components/PastBattlesList.tsx
@@ -1,8 +1,13 @@
 import { useGetClosedBattles } from '../hooks/useGetClosedBattles';
 import PastBattleCard from './PastBattleCard';
+import EmptyBattlesState from './EmptyBattlesState';
 
 export default function PastBattlesList() {
   const { battles: closedBattles } = useGetClosedBattles({ offset: 0, limit: 6 });
+
+  if (closedBattles.length === 0) {
+    return <EmptyBattlesState type="past" height="36rem" />;
+  }
 
   return (
     <div className="grid grid-cols-3 gap-4 h-[36rem]">

--- a/frontend/src/pages/mainPage/components/PastBattlesList.tsx
+++ b/frontend/src/pages/mainPage/components/PastBattlesList.tsx
@@ -2,15 +2,11 @@ import { useGetClosedBattles } from '../hooks/useGetClosedBattles';
 import PastBattleCard from './PastBattleCard';
 
 export default function PastBattlesList() {
-  const { battles: closedBattles, isError, error } = useGetClosedBattles({ offset: 0, limit: 6 });
-
-  if (isError) {
-    throw error;
-  }
+  const { battles: closedBattles } = useGetClosedBattles({ offset: 0, limit: 6 });
 
   return (
     <div className="grid grid-cols-3 gap-4 h-[36rem]">
-      {closedBattles?.map((b) => (
+      {closedBattles.map((b) => (
         <PastBattleCard key={b.id} item={b} />
       ))}
     </div>

--- a/frontend/src/pages/mainPage/components/PastBattlesSection.tsx
+++ b/frontend/src/pages/mainPage/components/PastBattlesSection.tsx
@@ -1,4 +1,6 @@
+import { Suspense } from 'react';
 import PastBattlesList from './PastBattlesList';
+import Skeleton from '@/commons/components/Skeleton';
 import SectionErrorBoundary from '@/commons/components/ErrorBoundary/SectionErrorBoundary';
 import SectionErrorFallback from '@/commons/components/ErrorBoundary/SectionErrorFallback';
 
@@ -17,11 +19,21 @@ export default function PastBattlesSection() {
             error={error}
             reset={reset}
             title="지난 배틀 결과를 불러올 수 없습니다"
-            minHeight="36rem"
+            height="36rem"
           />
         )}
       >
-        <PastBattlesList />
+        <Suspense
+          fallback={
+            <div className="grid grid-cols-3 gap-4">
+              {[...Array(6)].map((_, i) => (
+                <Skeleton key={i} width="100%" height="18rem" className="rounded-2xl" />
+              ))}
+            </div>
+          }
+        >
+          <PastBattlesList />
+        </Suspense>
       </SectionErrorBoundary>
     </section>
   );

--- a/frontend/src/pages/mainPage/hooks/useGetClosedBattles.ts
+++ b/frontend/src/pages/mainPage/hooks/useGetClosedBattles.ts
@@ -1,9 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { getClosedBattles } from '../api/getClosedBattles';
 import type { GetBattleListParams } from '../api/types';
 
 export function useGetClosedBattles({ offset, limit }: GetBattleListParams) {
-  const { data, ...rest } = useQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ['battles', 'closed', { offset, limit }],
     queryFn: () => getClosedBattles({ offset, limit }),
     select: (data) => ({
@@ -15,8 +15,7 @@ export function useGetClosedBattles({ offset, limit }: GetBattleListParams) {
   });
 
   return {
-    battles: data?.battles ?? [],
-    total: data?.total ?? 0,
-    ...rest
+    battles: data.battles,
+    total: data.total
   };
 }

--- a/frontend/src/pages/mainPage/hooks/useGetOpenBattles.ts
+++ b/frontend/src/pages/mainPage/hooks/useGetOpenBattles.ts
@@ -1,9 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { getOpenBattles } from '../api/getOpenBattles';
 import type { GetBattleListParams } from '../api/types';
 
 export function useGetOpenBattles({ offset, limit }: GetBattleListParams) {
-  const { data, ...rest } = useQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ['battles', 'open', { offset, limit }],
     queryFn: () => getOpenBattles({ offset, limit }),
     select: (data) => ({
@@ -16,8 +16,7 @@ export function useGetOpenBattles({ offset, limit }: GetBattleListParams) {
   });
 
   return {
-    battles: data?.battles ?? [],
-    total: data?.total ?? 0,
-    ...rest
+    battles: data.battles,
+    total: data.total
   };
 }

--- a/frontend/src/pages/mainPage/index.tsx
+++ b/frontend/src/pages/mainPage/index.tsx
@@ -1,13 +1,10 @@
 import { Link, useNavigate } from 'react-router-dom';
-import StatCard from '@/pages/mainPage/components/StatCard';
 import BattleCategoryCard from '@/pages/mainPage/components/BattleCategoryCard';
 import LiveBattlesSection from '@/pages/mainPage/components/LiveBattlesSection';
 import PastBattlesSection from '@/pages/mainPage/components/PastBattlesSection';
 import { BATTLE_CATEGORY_CONFIG } from '@/pages/mainPage/types/battle';
 import BattleIcon from '@/assets/icon/battle.svg?react';
 import Header from '@/commons/components/Header';
-import { useGetOpenBattles } from '@/pages/mainPage/hooks/useGetOpenBattles';
-import { useGetClosedBattles } from '@/pages/mainPage/hooks/useGetClosedBattles';
 import { useAuthStore, selectUser } from '@/commons/stores/authStore';
 import { useToastStore, selectAddToast } from '@/commons/stores/toastStore';
 
@@ -17,8 +14,6 @@ export default function MainPage() {
   const navigate = useNavigate();
   const user = useAuthStore(selectUser);
   const addToast = useToastStore(selectAddToast);
-  const { total: openTotal } = useGetOpenBattles({ offset: 0, limit: 3 });
-  const { total: closedTotal } = useGetClosedBattles({ offset: 0, limit: 6 });
 
   const handleCreateBattle = (e: React.MouseEvent) => {
     if (!user) {
@@ -66,12 +61,6 @@ export default function MainPage() {
 
           {/* Stats */}
           <section>
-            <div className="grid grid-cols-3 gap-6">
-              <StatCard type="TOTAL_BATTLES" value={openTotal + closedTotal} />
-              <StatCard type="LIVE_BATTLES" value={openTotal} />
-              <StatCard type="TOTAL_USERS" value={8567} />
-            </div>
-
             <div className="mt-6 grid grid-cols-3 gap-6">
               {BATTLE_CATEGORIES.slice(0, 3).map((c) => (
                 <BattleCategoryCard key={c.key} title={c.title} description={c.description} />


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #362

## ✅ 작업 내용

### 1. 공통 로딩 UI 컴포넌트 구현
- **LoadingOverlay**: 전체 화면 로딩 상태를 표시하는 모달 형식 컴포넌트
  - 그라데이션 배경과 회전 애니메이션 효과
  
- **Skeleton**: 콘텐츠 로딩 중 자리를 임시 대처하는 컴포넌트로 Layout Shift 방지

<br/>

### 2. React Query Suspense 모드 전면 도입
기존의 수동 로딩 상태 관리(`isLoading`, `isPending`)를 제거하고 useSuspenseQuery를 이용해 선언적 로딩 처리로 전환 했습니다. 

**useQuery  -> useSuspenseQuery로 마이그레이션된 훅**
- `useGetOpenBattles`: 진행 중인 배틀 목록 조회
- `useGetClosedBattles`: 종료된 배틀 목록 조회
- `useGetBattleInfo`: 배틀 상세 정보 조회
- `useGetBattleResult`: 배틀 결과 조회

**변경 사항:**
- `useQuery` → `useSuspenseQuery` 전환
- `enabled`, `throwOnError` 옵션 제거 (Suspense가 자동 처리 하기에 필요 없더라구요)
- 기존에 해당 훅들의 상태((`isLoading`, `isPending`)를 이용하여 로딩, 에러 UI를 표시하는 로직들 모두 제거했습니다. 

<br/>

### 3. 페이지별 Suspense Boundary 적용

- BattlePage -  "배틀 정보를 불러오는 중..." 메시지와 함께 LoadingOverlay 표시
- BattleResultPage -  "배틀 결과를 불러오는 중..." 메시지와 함께 LoadingOverlay 표시
- LiveBattlesSection - Suspense + Skeleton으로 로딩 상태 표시
- PastBattlesSection - Suspense + Skeleton으로 로딩 상태 표시
- BattleCreatePage - 배틀 생성 API 요청 중 LoadingOverlay 표시
<br/>

### 4. 메인 페이지 배틀 목록이 비어있을 때 표시되는 안내 컴포넌트 구현 




<br />

## 📸 참고 사항

### 주요 변경 파일
**새로 생성된 컴포넌트:**
- `frontend/src/commons/components/LoadingOverlay.tsx`
- `frontend/src/commons/components/Skeleton.tsx`
- `frontend/src/pages/mainPage/components/EmptyBattlesState.tsx`

**Suspense 적용 페이지:**
- `frontend/src/App.tsx` - BattlePage, BattleResultPage 라우트
- `frontend/src/pages/mainPage/components/LiveBattlesSection.tsx`
- `frontend/src/pages/mainPage/components/PastBattlesSection.tsx`
- `frontend/src/pages/battleCreatePage/index.tsx`

**useSuspenseQuery 마이그레이션:**
- `frontend/src/pages/mainPage/hooks/useGetOpenBattles.ts`
- `frontend/src/pages/mainPage/hooks/useGetClosedBattles.ts`
- `frontend/src/commons/hooks/useGetBattleInfo.ts`
- `frontend/src/pages/battleResultPage/hooks/useGetBattleResult.ts`


<br />