### PR TITLE
[Fix] 잘못된 홈 리다이렉트`(/)`를 `/main`으로 통일

### DIFF
--- a/frontend/src/commons/apis/getBattleInfo.ts
+++ b/frontend/src/commons/apis/getBattleInfo.ts
@@ -42,7 +42,7 @@ const getBattleInfo = async (id: string) => {
     if (!response.ok) {
       if (response.status === 403) {
         alert('비공개 배틀에 접근하려면 초대 코드가 필요합니다.');
-        window.location.href = '/';
+        window.location.href = '/main';
         throw new Error('비공개 배틀에 접근하려면 초대 코드가 필요합니다.');
       }
       throw new Error('배틀 데이터를 불러오는데 실패했습니다.');

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -231,7 +231,7 @@ export default function BattleCreatePage() {
                 <div className="flex items-center justify-end gap-3 pt-2">
                   <button
                     type="button"
-                    onClick={() => (window.location.href = '/')}
+                    onClick={() => (window.location.href = '/main')}
                     className="rounded-xl border border-[#2b2b3e] bg-transparent px-5 py-3 text-gray-200 hover:bg-[#1a1a2e] transition-colors"
                   >
                     취소

--- a/frontend/src/pages/tutorialPage/battle/index.tsx
+++ b/frontend/src/pages/tutorialPage/battle/index.tsx
@@ -102,7 +102,7 @@ export default function TutorialBattlePage() {
   const shouldShowInput = !isInputDisabled(selectedTeam, phase);
 
   const handleAutoExit = useCallback(() => {
-    navigate('/');
+    navigate('/main');
   }, [navigate]);
 
   useAutoExitOnDone(practicePhase === 'done', handleAutoExit);


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #396

## ✅ 작업 내용

### `/`로 잘못 라우팅되던 3곳을 `/main`으로 수정

| 위치 | 변경 전 | 변경 후 |
|---|---|---|
| `battleCreatePage` 취소 버튼 | `window.location.href = '/'` | `window.location.href = '/main'` |
| `getBattleInfo.ts` 403 처리 | `window.location.href = '/'` | `window.location.href = '/main'` |
| `tutorialPage/battle` 실습 완료 후 자동 이동 | `navigate('/')` | `navigate('/main')` |

기존에 라우팅 되던 `/`는 `App.tsx`에서 `/entry`(랜딩 페이지)로 redirect되기 때문에, 취소, 돌아가기, 완료 후 랜딩 페이지로 빠지는 문제가 있었습니다. 
의도에 맞게 `/main`으로 직접 이동하도록 수정했습니다.

<br />
