### PR TITLE
[Fix] 선정된 이의제기, 반론 text가 너무 길면 타임라인 UI, 채팅 라운지 UI가 비정상적으로 표시되는 문제 수정

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -224,6 +224,35 @@
   animation: shake-fade-out 0.8s cubic-bezier(0.68, -0.55, 0.265, 1.55);
 }
 
+@keyframes input-exceed-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  15% {
+    transform: translateX(-6px);
+  }
+  30% {
+    transform: translateX(6px);
+  }
+  45% {
+    transform: translateX(-4px);
+  }
+  60% {
+    transform: translateX(4px);
+  }
+  75% {
+    transform: translateX(-2px);
+  }
+  90% {
+    transform: translateX(2px);
+  }
+}
+
+.animate-input-exceed-shake {
+  animation: input-exceed-shake 0.5s ease-in-out;
+}
+
 /* Custom styles */
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -15,6 +15,7 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
   const [inputValue, setInputValue] = useState('');
   const [isFocused, setIsFocused] = useState(false);
   const [isShaking, setIsShaking] = useState(false);
+  const [isLimitExceeded, setIsLimitExceeded] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const round = battleProgress?.round;
   const phase = battleProgress?.phase;
@@ -23,14 +24,18 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     let newValue = e.target.value;
-    const over = newValue.length > MAX_LENGTH;
 
-    if (over) {
-      if (inputValue.length < MAX_LENGTH) {
-        setIsShaking(true);
-        setTimeout(() => setIsShaking(false), 500);
-      }
+    // 120자를 초과하려고 하면 자르기
+    if (newValue.length > MAX_LENGTH) {
       newValue = newValue.slice(0, MAX_LENGTH);
+    }
+
+    // 119글자에서 120글자로 도달했을 때 애니메이션 발동
+    if (inputValue.length < MAX_LENGTH && newValue.length === MAX_LENGTH) {
+      setIsLimitExceeded(true);
+      setIsShaking(true);
+      setTimeout(() => setIsShaking(false), 500);
+      setTimeout(() => setIsLimitExceeded(false), 2000);
     }
 
     setInputValue(newValue);
@@ -86,9 +91,13 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
               onBlur={() => setIsFocused(false)}
               placeholder={config.placeholderText}
               autoFocus
-              className={`w-full bg-black/30 backdrop-blur-sm rounded-lg px-4 py-3.5 text-sm text-white placeholder-gray-500/60 border-2 transition-colors focus:outline-none focus:ring-2 ${
-                isFocused ? config.colors.focusBorder : config.colors.border
-              } ${config.colors.focusRing} ${isShaking ? 'animate-input-exceed-shake' : ''} disabled:opacity-50 disabled:cursor-not-allowed`}
+              className={`w-full bg-black/30 backdrop-blur-sm rounded-lg px-4 py-3.5 text-sm text-white placeholder-gray-500/60 border-2 transition-all duration-500 focus:outline-none focus:ring-2 ${
+                isLimitExceeded
+                  ? 'border-red-500 focus:ring-red-500/30'
+                  : isFocused
+                    ? config.colors.focusBorder
+                    : config.colors.border
+              } ${isLimitExceeded ? '' : config.colors.focusRing} ${isShaking ? 'animate-input-exceed-shake' : ''} disabled:opacity-50 disabled:cursor-not-allowed`}
             />
 
             <button

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from 'react';
+import { useToastStore, selectAddToast } from '@/commons/stores/toastStore';
 import { getDiscussionConfig } from '../../utils/battlePhase';
 import { useBattleStore, selectBattleProgress } from '../../stores/battleStore';
 import BattleIcon from '@/assets/icon/battle.svg?react';
@@ -17,6 +18,8 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
   const [isShaking, setIsShaking] = useState(false);
   const [isLimitExceeded, setIsLimitExceeded] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const addToast = useToastStore(selectAddToast);
+
   const round = battleProgress?.round;
   const phase = battleProgress?.phase;
   const config = getDiscussionConfig(phase);
@@ -25,12 +28,11 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     let newValue = e.target.value;
 
-    // 120자를 초과하려고 하면 자르기
     if (newValue.length > MAX_LENGTH) {
+      addToast({ message: `${phase === 'ATTACK' ? '이의제기' : '반론'}은 최대 120글자까지 입력할 수 있습니다.` });
       newValue = newValue.slice(0, MAX_LENGTH);
     }
 
-    // 119글자에서 120글자로 도달했을 때 애니메이션 발동
     if (inputValue.length < MAX_LENGTH && newValue.length === MAX_LENGTH) {
       setIsLimitExceeded(true);
       setIsShaking(true);

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -4,6 +4,8 @@ import { useBattleStore, selectBattleProgress } from '../../stores/battleStore';
 import BattleIcon from '@/assets/icon/battle.svg?react';
 import ShieldIcon from '@/assets/icon/shield.svg?react';
 
+const MAX_LENGTH = 120;
+
 interface DiscussionInputProps {
   onSubmit?: (content: string) => void;
 }
@@ -12,11 +14,27 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
   const battleProgress = useBattleStore(selectBattleProgress);
   const [inputValue, setInputValue] = useState('');
   const [isFocused, setIsFocused] = useState(false);
+  const [isShaking, setIsShaking] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const round = battleProgress?.round;
   const phase = battleProgress?.phase;
   const config = getDiscussionConfig(phase);
   const PhaseIcon = phase === 'ATTACK' ? BattleIcon : ShieldIcon;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let newValue = e.target.value;
+    const over = newValue.length > MAX_LENGTH;
+
+    if (over) {
+      if (inputValue.length < MAX_LENGTH) {
+        setIsShaking(true);
+        setTimeout(() => setIsShaking(false), 500);
+      }
+      newValue = newValue.slice(0, MAX_LENGTH);
+    }
+
+    setInputValue(newValue);
+  };
 
   const handleSubmit = () => {
     if (inputValue.trim()) {
@@ -62,7 +80,7 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
               ref={inputRef}
               type="text"
               value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
+              onChange={handleChange}
               onKeyDown={handleKeyPress}
               onFocus={() => setIsFocused(true)}
               onBlur={() => setIsFocused(false)}
@@ -70,7 +88,7 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
               autoFocus
               className={`w-full bg-black/30 backdrop-blur-sm rounded-lg px-4 py-3.5 text-sm text-white placeholder-gray-500/60 border-2 transition-colors focus:outline-none focus:ring-2 ${
                 isFocused ? config.colors.focusBorder : config.colors.border
-              } ${config.colors.focusRing} disabled:opacity-50 disabled:cursor-not-allowed`}
+              } ${config.colors.focusRing} ${isShaking ? 'animate-input-exceed-shake' : ''} disabled:opacity-50 disabled:cursor-not-allowed`}
             />
 
             <button

--- a/frontend/src/pages/battlePage/components/effects/DiscussionModal.tsx
+++ b/frontend/src/pages/battlePage/components/effects/DiscussionModal.tsx
@@ -97,7 +97,7 @@ export default function DiscussionModal({ isOpen, team, content, type, onClose }
           <div
             className={`max-w-2xl px-8 py-6 bg-gray-800/80 backdrop-blur-sm rounded-2xl border-2 border-gray-700 shadow-2xl transition-all duration-500 delay-400 ${cardClass}`}
           >
-            <p className="text-gray-100 text-lg leading-relaxed">{content}</p>
+            <p className="text-gray-100 text-lg leading-relaxed break-all">{content}</p>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/teamSelectPage/components/steps/Step4Timeline.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/Step4Timeline.tsx
@@ -142,8 +142,7 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
     const isTeamA = team === 'A';
 
     return (
-      <div className="p-6">
-        {/* Header */}
+      <div className="p-6 w-full flex flex-col h-48 overflow-hidden justify-between">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
             <span
@@ -158,10 +157,8 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
           <span className="text-gray-500 text-xs">{formatTime(message.selectedAt)}</span>
         </div>
 
-        {/* Content */}
-        <p className="text-gray-300 mb-4 leading-relaxed text-sm">{message.content}</p>
+        <p className="text-gray-300 mb-4 leading-relaxed text-xs break-all text-left">{message.content}</p>
 
-        {/* Vote Display */}
         <div
           className={`flex items-center gap-2 px-4 py-2 rounded-lg border-2 w-fit ${
             isTeamA ? 'bg-blue-600/20 border-blue-500/30' : 'bg-red-600/20 border-red-500/30'


### PR DESCRIPTION
## 🔗 관련 이슈
Closes  #345

## ✅ 작업 내용

### 💡개선 사항
#### 이의제기/반론 입력 최대 글자 수 제한

- 120자 초과 입력 시 토스트 알림 표시 로직 추가
- 120자 초과 입력시 입력창 테두리가 빨간색으로 변경 및 흔들림(shake) 애니메이션 적용 기능 적용 

#### 팀 선택 페이지의 타임라인 카드에서 이의제기/반론 텍스트가 길면 모달 카드를 벗어나던 문제 해결
- 텍스트 길이에 관계없이 카드 높이 ` h-48`로 고정
- 카드에 break-all 적용하여 카드가 비정상적으로 커지고 텍스트가 오버플로우 되는 문제 해결 

#### 선정된 이의제기/ 반박 이펙트 모달에서 긴 텍스트를 표시할 때 텍스트 오버플로우 되는 문제 해결  
- 긴 텍스트가 표시 되는 경우 카드 크기에 맞춰 자동 개행되도록 하여 비정상적으로 표시 되는 문제 해결


<br />

## 구현 스크린 샷
#### 이의제기/반론 입력 최대 글자 수 제한
![20260303-2009-33 3993722](https://github.com/user-attachments/assets/8f0bd960-d1eb-4cc8-90da-5629a12977d8)


### 팀 선택 페이지의 타임라인 카드에서 이의제기/반론 텍스트가 길면 모달 카드를 벗어나던 문제
#### 문제 상황

<img width="1092" height="887" alt="스크린샷 2026-03-04 034040" src="https://github.com/user-attachments/assets/e562b50d-8fc0-4773-adae-a0d364b63175" />

#### 수정 후 

<img width="869" height="626" alt="스크린샷 2026-03-04 043129" src="https://github.com/user-attachments/assets/44a456ac-1543-4647-ab15-1a505eb70603" />

<br/>

### 선정된 이의제기/ 반박 이펙트 모달에서 긴 텍스트를 표시할 때 텍스트 오버플로우 되는 문제 
#### 문제 상황
<img width="1518" height="684" alt="스크린샷 2026-03-04 045224" src="https://github.com/user-attachments/assets/27125580-f3e7-4a7b-aa15-b9acedc63753" />

#### 수정 후
<img width="1007" height="684" alt="image" src="https://github.com/user-attachments/assets/de7da1fb-2957-40ce-a52e-018f2e1f4d18" />


