### PR TITLE
[Test] 메인 페이지 렌더링 및 유저 인터랙션 E2E 테스트 추가

### DIFF
--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -1,0 +1,39 @@
+import type { Page } from '@playwright/test';
+
+const OAUTH_KEY = 'CMC_OAUTH_USER';
+
+export interface MockOAuthUser {
+  id: string;
+  nickname: string;
+  type: 'oauth';
+  provider: 'github' | 'kakao';
+  avatarUrl?: string;
+  tier?: string;
+  rating?: number;
+}
+
+export const DEFAULT_OAUTH_USER: MockOAuthUser = {
+  id: 'test-user-id',
+  nickname: '테스트유저',
+  type: 'oauth',
+  provider: 'github',
+  tier: 'BRONZE',
+  rating: 0,
+};
+
+/** 인증된 OAuth 유저 상태 주입 */
+export async function injectOAuthUser(page: Page, user: MockOAuthUser = DEFAULT_OAUTH_USER): Promise<void> {
+  await page.addInitScript(
+    ({ key, value }: { key: string; value: MockOAuthUser }) => {
+      localStorage.setItem(key, JSON.stringify(value));
+    },
+    { key: OAUTH_KEY, value: user }
+  );
+}
+
+/** 미인증 상태 - /api/auth/me 401 mock */
+export async function mockUnauthenticated(page: Page): Promise<void> {
+  await page.route('**/api/auth/me', (route) =>
+    route.fulfill({ status: 401, body: JSON.stringify({ message: 'Unauthorized' }) })
+  );
+}

--- a/frontend/e2e/main.spec.ts
+++ b/frontend/e2e/main.spec.ts
@@ -1,6 +1,115 @@
 import { test, expect } from '@playwright/test';
 import { injectOAuthUser, mockUnauthenticated } from './helpers/auth';
 
+const MOCK_OPEN_BATTLE = {
+  id: 'battle-live-001',
+  title: '블록 if vs 한 줄 if',
+  description: '코드 스타일 비교',
+  status: 'OPEN',
+  createdAt: new Date().toISOString(),
+  expiresAt: new Date(Date.now() + 3600000).toISOString(),
+  clientCount: 10,
+  category: 'REFACTORING',
+  timeLabel: '1시간 후 종료',
+};
+
+const MOCK_CLOSED_BATTLE = {
+  id: 'battle-closed-001',
+  title: '재귀 vs 반복문',
+  description: '알고리즘 접근법 비교',
+  category: 'ALGORITHM',
+  status: 'CLOSED',
+  createdAt: new Date().toISOString(),
+  expiresAt: new Date().toISOString(),
+  result: {
+    winner: 'A',
+    teamA: { votes: 30, percentage: 60 },
+    teamB: { votes: 20, percentage: 40 },
+    neutral: { votes: 0, percentage: 0 },
+  },
+};
+
+test.describe('메인 페이지 - 렌더링', () => {
+  test('기본 Hero 섹션이 렌더링된다', async ({ page }) => {
+    await mockUnauthenticated(page);
+    await page.goto('/main');
+
+    await expect(page.getByRole('heading', { name: '코문철' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '새 배틀 생성' })).toBeVisible();
+    await expect(page.getByRole('link', { name: '튜토리얼' })).toBeVisible();
+  });
+
+  test('실시간 배틀 / 지난 배틀 결과 섹션 헤더가 렌더링된다', async ({ page }) => {
+    await mockUnauthenticated(page);
+    await page.goto('/main');
+
+    await expect(page.getByRole('heading', { name: '실시간 배틀' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '지난 배틀 결과' })).toBeVisible();
+  });
+
+  test('비로그인 상태에서 헤더에 로그인 링크가 표시된다', async ({ page }) => {
+    await mockUnauthenticated(page);
+    await page.goto('/main');
+
+    await expect(page.getByRole('link', { name: '로그인' })).toBeVisible();
+  });
+
+  test('로그인 상태에서 헤더에 유저 닉네임과 티어 아이콘이 표시된다', async ({ page }) => {
+    await injectOAuthUser(page);
+    await page.goto('/main');
+
+    await expect(page.getByText('테스트유저')).toBeVisible();
+    await expect(page.getByAltText('BRONZE tier')).toBeVisible();
+    await expect(page.getByRole('link', { name: '로그인' })).not.toBeVisible();
+  });
+
+  test('실시간 배틀 카드가 렌더링된다', async ({ page }) => {
+    await mockUnauthenticated(page);
+    await page.route('**/api/battles/open*', (route) =>
+      route.fulfill({ status: 200, json: { battles: [MOCK_OPEN_BATTLE], meta: { offset: 0, limit: 3, total: 1 } } })
+    );
+    await page.goto('/main');
+
+    await expect(page.getByText('블록 if vs 한 줄 if')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'LIVE NOW →' })).toBeVisible();
+  });
+
+  test('지난 배틀 결과 카드가 렌더링된다', async ({ page }) => {
+    await mockUnauthenticated(page);
+    await page.route('**/api/battles/closed*', (route) =>
+      route.fulfill({ status: 200, json: { battles: [MOCK_CLOSED_BATTLE], meta: { offset: 0, limit: 6, total: 1 } } })
+    );
+    await page.goto('/main');
+
+    await expect(page.getByText('재귀 vs 반복문')).toBeVisible();
+    await expect(page.getByRole('link', { name: '결과 보기 →' })).toBeVisible();
+  });
+
+  test('배틀 목록 API 실패 시 에러 바운더리가 노출된다', async ({ page }) => {
+    await mockUnauthenticated(page);
+    await page.route('**/api/battles/open*', (route) => route.fulfill({ status: 500 }));
+    await page.route('**/api/battles/closed*', (route) => route.fulfill({ status: 500 }));
+    await page.goto('/main');
+
+    await expect(page.getByText('실시간 배틀을 불러올 수 없습니다')).toBeVisible();
+    await expect(page.getByText('지난 배틀 결과를 불러올 수 없습니다')).toBeVisible();
+  });
+
+  test('배틀이 없을 때 empty state가 노출된다', async ({ page }) => {
+    await mockUnauthenticated(page);
+    await page.route('**/api/battles/open*', (route) =>
+      route.fulfill({ status: 200, json: { battles: [], meta: { offset: 0, limit: 3, total: 0 } } })
+    );
+    await page.route('**/api/battles/closed*', (route) =>
+      route.fulfill({ status: 200, json: { battles: [], meta: { offset: 0, limit: 6, total: 0 } } })
+    );
+    await page.goto('/main');
+
+    await expect(page.getByText('진행 중인 배틀이 없습니다')).toBeVisible();
+    await expect(page.getByText('종료된 배틀이 없습니다')).toBeVisible();
+  });
+});
+
 test.describe('메인 페이지 - 새 배틀 생성 버튼', () => {
   test('비로그인 상태에서 새 배틀 생성 버튼 클릭 시 경고 toast가 표시된다', async ({ page }) => {
     await mockUnauthenticated(page);

--- a/frontend/e2e/main.spec.ts
+++ b/frontend/e2e/main.spec.ts
@@ -110,6 +110,32 @@ test.describe('메인 페이지 - 렌더링', () => {
   });
 });
 
+test.describe('메인 페이지 - 배틀 카드 클릭', () => {
+  test('LIVE NOW → 클릭 시 팀 선택 페이지로 이동한다', async ({ page }) => {
+    await mockUnauthenticated(page);
+    await page.route('**/api/battles/open*', (route) =>
+      route.fulfill({ status: 200, json: { battles: [MOCK_OPEN_BATTLE], meta: { offset: 0, limit: 3, total: 1 } } })
+    );
+    await page.goto('/main');
+
+    await page.getByRole('link', { name: 'LIVE NOW →' }).click();
+
+    await expect(page).toHaveURL(`/battle/${MOCK_OPEN_BATTLE.id}/team-select`);
+  });
+
+  test('결과 보기 → 클릭 시 결과 페이지로 이동한다', async ({ page }) => {
+    await mockUnauthenticated(page);
+    await page.route('**/api/battles/closed*', (route) =>
+      route.fulfill({ status: 200, json: { battles: [MOCK_CLOSED_BATTLE], meta: { offset: 0, limit: 6, total: 1 } } })
+    );
+    await page.goto('/main');
+
+    await page.getByRole('link', { name: '결과 보기 →' }).click();
+
+    await expect(page).toHaveURL(`/battles/${MOCK_CLOSED_BATTLE.id}/result`);
+  });
+});
+
 test.describe('메인 페이지 - 새 배틀 생성 버튼', () => {
   test('비로그인 상태에서 새 배틀 생성 버튼 클릭 시 경고 toast가 표시된다', async ({ page }) => {
     await mockUnauthenticated(page);

--- a/frontend/e2e/main.spec.ts
+++ b/frontend/e2e/main.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { injectOAuthUser, mockUnauthenticated } from './helpers/auth';
+
+test.describe('메인 페이지 - 새 배틀 생성 버튼', () => {
+  test('비로그인 상태에서 새 배틀 생성 버튼 클릭 시 경고 toast가 표시된다', async ({ page }) => {
+    await mockUnauthenticated(page);
+    await page.goto('/main');
+
+    await page.getByRole('button', { name: '새 배틀 생성' }).click();
+
+    await expect(page.getByText('로그인 후 이용 가능합니다.')).toBeVisible();
+  });
+
+  test('로그인 상태에서 새 배틀 생성 버튼 클릭 시 /battle/create로 이동한다', async ({ page }) => {
+    await injectOAuthUser(page);
+    await page.goto('/main');
+
+    await page.getByRole('button', { name: '새 배틀 생성' }).click();
+
+    await expect(page).toHaveURL('/battle/create');
+  });
+});

--- a/frontend/tsconfig.e2e.json
+++ b/frontend/tsconfig.e2e.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node", "@playwright/test"]
+  },
+  "include": ["e2e"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test/mocks/sentry.ts', './src/test/setup.ts'],
-    css: true
+    css: true,
+    include: ['src/**/*.{test,spec}.{ts,tsx}']
   }
 });


### PR DESCRIPTION
## ✅ 작업 내용

### 인증 테스트 헬퍼 추가
우선 메인 페이지에 로그인/비로그인 상태에 따라 달라지는 기능들이 존재하기에, 실제 외부 OAuth 플로우를 타지 않고 Mock auth 정보를 주입 하여 E2E 테스트에 사용 될 수 있는 유틸 헬퍼 함수를 구현했습니다. 
메인 페이지 외에도 배틀 생성 페이지, 인게임에서도 인증 상태에 따른 api 동작이 필요함으로  `e2e/helpers/`에 저장했습니다.

#### injectOAuthUser(page, user?)
테스트안에서 localStorage에 OAuth 유저 정보(mock)를 주입해 로그인 시키는 함수
##### 사용 예시
```typescript
  test('로그인 상태에서 헤더에 유저 닉네임과 티어 아이콘이 표시된다', async ({ page }) => {
    await injectOAuthUser(page);
    await page.goto('/main');

    await expect(page.getByText('테스트유저')).toBeVisible();
    await expect(page.getByAltText('BRONZE tier')).toBeVisible();
    await expect(page.getByRole('link', { name: '로그인' })).not.toBeVisible();
  });
```

#### mockUnauthenticated(page)
`/api/auth/me API`를 401로 mock하여 비로그인 상태를 만들어주는 함수 
##### 사용 예시 
```typescript
  test('비로그인 상태에서 헤더에 로그인 링크가 표시된다', async ({ page }) => {
    await mockUnauthenticated(page);
    await page.goto('/main');

    await expect(page.getByRole('link', { name: '로그인' })).toBeVisible();
  });
```

### 추가한 테스트 목록
- 실시간 배틀 / 지난 배틀 결과 섹션 헤더가 렌더링된다
- 비로그인 상태에서 헤더에 로그인 링크가 표시된다
- 로그인 상태에서 헤더에 유저 닉네임과 티어 아이콘이 표시된다
- 실시간 배틀 / 지난 배틀 결과 카드가 렌더링된다
- 지난 배틀 결과 카드가 렌더링된다
- 배틀 목록 API 실패 시 에러 바운더리가 노출된다
- 배틀이 없을 때 빈 배틀 목록 카드가 노출된다
- 배틀 카드에서 `LIVE NOW`버튼 클릭 시 팀 선택 페이지로 이동한다
- 배틀 카드에서 `결과 보기`버튼 클릭 시 결과 페이지로 이동한다
- 비로그인 상태에서 새 배틀 생성 버튼 클릭 시 경고 toast가 표시된다
- 로그인 상태에서 새 배틀 생성 버튼 클릭 시 배틀 생성 페이지로 이동한다
