### PR TITLE
[Test] 배틀 생성 페이지에서 생성 플로우 E2E 테스트 추가

### DIFF
--- a/frontend/e2e/battleCreate.spec.ts
+++ b/frontend/e2e/battleCreate.spec.ts
@@ -1,5 +1,13 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { injectOAuthUser } from './helpers/auth';
+
+async function fillRequiredFields(page: Page) {
+  await page.getByPlaceholder('예: 배열에서 중복 제거하기').fill('테스트 배틀');
+  await page.getByPlaceholder('어떤 코드를 비교하고 싶으신가요?').fill('코드 비교 설명');
+  await page.getByPlaceholder('첫 번째 코드를 입력하세요').fill('const a = 1;');
+  await page.getByPlaceholder('두 번째 코드를 입력하세요').fill('let b = 2;');
+  await page.getByLabel('효율성').check();
+}
 
 test.describe('배틀 생성 페이지 - 폼 렌더링', () => {
   test('페이지 진입 시 필수 입력 필드와 버튼이 렌더링된다', async ({ page }) => {
@@ -44,11 +52,7 @@ test.describe('배틀 생성 페이지 - 버튼 활성화', () => {
     await injectOAuthUser(page);
     await page.goto('/battle/create');
 
-    await page.getByPlaceholder('예: 배열에서 중복 제거하기').fill('테스트 배틀');
-    await page.getByPlaceholder('어떤 코드를 비교하고 싶으신가요?').fill('코드 비교 설명');
-    await page.getByPlaceholder('첫 번째 코드를 입력하세요').fill('const a = 1;');
-    await page.getByPlaceholder('두 번째 코드를 입력하세요').fill('let b = 2;');
-    await page.getByLabel('효율성').check();
+    await fillRequiredFields(page);
 
     await expect(page.getByTestId('create-battle-button')).toBeEnabled();
   });
@@ -61,15 +65,53 @@ test.describe('배틀 생성 페이지 - 버튼 활성화', () => {
     await page.getByPlaceholder('어떤 코드를 비교하고 싶으신가요?').fill('코드 비교 설명');
     await page.getByPlaceholder('첫 번째 코드를 입력하세요').fill('const a = 1;');
     await page.getByPlaceholder('두 번째 코드를 입력하세요').fill('let b = 2;');
+    await page.locator('select').nth(2).selectOption({ label: '30분' });
 
-    await page.selectOption('select:nth-of-type(2)', 'THIRTY_MIN');
-
-    // 쟁점 1개만 선택 -> 버튼 비활성화
     await page.getByLabel('효율성').check();
     await expect(page.getByTestId('create-battle-button')).toBeDisabled();
 
-    // 쟁점 2개 선택 -> 버튼 활성화
     await page.getByLabel('가독성').check();
     await expect(page.getByTestId('create-battle-button')).toBeEnabled();
+  });
+});
+
+test.describe('배틀 생성 페이지 - 생성 플로우', () => {
+  test('생성 중 로딩 오버레이가 노출된다', async ({ page }) => {
+    await injectOAuthUser(page);
+    await page.route('**/api/battles', (route) => {
+      setTimeout(() => route.fulfill({ status: 200, json: { battleId: 'new-battle-id' } }), 1000);
+    });
+    await page.goto('/battle/create');
+
+    await fillRequiredFields(page);
+    await page.getByTestId('create-battle-button').click();
+
+    await expect(page.getByText('배틀 생성 중입니다...')).toBeVisible();
+  });
+
+  test('배틀 생성 성공 시 팀 선택 페이지로 이동한다', async ({ page }) => {
+    await injectOAuthUser(page);
+    await page.route('**/api/battles', (route) =>
+      route.fulfill({ status: 200, json: { battleId: 'new-battle-id' } })
+    );
+    await page.goto('/battle/create');
+
+    await fillRequiredFields(page);
+    await page.getByTestId('create-battle-button').click();
+
+    await expect(page).toHaveURL('/battle/new-battle-id/team-select/');
+  });
+
+  test('배틀 생성 API 실패 시 toast가 노출된다', async ({ page }) => {
+    await injectOAuthUser(page);
+    await page.route('**/api/battles', (route) =>
+      route.fulfill({ status: 500 })
+    );
+    await page.goto('/battle/create');
+
+    await fillRequiredFields(page);
+    await page.getByTestId('create-battle-button').click();
+
+    await expect(page.getByText('배틀 생성에 실패했습니다.')).toBeVisible();
   });
 });

--- a/frontend/e2e/battleCreate.spec.ts
+++ b/frontend/e2e/battleCreate.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { injectOAuthUser } from './helpers/auth';
+
+test.describe('배틀 생성 페이지 - 폼 렌더링', () => {
+  test('페이지 진입 시 필수 입력 필드와 버튼이 렌더링된다', async ({ page }) => {
+    await injectOAuthUser(page);
+    await page.goto('/battle/create');
+
+    await expect(page.getByRole('heading', { name: '새 배틀 생성' })).toBeVisible();
+    await expect(page.getByPlaceholder('예: 배열에서 중복 제거하기')).toBeVisible();
+    await expect(page.getByPlaceholder('어떤 코드를 비교하고 싶으신가요?')).toBeVisible();
+    await expect(page.getByPlaceholder('첫 번째 코드를 입력하세요')).toBeVisible();
+    await expect(page.getByPlaceholder('두 번째 코드를 입력하세요')).toBeVisible();
+    await expect(page.getByText('언어')).toBeVisible();
+    await expect(page.getByText('카테고리')).toBeVisible();
+    await expect(page.getByText('배틀 시간')).toBeVisible();
+    await expect(page.getByText('배틀 공개 여부')).toBeVisible();
+    await expect(page.getByText('대주제 선택')).toBeVisible();
+    await expect(page.getByRole('button', { name: '취소' })).toBeVisible();
+    await expect(page.getByTestId('create-battle-button')).toBeVisible();
+  });
+});
+
+test.describe('배틀 생성 페이지 - 버튼 비활성화', () => {
+  test('필수 항목 미입력 시 배틀 생성하기 버튼이 비활성화된다', async ({ page }) => {
+    await injectOAuthUser(page);
+    await page.goto('/battle/create');
+
+    await expect(page.getByTestId('create-battle-button')).toBeDisabled();
+  });
+
+  test('제목만 입력 시 버튼이 비활성화된다', async ({ page }) => {
+    await injectOAuthUser(page);
+    await page.goto('/battle/create');
+
+    await page.getByPlaceholder('예: 배열에서 중복 제거하기').fill('테스트 제목');
+
+    await expect(page.getByTestId('create-battle-button')).toBeDisabled();
+  });
+});
+
+test.describe('배틀 생성 페이지 - 버튼 활성화', () => {
+  test('필수 항목 모두 입력 시 버튼이 활성화된다 (15분 / 쟁점 1개)', async ({ page }) => {
+    await injectOAuthUser(page);
+    await page.goto('/battle/create');
+
+    await page.getByPlaceholder('예: 배열에서 중복 제거하기').fill('테스트 배틀');
+    await page.getByPlaceholder('어떤 코드를 비교하고 싶으신가요?').fill('코드 비교 설명');
+    await page.getByPlaceholder('첫 번째 코드를 입력하세요').fill('const a = 1;');
+    await page.getByPlaceholder('두 번째 코드를 입력하세요').fill('let b = 2;');
+    await page.getByLabel('효율성').check();
+
+    await expect(page.getByTestId('create-battle-button')).toBeEnabled();
+  });
+
+  test('30분 선택 시 쟁점 2개 선택해야 버튼이 활성화된다', async ({ page }) => {
+    await injectOAuthUser(page);
+    await page.goto('/battle/create');
+
+    await page.getByPlaceholder('예: 배열에서 중복 제거하기').fill('테스트 배틀');
+    await page.getByPlaceholder('어떤 코드를 비교하고 싶으신가요?').fill('코드 비교 설명');
+    await page.getByPlaceholder('첫 번째 코드를 입력하세요').fill('const a = 1;');
+    await page.getByPlaceholder('두 번째 코드를 입력하세요').fill('let b = 2;');
+
+    await page.selectOption('select:nth-of-type(2)', 'THIRTY_MIN');
+
+    // 쟁점 1개만 선택 → 버튼 비활성화
+    await page.getByLabel('효율성').check();
+    await expect(page.getByTestId('create-battle-button')).toBeDisabled();
+
+    // 쟁점 2개 선택 → 버튼 활성화
+    await page.getByLabel('가독성').check();
+    await expect(page.getByTestId('create-battle-button')).toBeEnabled();
+  });
+});

--- a/frontend/e2e/battleCreate.spec.ts
+++ b/frontend/e2e/battleCreate.spec.ts
@@ -64,11 +64,11 @@ test.describe('배틀 생성 페이지 - 버튼 활성화', () => {
 
     await page.selectOption('select:nth-of-type(2)', 'THIRTY_MIN');
 
-    // 쟁점 1개만 선택 → 버튼 비활성화
+    // 쟁점 1개만 선택 -> 버튼 비활성화
     await page.getByLabel('효율성').check();
     await expect(page.getByTestId('create-battle-button')).toBeDisabled();
 
-    // 쟁점 2개 선택 → 버튼 활성화
+    // 쟁점 2개 선택 -> 버튼 활성화
     await page.getByLabel('가독성').check();
     await expect(page.getByTestId('create-battle-button')).toBeEnabled();
   });

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.e2e.json" }
   ]
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #395

## ✅ 작업 내용
<img width="605" height="373" alt="image" src="https://github.com/user-attachments/assets/031daf3a-af41-47f7-9a80-928ff245973a" />


### 추가한 테스트 목록
* 페이지 진입 시 필수 입력 필드와 버튼이 렌더링된다
* 필수 입력 필드를 모두 입력하면 생성 버튼이 활성화된다
* 투표 항목을 1개만 선택하면 생성 버튼이 비활성화되고, 2개 선택 시 활성화된다
* 배틀 생성 버튼 클릭 시 로딩 오버레이가 노출된다
* 배틀 생성 성공 시 팀 선택 페이지로 이동한다
* 배틀 생성 API 실패 시 에러 toast가 노출된다

## 📸 참고 사항
<img width="1608" height="301" alt="image" src="https://github.com/user-attachments/assets/fac30cd6-fd7a-4fbe-be6b-4246d91acebe" />
현재 deploy-dev.yml이 dev 브랜치 push 시 CD까지 자동으로 실행되도록 설정되어 있는데, NCP dev 서버가 없는 상태라 머지할 때마다 워크플로우가 실패하고 있습니다. dev 브랜치에 CD가 필요한지, 아니면 CI만 돌리고 CD는 release에서만 할지 팀에서 한번 논의해보면 좋을 것 같습니다.

<br />

