### PR TITLE
[Settings] Playwright E2E 테스트 환경 구축

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+# Playwright
+playwright-report
+test-results
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-query-devtools": "^5.91.2",
     "@testing-library/jest-dom": "^6.9.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,10 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:coverage": "vitest --coverage"
+    "test:coverage": "vitest --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:debug": "playwright test --debug"
   },
   "dependencies": {
     "@sentry/react": "^10.38.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? undefined : 1,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.2
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
@@ -1262,6 +1265,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/adapter-pg@7.2.0':
     resolution: {integrity: sha512-euIdQ13cRB2wZ3jPsnDnFhINquo1PYFPCg6yVL8b2rp3EdinQHsX9EDdCtRr489D5uhphcRk463OdQAFlsCr0w==}
@@ -3283,6 +3291,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4380,6 +4393,16 @@ packages:
   pkginfo@0.3.1:
     resolution: {integrity: sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==}
     engines: {node: '>= 0.4.0'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -6500,6 +6523,10 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
+
   '@prisma/adapter-pg@7.2.0':
     dependencies:
       '@prisma/driver-adapter-utils': 7.2.0
@@ -8561,6 +8588,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -9805,6 +9835,14 @@ snapshots:
       pathe: 2.0.3
 
   pkginfo@0.3.1: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #390

## ✅ 작업 내용
### Playwright E2E 라이브러리 추가 
* `@playwright/test (v1.58.2)` 패키지 추가

### Playwright  E2E 테스트 환경 초기 세팅 - `playwright.config.ts` 작성
```javascript
 fullyParallel: true,
  forbidOnly: !!process.env.CI,
  retries: process.env.CI ? 2 : 0,
  workers: process.env.CI ? undefined : 1,
  reporter: 'html',
  use: {
    baseURL: 'http://localhost:5173',
    trace: 'on-first-retry',
  },

  projects: [
    {
      name: 'chromium',
      use: { ...devices['Desktop Chrome'] },
    },
    {
      name: 'firefox',
      use: { ...devices['Desktop Firefox'] },
    },
    {
      name: 'webkit',
      use: { ...devices['Desktop Safari'] },
    },
  ],

  webServer: {
    command: 'pnpm dev',
    url: 'http://localhost:5173',
    reuseExistingServer: !process.env.CI,
  },
```

* 브라우저 테스트 환경
`chromium`, `firefox`, `webkit` 3가지 브라우저 환경에서 테스트가 정상 동작하는지 확인할 수 있도록 설정했습니다.

* CI 환경과 로컬 환경 구분
CI 환경에서는 테스트 안정성과 실행 속도를 고려해   `retries: 2`, `workers: undefined` 설정을 적용했습니다.

- `forbidOnly: true`  
  실수로 `.only`가 포함된 상태로 PR이 올라가 전체 테스트가 건너뛰는 상황을 방지하기 위함

- `retries: 2`  
  CI 환경에서는 네트워크, 브라우저 타이밍, 리소스 문제 등으로 간헐적인 flaky 테스트가 발생할 수 있어 테스트 실패 시 최대 2회 재시도하도록 설정했습니다.

- `workers: undefined`  
  CI 환경에서는 여러 worker를 사용해 **병렬 실행**하여 전체 테스트 실행 시간을 줄이도록 했습니다.

* 디버깅을 위한 trace 설정
`trace: 'on-first-retry'` 옵션을 통해 테스트 실패 후 재시도 시 Playwright trace가 기록되도록 설정했습니다.

<br/>

### package.json에 E2E 실행 스크립트 추가 
```javascript
test:e2e` // 전체 실행 (CI용)
test:e2e:ui // Playwright UI 모드
test:e2e:debug // 스텝별 디버깅 용도
```
테스트 코드를 작성하고 직접 테스트 진행상황을 확인하고 싶다면 `test:e2e:ui`를 사용하시면 될 것 같습니다.

<br/>



## 📸 참고 사항
### E2E 테스트 코드 관리 폴더
만약에 프론트엔드 E2E 테스트 코드를 추가할 일이 있으시다면 `frontend/e2e`에서 관리하시면  됩니다!

### Playwright 산출물
<img width="864" height="599" alt="스크린샷 2026-03-05 204238" src="https://github.com/user-attachments/assets/76e8f1ad-1ca4-44c3-ac58-ce9ba43d6fac" />

E2E 테스트를 진행한다면 테스트 결과 및 레포트가 생성되는데 `frontend/playwright-report/`에 html 파일 형식으로 생성 됩니다. 
결과는 위 사진과 같이 생겼으며  `.gitignore`에 추가하여 pr에는 포함시키지 않도록 했습니다.


### 추후 예정 테스트 우선순위:

P0 — 진입 페이지, 로그인
P1 — 메인 페이지, 배틀 생성
P2 — 비회원 로그인 → 팀 선택 위저드 전체 플로우
P3 — 배틀 진행 페이지


<br/>

## 💬 질문사항 (고민했던 부분)
### API mocking을 위해  MSW 도입 하려다가 안했습니다. 
테스트 코드 작성을 위해 MSW를 추가할까 고민했는데, Playwright에서 `page.route()` 등 자체적으로 API mocking 기능을 제공해줘서 우선은 MSW 없이 진행했습니다.

다만 Playwright mocking만으로 테스트 작성이 빈약하다고 판단되는 경우에는 추후 MSW도 같이 도입하는 방향으로 고려하고 있습니다.

<br/>

## 참고 사항
현재 pnpm 버전 충돌로 lockfile이 계속 변경되는 문제가 있어서 아래 명령어 한 번씩 실행 부탁드려요!
```
$ corepack enable
```
이후부터 pnpm install 시 package.json 기준 버전(10.23.0)으로 자동 고정되어 lockfile이 더 이상 변경되지 않습니다 🙏