### PR TITLE
[Refactor] 아이콘 관리 구조 개선 (중앙화 + 공용 컴포넌트 도입)

### DIFF
--- a/frontend/e2e/teamSelect.spec.ts
+++ b/frontend/e2e/teamSelect.spec.ts
@@ -19,6 +19,7 @@ async function navigateToTeamSelect(page: Page) {
   }
 }
 
+
 test.describe('팀 선택 페이지 - 렌더링', () => {
   test('페이지 타이틀과 1단계 상황 요약이 렌더링된다', async ({ page }) => {
     await setupPage(page);

--- a/frontend/src/commons/components/ErrorBoundary/SectionErrorFallback.tsx
+++ b/frontend/src/commons/components/ErrorBoundary/SectionErrorFallback.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, RefreshCw } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 
 interface SectionErrorFallbackProps {
   error: Error;
@@ -22,7 +22,7 @@ export default function SectionErrorFallback({
     >
       <div className="flex flex-col items-center gap-4 text-center">
         <div className="p-3 bg-orange-500/10 rounded-full">
-          <AlertTriangle className="w-8 h-8 text-orange-500" />
+          <Icon name="alertTriangle" className="w-8 h-8 text-orange-500" />
         </div>
 
         <div className="space-y-2">
@@ -34,7 +34,7 @@ export default function SectionErrorFallback({
           onClick={reset}
           className="flex items-center gap-2 px-6 py-3 bg-orange-500 hover:bg-orange-600 text-white font-medium rounded-lg transition-colors duration-200"
         >
-          <RefreshCw className="w-4 h-4" />
+          <Icon name="refreshCw" className="w-4 h-4" />
           다시 시도
         </button>
       </div>

--- a/frontend/src/commons/components/Header.tsx
+++ b/frontend/src/commons/components/Header.tsx
@@ -1,32 +1,7 @@
 import { Link } from 'react-router-dom';
-import BattleIcon from '@/assets/icon/battle.svg?react';
+import Icon, { type TierName } from './Icon';
 import { useAuthStore, selectUser, selectIsOAuth } from '@/commons/stores/authStore';
 import UserProfileDropdown from './UserProfileDropdown';
-import tierBronze from '@/assets/icon/bronze.png';
-import tierSilver from '@/assets/icon/silver.png';
-import tierGold from '@/assets/icon/gold.png';
-import tierDiamond from '@/assets/icon/diamond.png';
-import tierMaster from '@/assets/icon/master.png';
-import tierGrandmaster from '@/assets/icon/grandmaster.png';
-
-const TIER_ICON_MAP: Record<string, string> = {
-  BRONZE: tierBronze,
-  SILVER: tierSilver,
-  GOLD: tierGold,
-  DIAMOND: tierDiamond,
-  MASTER: tierMaster,
-  GRANDMASTER: tierGrandmaster
-};
-
-const TIER_ICON_SCALE: Record<string, number> = {
-  BRONZE: 1.12,
-  SILVER: 1.12,
-  GOLD: 1.12,
-  PLATINUM: 1.12,
-  DIAMOND: 1.12,
-  MASTER: 1.12,
-  GRANDMASTER: 1.12
-};
 
 export default function Header() {
   const user = useAuthStore(selectUser);
@@ -38,7 +13,7 @@ export default function Header() {
         <div className="w-full px-8 h-full flex items-center justify-between">
           {/* 좌측 로고 */}
           <Link to="/main" className="flex items-center gap-2">
-            <BattleIcon className="w-6 h-6 text-orange-500" />
+            <Icon name="battle" className="w-6 h-6 text-orange-500" />
             <span className=" font-semibold ">배틀 아레나</span>
           </Link>
 
@@ -47,14 +22,14 @@ export default function Header() {
             {user && isOAuth ? (
               // OAuth 로그인 사용자: 프로필 드롭다운 표시
               <div className="flex items-center gap-1">
-                {user.tier && TIER_ICON_MAP[user.tier] && (
+                {user.tier && (
                   <div className="relative group flex items-center">
                     <div className="w-[25px] h-[25px] flex items-center justify-center overflow-hidden">
-                      <img
-                        src={TIER_ICON_MAP[user.tier]}
+                      <Icon
+                        name={user.tier.toLowerCase() as TierName}
                         alt={`${user.tier} tier`}
                         className="w-full h-full object-contain block"
-                        style={{ transform: `scale(${TIER_ICON_SCALE[user.tier] ?? 1})` }}
+                        style={{ transform: 'scale(1.12)' }}
                       />
                     </div>
                     <div className="absolute left-1/2 top-full mt-2 -translate-x-1/2 scale-95 opacity-0 pointer-events-none transition-all duration-150 group-hover:opacity-100 group-hover:scale-100">

--- a/frontend/src/commons/components/Icon/icons.ts
+++ b/frontend/src/commons/components/Icon/icons.ts
@@ -31,6 +31,32 @@ import UserIcon from '@/assets/icon/user.svg?react';
 import VoteIcon from '@/assets/icon/vote.svg?react';
 import WorldIcon from '@/assets/icon/world.svg?react';
 
+import {
+  Activity,
+  AlertTriangle,
+  ArrowDown,
+  ArrowRight,
+  Award,
+  BookOpen,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  Code2,
+  ExternalLink,
+  Flag,
+  Flame,
+  Home,
+  Medal,
+  RefreshCw,
+  Shuffle,
+  Sparkles,
+  Target,
+  TrendingUp,
+  Zap
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
 import BronzePng from '@/assets/icon/bronze.png';
 import SilverPng from '@/assets/icon/silver.png';
 import GoldPng from '@/assets/icon/gold.png';
@@ -41,6 +67,8 @@ import GrandmasterPng from '@/assets/icon/grandmaster.png';
 import type { FC, SVGProps } from 'react';
 
 export type SvgIconComponent = FC<SVGProps<SVGSVGElement>>;
+
+const lc = (icon: LucideIcon): SvgIconComponent => icon as SvgIconComponent;
 
 export const SVG_ICONS = {
   battle: BattleIcon,
@@ -74,7 +102,30 @@ export const SVG_ICONS = {
   trophy: TrophyIcon,
   user: UserIcon,
   vote: VoteIcon,
-  world: WorldIcon
+  world: WorldIcon,
+  // lucide-react icons
+  activity: lc(Activity),
+  alertTriangle: lc(AlertTriangle),
+  arrowDown: lc(ArrowDown),
+  arrowRight: lc(ArrowRight),
+  award: lc(Award),
+  bookOpen: lc(BookOpen),
+  chevronDown: lc(ChevronDown),
+  chevronLeft: lc(ChevronLeft),
+  chevronRight: lc(ChevronRight),
+  chevronUp: lc(ChevronUp),
+  code2: lc(Code2),
+  externalLink: lc(ExternalLink),
+  flag: lc(Flag),
+  flame: lc(Flame),
+  home: lc(Home),
+  medal: lc(Medal),
+  refreshCw: lc(RefreshCw),
+  shuffle: lc(Shuffle),
+  sparkles: lc(Sparkles),
+  target: lc(Target),
+  trendingUp: lc(TrendingUp),
+  zap: lc(Zap)
 } as const satisfies Record<string, SvgIconComponent>;
 
 export const TIER_ICONS = {

--- a/frontend/src/commons/components/Icon/icons.ts
+++ b/frontend/src/commons/components/Icon/icons.ts
@@ -1,0 +1,90 @@
+import BattleIcon from '@/assets/icon/battle.svg?react';
+import CheckIcon from '@/assets/icon/check.svg?react';
+import ClockIcon from '@/assets/icon/clock.svg?react';
+import CloseIcon from '@/assets/icon/close.svg?react';
+import CopyIcon from '@/assets/icon/copy.svg?react';
+import CrownIcon from '@/assets/icon/crown.svg?react';
+import DevIcon from '@/assets/icon/dev.svg?react';
+import DownArrowIcon from '@/assets/icon/downArrow.svg?react';
+import ExclamationIcon from '@/assets/icon/exclamation.svg?react';
+import EyeIcon from '@/assets/icon/eye.svg?react';
+import GithubIcon from '@/assets/icon/github.svg?react';
+import KakaoIcon from '@/assets/icon/kakao.svg?react';
+import LikeIcon from '@/assets/icon/like.svg?react';
+import MessageIcon from '@/assets/icon/message.svg?react';
+import PauseIcon from '@/assets/icon/pause.svg?react';
+import PeopleIcon from '@/assets/icon/people.svg?react';
+import PeoplesIcon from '@/assets/icon/peoples.svg?react';
+import PlayIcon from '@/assets/icon/play.svg?react';
+import PlusIcon from '@/assets/icon/plus.svg?react';
+import QuestionIcon from '@/assets/icon/question.svg?react';
+import ScaleIcon from '@/assets/icon/scale.svg?react';
+import SendIcon from '@/assets/icon/send.svg?react';
+import ShieldIcon from '@/assets/icon/shield.svg?react';
+import SkipIcon from '@/assets/icon/skip.svg?react';
+import SoundIcon from '@/assets/icon/sound.svg?react';
+import SwitchIcon from '@/assets/icon/switch.svg?react';
+import TimelineIcon from '@/assets/icon/timeline.svg?react';
+import TimerIcon from '@/assets/icon/timer.svg?react';
+import TrophyIcon from '@/assets/icon/trophy.svg?react';
+import UserIcon from '@/assets/icon/user.svg?react';
+import VoteIcon from '@/assets/icon/vote.svg?react';
+import WorldIcon from '@/assets/icon/world.svg?react';
+
+import BronzePng from '@/assets/icon/bronze.png';
+import SilverPng from '@/assets/icon/silver.png';
+import GoldPng from '@/assets/icon/gold.png';
+import DiamondPng from '@/assets/icon/diamond.png';
+import MasterPng from '@/assets/icon/master.png';
+import GrandmasterPng from '@/assets/icon/grandmaster.png';
+
+import type { FC, SVGProps } from 'react';
+
+export type SvgIconComponent = FC<SVGProps<SVGSVGElement>>;
+
+export const SVG_ICONS = {
+  battle: BattleIcon,
+  check: CheckIcon,
+  clock: ClockIcon,
+  close: CloseIcon,
+  copy: CopyIcon,
+  crown: CrownIcon,
+  dev: DevIcon,
+  downArrow: DownArrowIcon,
+  exclamation: ExclamationIcon,
+  eye: EyeIcon,
+  github: GithubIcon,
+  kakao: KakaoIcon,
+  like: LikeIcon,
+  message: MessageIcon,
+  pause: PauseIcon,
+  people: PeopleIcon,
+  peoples: PeoplesIcon,
+  play: PlayIcon,
+  plus: PlusIcon,
+  question: QuestionIcon,
+  scale: ScaleIcon,
+  send: SendIcon,
+  shield: ShieldIcon,
+  skip: SkipIcon,
+  sound: SoundIcon,
+  switch: SwitchIcon,
+  timeline: TimelineIcon,
+  timer: TimerIcon,
+  trophy: TrophyIcon,
+  user: UserIcon,
+  vote: VoteIcon,
+  world: WorldIcon
+} as const satisfies Record<string, SvgIconComponent>;
+
+export const TIER_ICONS = {
+  bronze: BronzePng,
+  silver: SilverPng,
+  gold: GoldPng,
+  diamond: DiamondPng,
+  master: MasterPng,
+  grandmaster: GrandmasterPng
+} as const satisfies Record<string, string>;
+
+export type IconName = keyof typeof SVG_ICONS;
+export type TierName = keyof typeof TIER_ICONS;

--- a/frontend/src/commons/components/Icon/index.tsx
+++ b/frontend/src/commons/components/Icon/index.tsx
@@ -9,10 +9,14 @@ interface IconProps extends SVGProps<SVGSVGElement> {
 
 export default function Icon({ name, alt, ...svgProps }: IconProps) {
   if (name in TIER_ICONS) {
-    return <img src={TIER_ICONS[name as TierName]} className={svgProps.className} alt={alt ?? name} />;
+    return (
+      <img src={TIER_ICONS[name as TierName]} className={svgProps.className} style={svgProps.style} alt={alt ?? name} />
+    );
   }
 
   const SvgIcon = SVG_ICONS[name as IconName];
 
   return <SvgIcon {...svgProps} />;
 }
+
+export type { IconName, TierName };

--- a/frontend/src/commons/components/Icon/index.tsx
+++ b/frontend/src/commons/components/Icon/index.tsx
@@ -1,0 +1,18 @@
+import { SVG_ICONS, TIER_ICONS } from './icons';
+import type { IconName, TierName } from './icons';
+import type { SVGProps } from 'react';
+
+interface IconProps extends SVGProps<SVGSVGElement> {
+  name: IconName | TierName;
+  alt?: string;
+}
+
+export default function Icon({ name, alt, ...svgProps }: IconProps) {
+  if (name in TIER_ICONS) {
+    return <img src={TIER_ICONS[name as TierName]} className={svgProps.className} alt={alt ?? name} />;
+  }
+
+  const SvgIcon = SVG_ICONS[name as IconName];
+
+  return <SvgIcon {...svgProps} />;
+}

--- a/frontend/src/commons/components/UserProfileDropdown.tsx
+++ b/frontend/src/commons/components/UserProfileDropdown.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import UserIcon from '@/assets/icon/user.svg?react';
+import Icon from './Icon';
 import { useLogout } from '@/commons/hooks/useLogout';
 
 interface UserProfileDropdownProps {
@@ -49,7 +49,7 @@ export default function UserProfileDropdown({ user }: UserProfileDropdownProps) 
           {user.avatarUrl ? (
             <img src={user.avatarUrl} alt={user.nickname} className="w-full h-full rounded-full object-cover" />
           ) : (
-            <UserIcon className="w-5 h-5 text-white" />
+            <Icon name="user" className="w-5 h-5 text-white" />
           )}
         </div>
         <span className="text-white text-sm font-medium">{user.nickname}</span>

--- a/frontend/src/commons/components/reference/ReferenceCard.tsx
+++ b/frontend/src/commons/components/reference/ReferenceCard.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import type { ReferenceLink } from '@/commons/types/battle';
 
 interface ReferenceCardProps {
@@ -55,7 +55,7 @@ export default function ReferenceCard({ reference, team, size = 'md' }: Referenc
         className={`${colors.text} font-semibold ${classes.title} hover:underline inline-flex items-center gap-1.5`}
       >
         {reference.title}
-        <ExternalLink className={`${classes.icon} opacity-60 flex-shrink-0`} />
+        <Icon name="externalLink" className={`${classes.icon} opacity-60 flex-shrink-0`} />
       </a>
 
       <p className={`text-gray-300 ${classes.description} leading-relaxed`}>{reference.summary}</p>

--- a/frontend/src/commons/components/reference/TeamReferencesAccordion.tsx
+++ b/frontend/src/commons/components/reference/TeamReferencesAccordion.tsx
@@ -1,4 +1,4 @@
-import { Sparkles, ChevronUp } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import type { ReferenceLink } from '@/commons/types/battle';
 import ReferenceCard from './ReferenceCard';
 
@@ -91,7 +91,7 @@ export default function TeamReferencesAccordion({
           </div>
         </div>
         <div className={`${colors.text} transition-transform duration-200 ${isExpanded ? 'rotate-0' : 'rotate-180'}`}>
-          <ChevronUp className={classes.icon} />
+          <Icon name="chevronUp" className={classes.icon} />
         </div>
       </button>
 
@@ -100,7 +100,7 @@ export default function TeamReferencesAccordion({
           {/* 관점 설명 */}
           <div className={`${colors.bg} ${colors.border} border rounded-lg ${classes.perspectiveContainer}`}>
             <div className="flex items-start gap-2">
-              <Sparkles className={`${classes.perspectiveIcon} ${colors.text} flex-shrink-0 mt-0.5`} />
+              <Icon name="sparkles" className={`${classes.perspectiveIcon} ${colors.text} flex-shrink-0 mt-0.5`} />
               <p className={`text-gray-300 ${classes.perspectiveText}`}>{perspective}</p>
             </div>
           </div>

--- a/frontend/src/commons/components/timeline/RoundCard/ArrowBadge.tsx
+++ b/frontend/src/commons/components/timeline/RoundCard/ArrowBadge.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 
 export default function ArrowBadge() {
   return (
@@ -6,7 +6,7 @@ export default function ArrowBadge() {
       <div className="relative">
         <div className="absolute inset-0 bg-orange-500/20 blur-lg rounded-full" />
         <div className="relative bg-gradient-to-r from-orange-500 to-blue-600 w-12 h-12 rounded-full flex items-center justify-center border-2 border-orange-400/50 shadow-lg">
-          <ArrowRight className="w-5 h-5 text-white font-bold" />
+          <Icon name="arrowRight" className="w-5 h-5 text-white" />
         </div>
       </div>
     </div>

--- a/frontend/src/commons/components/timeline/RoundCard/MessageCard.tsx
+++ b/frontend/src/commons/components/timeline/RoundCard/MessageCard.tsx
@@ -1,4 +1,4 @@
-import { ThumbsUp } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import type { TimelineItem } from '@/pages/battleResultPage/types';
 
 interface MessageCardProps {
@@ -40,7 +40,7 @@ export default function MessageCard({ message, team, formatTime }: MessageCardPr
           isTeamA ? 'bg-blue-600/20 border-blue-500/30' : 'bg-red-600/20 border-red-500/30'
         }`}
       >
-        <ThumbsUp className={`w-4 h-4 ${isTeamA ? 'text-blue-400' : 'text-red-400'}`} />
+        <Icon name="like" className={`w-4 h-4 ${isTeamA ? 'text-blue-400' : 'text-red-400'}`} />
         <span className={`font-bold ${isTeamA ? 'text-blue-300' : 'text-red-300'}`}>{message.upvotes}</span>
       </div>
     </div>

--- a/frontend/src/commons/components/timeline/RoundCard/PhaseHeader.tsx
+++ b/frontend/src/commons/components/timeline/RoundCard/PhaseHeader.tsx
@@ -1,16 +1,16 @@
-import { Zap, Shield, ArrowRight } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 
 export default function PhaseHeader() {
   return (
     <div className="px-6 py-3 bg-gradient-to-r from-orange-900/20 to-blue-900/20 border-b border-[#2d2d3f]">
       <div className="flex items-center justify-center gap-3">
         <div className="flex items-center gap-2">
-          <Zap className="w-4 h-4 text-orange-400" />
+          <Icon name="zap" className="w-4 h-4 text-orange-400" />
           <span className="text-orange-400 font-bold text-xs uppercase tracking-wider">이의제기</span>
         </div>
-        <ArrowRight className="w-5 h-5 text-gray-500" />
+        <Icon name="arrowRight" className="w-5 h-5 text-gray-500" />
         <div className="flex items-center gap-2">
-          <Shield className="w-4 h-4 text-blue-400" />
+          <Icon name="shield" className="w-4 h-4 text-blue-400" />
           <span className="text-blue-400 font-bold text-xs uppercase tracking-wider">반박</span>
         </div>
       </div>

--- a/frontend/src/commons/components/timeline/RoundCard/RoundHeader.tsx
+++ b/frontend/src/commons/components/timeline/RoundCard/RoundHeader.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronUp, Flame } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 
 interface RoundHeaderProps {
   round: string;
@@ -53,7 +53,7 @@ export default function RoundHeader({
 
         {showStatus && isActive && (
           <div className="flex items-center gap-2 text-orange-400">
-            <Flame className="w-5 h-5 animate-pulse" />
+            <Icon name="flame" className="w-5 h-5 animate-pulse" />
             <span className="text-sm font-bold">진행 중</span>
           </div>
         )}
@@ -65,7 +65,7 @@ export default function RoundHeader({
 
       {!isFuture && (
         <div className="text-gray-400">
-          {isExpanded ? <ChevronUp className="w-5 h-5" /> : <ChevronDown className="w-5 h-5" />}
+          {isExpanded ? <Icon name="chevronUp" className="w-5 h-5" /> : <Icon name="chevronDown" className="w-5 h-5" />}
         </div>
       )}
     </button>

--- a/frontend/src/commons/components/toast/ToastItem.tsx
+++ b/frontend/src/commons/components/toast/ToastItem.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import ExclamationIcon from '@/assets/icon/exclamation.svg?react';
+import Icon from '@/commons/components/Icon';
 import type { Toast } from '../../stores/toastStore';
 
 interface ToastItemProps {
@@ -28,7 +28,7 @@ export const ToastItem = ({ toast, onRemove }: ToastItemProps) => {
         isExiting ? 'opacity-0 translate-x-full' : 'opacity-100 translate-x-0'
       }`}
     >
-      <ExclamationIcon className="w-5 h-5 text-white flex-shrink-0 mt-0.5" />
+      <Icon name="exclamation" className="w-5 h-5 text-white flex-shrink-0 mt-0.5" />
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium text-white break-words">{toast.message}</p>
       </div>

--- a/frontend/src/pages/battleCreatePage/components/InviteLinkButton.tsx
+++ b/frontend/src/pages/battleCreatePage/components/InviteLinkButton.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-import CheckIcon from '@/assets/icon/check.svg?react';
-import CopyIcon from '@/assets/icon/copy.svg?react';
+import Icon from '@/commons/components/Icon';
 
 interface InviteLinkProps {
   inviteCode: string;
@@ -29,12 +28,12 @@ export default function InviteLinkButton({ inviteCode }: InviteLinkProps) {
     >
       {copied ? (
         <>
-          <CheckIcon className="w-4 h-4 shrink-0" />
+          <Icon name="check" className="w-4 h-4 shrink-0" />
           <span className="text-sm hidden sm:inline">복사됨</span>
         </>
       ) : (
         <>
-          <CopyIcon className="w-4 h-4 shrink-0" />
+          <Icon name="copy" className="w-4 h-4 shrink-0" />
           <span className="text-sm hidden sm:inline">친구 초대</span>
         </>
       )}

--- a/frontend/src/pages/battlePage/components/chatting/ChatInput.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatInput.tsx
@@ -1,4 +1,4 @@
-import SendIcon from '@/assets/icon/send.svg?react';
+import Icon from '@/commons/components/Icon';
 import { useState } from 'react';
 
 interface ChatInputProps {
@@ -33,7 +33,7 @@ export default function ChatInput({ onSend }: ChatInputProps) {
           className="flex-1 bg-[#2D2D3F] border border-[#3D3D4F] rounded-md px-3 py-2.5 text-xs text-white placeholder-[#666] focus:outline-none focus:border-[#FF6900]"
         />
         <button onClick={handleSend} className="p-2.5 rounded-md bg-[#3D3D4F] hover:bg-[#4D4D5F] transition-colors">
-          <SendIcon />
+          <Icon name="send" />
         </button>
       </div>
     </div>

--- a/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatMessage.tsx
@@ -1,11 +1,7 @@
 import { getTimeAgo } from '@/commons/utils/getTimeAgo';
 import { useAuthStore, selectUser } from '@/commons/stores/authStore';
-import tierBronze from '@/assets/icon/bronze.png';
-import tierSilver from '@/assets/icon/silver.png';
-import tierGold from '@/assets/icon/gold.png';
-import tierDiamond from '@/assets/icon/diamond.png';
-import tierMaster from '@/assets/icon/master.png';
-import tierGrandmaster from '@/assets/icon/grandmaster.png';
+import Icon from '@/commons/components/Icon';
+import type { TierName } from '@/commons/components/Icon';
 
 interface ChatMessageProps {
   user: string;
@@ -35,15 +31,6 @@ const TEAM_LABELS = {
   NONE: '중립'
 };
 
-const TIER_ICON_MAP: Record<string, string> = {
-  BRONZE: tierBronze,
-  SILVER: tierSilver,
-  GOLD: tierGold,
-  DIAMOND: tierDiamond,
-  MASTER: tierMaster,
-  GRANDMASTER: tierGrandmaster
-};
-
 export default function ChatMessage({ user, team, content, timestamp, tier, showTeamBadge = false }: ChatMessageProps) {
   const currentUser = useAuthStore(selectUser);
   const nickNameColor = TEAM_NICKNAME_COLORS[team];
@@ -53,8 +40,8 @@ export default function ChatMessage({ user, team, content, timestamp, tier, show
     <div className={`flex ${isYou ? 'flex-col items-end' : 'flex-col items-start'} mb-3`}>
       <div className="flex items-center gap-2 mb-1">
         <div className="flex items-center gap-1 mb-1">
-          {tier && TIER_ICON_MAP[tier] && (
-            <img src={TIER_ICON_MAP[tier]} alt={`${tier} tier`} className="w-6 h-6 object-contain" />
+          {tier && (
+            <Icon name={tier.toLowerCase() as TierName} alt={`${tier} tier`} className="w-6 h-6 object-contain" />
           )}
           <span className={`text-xs font-medium ${nickNameColor}`}>{user}</span>
           {showTeamBadge && (

--- a/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatSection.tsx
@@ -2,8 +2,7 @@ import ChatInput from './ChatInput';
 import ChatMessage from './ChatMessage';
 import DiscussionMessage from './DiscussionMessage';
 import ChatTabs from './ChatTabs';
-import PeoplesIcons from '@/assets/icon/peoples.svg?react';
-import MessageIcon from '@/assets/icon/message.svg?react';
+import Icon from '@/commons/components/Icon';
 
 import { useState, useMemo } from 'react';
 import { useBattleStore, selectSelectedTeam, selectTeamCounts, selectChatInitialized } from '../../stores/battleStore';
@@ -50,11 +49,11 @@ export default function ChatSection() {
       <div className="px-4 pt-3 pb-2 border-b border-[#2D2D3F]">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
-            <MessageIcon />
+            <Icon name="message" />
             <h3 className="text-sm font-medium text-white">라운지</h3>
           </div>
           <span className="text-xs text-[#99A1AF] flex items-center gap-1">
-            <PeoplesIcons />
+            <Icon name="peoples" />
             {currentMemberCount}
           </span>
         </div>

--- a/frontend/src/pages/battlePage/components/chatting/ChatTabs.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatTabs.tsx
@@ -1,5 +1,4 @@
-import PeopleIcon from '@/assets/icon/peoples.svg?react';
-import WordIcon from '@/assets/icon/world.svg?react';
+import Icon from '@/commons/components/Icon';
 
 interface ChatTabsProps {
   activeTab: 'team' | 'all';
@@ -18,7 +17,7 @@ export default function ChatTabs({ activeTab, onTabChange, team, unreadTeamCount
     return (
       <div className="flex-1 py-3 w-full text-xs font-medium rounded-t-lg bg-[#FF6900] text-white">
         <span className="flex items-center justify-center gap-1">
-          <WordIcon className="w-5 h-5" />
+          <Icon name="world" className="w-5 h-5" />
           <span className="">전체 라운지</span>
           {showAllCount && (
             <span className="min-w-[1.125rem] px-1.5 py-px text-[0.688rem] rounded-full bg-white/20 text-white">
@@ -39,7 +38,7 @@ export default function ChatTabs({ activeTab, onTabChange, team, unreadTeamCount
         }`}
       >
         <span className="flex items-center justify-center gap-1">
-          <PeopleIcon className="w-5 h-5" />
+          <Icon name="peoples" className="w-5 h-5" />
           <span className="">팀 라운지</span>
           {showTeamCount && (
             <span className="min-w-[1.125rem] px-1.5 py-px text-[0.688rem] rounded-full bg-black/30 text-white">
@@ -55,7 +54,7 @@ export default function ChatTabs({ activeTab, onTabChange, team, unreadTeamCount
         }`}
       >
         <span className="flex items-center justify-center gap-1">
-          <WordIcon className="w-5 h-5" />
+          <Icon name="world" className="w-5 h-5" />
           <span className="">전체 라운지</span>
           {showAllCount && (
             <span className="min-w-[1.125rem] px-1.5 py-px text-[0.688rem] rounded-full bg-black/30 text-white">

--- a/frontend/src/pages/battlePage/components/chatting/DiscussionMessage.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/DiscussionMessage.tsx
@@ -1,6 +1,4 @@
-import BattleIcon from '@/assets/icon/battle.svg?react';
-import ShieldIcon from '@/assets/icon/shield.svg?react';
-import VoteIcon from '@/assets/icon/vote.svg?react';
+import Icon from '@/commons/components/Icon';
 
 interface DiscussionMessageProps {
   user: string;
@@ -38,9 +36,9 @@ export default function DiscussionMessage({ user, team, content, type, votes }: 
       <div className="flex items-center gap-2.5">
         <div className={`flex-shrink-0 w-7 h-7 rounded-md flex items-center justify-center ${TEAM_BADGE_BG[team]}`}>
           {type === 'attack' ? (
-            <BattleIcon className="w-4 h-4 text-white" />
+            <Icon name="battle" className="w-4 h-4 text-white" />
           ) : (
-            <ShieldIcon className="w-4 h-4 text-white" />
+            <Icon name="shield" className="w-4 h-4 text-white" />
           )}
         </div>
 
@@ -54,7 +52,7 @@ export default function DiscussionMessage({ user, team, content, type, votes }: 
 
         {typeof votes === 'number' && (
           <div className="flex-shrink-0 flex items-center gap-1.5 bg-orange-500/20 px-2.5 py-1 rounded-md border border-orange-500/30">
-            <VoteIcon className="w-3 h-3 text-orange-400" />
+            <Icon name="vote" className="w-3 h-3 text-orange-400" />
             <span className="text-orange-400 text-sm font-bold">{votes}</span>
           </div>
         )}

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionInput.tsx
@@ -2,8 +2,7 @@ import { useState, useRef } from 'react';
 import { useToastStore, selectAddToast } from '@/commons/stores/toastStore';
 import { getDiscussionConfig } from '../../utils/battlePhase';
 import { useBattleStore, selectBattleProgress } from '../../stores/battleStore';
-import BattleIcon from '@/assets/icon/battle.svg?react';
-import ShieldIcon from '@/assets/icon/shield.svg?react';
+import Icon, { type IconName } from '@/commons/components/Icon';
 
 const MAX_LENGTH = 120;
 
@@ -23,7 +22,7 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
   const round = battleProgress?.round;
   const phase = battleProgress?.phase;
   const config = getDiscussionConfig(phase);
-  const PhaseIcon = phase === 'ATTACK' ? BattleIcon : ShieldIcon;
+  const iconName = (phase === 'ATTACK' ? 'battle' : 'shield') as IconName;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     let newValue = e.target.value;
@@ -79,7 +78,7 @@ export default function DiscussionInput({ onSubmit }: DiscussionInputProps) {
             className={`rounded-xl flex items-center justify-center shrink-0 w-16 h-16 border-2 ${config.colors.iconBox}
     animate-pulse`}
           >
-            <PhaseIcon className={`w-8 h-8 ${config.colors.icon}`} />
+            <Icon name={iconName} className={`w-8 h-8 ${config.colors.icon}`} />
           </div>
 
           <div className="flex-1 flex gap-3">

--- a/frontend/src/pages/battlePage/components/discussion/DiscussionVote.tsx
+++ b/frontend/src/pages/battlePage/components/discussion/DiscussionVote.tsx
@@ -1,4 +1,4 @@
-import ScaleIcon from '@/assets/icon/scale.svg?react';
+import Icon from '@/commons/components/Icon';
 import DiscussionVoteItem from './DiscussionVoteItem';
 import { isMyTeamAttacking } from '../../utils/battlePhase';
 import { useBattleStore, selectDiscussions, selectBattleProgress, selectSelectedTeam } from '../../stores/battleStore';
@@ -46,7 +46,7 @@ export default function DiscussionVote({ onVote }: DiscussionVoteProps) {
     <section className="w-full bg-[#1E1E2F] rounded-lg overflow-hidden">
       <div className="bg-gradient-to-r from-[#59168B] to-[#1C398E] p-4">
         <div className="flex items-center gap-2 mb-2">
-          <ScaleIcon className="w-5 h-5" />
+          <Icon name="scale" className="w-5 h-5" />
           <h3 className="text-sm font-medium text-white">{headerText}</h3>
         </div>
 

--- a/frontend/src/pages/battlePage/components/effects/RoundUpdateModal.tsx
+++ b/frontend/src/pages/battlePage/components/effects/RoundUpdateModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import CrownIcon from '@/assets/icon/crown.svg?react';
+import Icon from '@/commons/components/Icon';
 
 interface RoundUpdateModalProps {
   isOpen: boolean;
@@ -66,7 +66,7 @@ export default function RoundUpdateModal({ isOpen, round, topic, onClose }: Roun
         {/* crown */}
         <div className={`relative flex justify-center mb-6 transition-all duration-500 ${badgeClass}`}>
           <div className="w-24 h-24 rounded-full bg-gradient-to-br from-orange-600 to-red-600 flex items-center justify-center shadow-lg shadow-orange-500/50">
-            <CrownIcon className="w-12 h-12 text-orange-200 bg-orange-200 bg-orange-200/0" />
+            <Icon name="crown" className="w-12 h-12 text-orange-200 bg-orange-200 bg-orange-200/0" />
           </div>
         </div>
 

--- a/frontend/src/pages/battlePage/components/effects/SkipModal.tsx
+++ b/frontend/src/pages/battlePage/components/effects/SkipModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import SkipIcon from '@/assets/icon/skip.svg?react';
+import Icon from '@/commons/components/Icon';
 
 interface SkipModalProps {
   isOpen: boolean;
@@ -64,7 +64,7 @@ export default function SkipModal({ isOpen, onClose }: SkipModalProps) {
             {/* 상단 아이콘 */}
             <div className="relative flex justify-center mb-6">
               <div className="w-24 h-24 rounded-full bg-gradient-to-br from-blue-600 to-cyan-600 flex items-center justify-center shadow-lg shadow-blue-500/50 animate-bounce">
-                <SkipIcon className="w-12 h-12 text-white" />
+                <Icon name="skip" className="w-12 h-12 text-white" />
               </div>
             </div>
 

--- a/frontend/src/pages/battlePage/components/header/PhaseSkip.tsx
+++ b/frontend/src/pages/battlePage/components/header/PhaseSkip.tsx
@@ -1,4 +1,4 @@
-import SkipIcon from '@/assets/icon/skip.svg?react';
+import Icon from '@/commons/components/Icon';
 import type { BattlePhase } from '@/commons/types/battle';
 
 interface PhaseSkipProps {
@@ -16,7 +16,7 @@ export default function PhaseSkip({ phase, isSkipEnabled, toggleSkip, totalSkips
       <div className="mb-1 bg-[#0a0a1a]/40 border border-gray-700 rounded-xl px-4 py-3">
         <div className="flex items-center gap-2 relative group">
           <span className="text-white text-sm font-semibold whitespace-nowrap">이번 페이즈 스킵</span>
-          <SkipIcon className="w-4 h-4 text-cyan-400" />
+          <Icon name="skip" className="w-4 h-4 text-cyan-400" />
 
           <button
             type="button"

--- a/frontend/src/pages/battlePage/components/header/SoundSettingsButton.tsx
+++ b/frontend/src/pages/battlePage/components/header/SoundSettingsButton.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from 'react';
-import SoundIcon from '@/assets/icon/sound.svg?react';
+import Icon from '@/commons/components/Icon';
 import SoundSettingsPopover from './SoundSettingsPopover';
 
 export interface BGMOption {
@@ -24,7 +24,7 @@ export default function SoundSettingsButton({ bgmOptions }: SoundSettingsButtonP
         className="flex items-center justify-center w-11 h-11 rounded-xl bg-[#2D2D3F]/80 hover:bg-[#3D3D4F] text-white transition-all shadow-lg border border-white/10"
         aria-label="사운드 설정"
       >
-        <SoundIcon className="w-6 h-6" />
+        <Icon name="sound" className="w-6 h-6" />
       </button>
       <SoundSettingsPopover
         isOpen={isSoundSettingsOpen}

--- a/frontend/src/pages/battlePage/components/header/SoundSettingsPopover.tsx
+++ b/frontend/src/pages/battlePage/components/header/SoundSettingsPopover.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { soundManager } from '@/commons/utils/soundManager';
-import CloseIcon from '@/assets/icon/close.svg?react';
-import PlayIcon from '@/assets/icon/play.svg?react';
-import PauseIcon from '@/assets/icon/pause.svg?react';
+import Icon from '@/commons/components/Icon';
 import VolumeSlider from './VolumeSlider';
 
 interface BGMOption {
@@ -109,7 +107,7 @@ export default function SoundSettingsPopover({ isOpen, onClose, anchorEl, bgmOpt
           className="absolute right-0 w-7 h-7 flex items-center justify-center rounded-full hover:bg-white/10 text-gray-400 hover:text-white transition-all"
           aria-label="닫기"
         >
-          <CloseIcon className="w-4 h-4" />
+          <Icon name="close" className="w-4 h-4" />
         </button>
       </div>
 
@@ -137,9 +135,9 @@ export default function SoundSettingsPopover({ isOpen, onClose, anchorEl, bgmOpt
               aria-label={isPlaying ? '일시정지' : '재생'}
             >
               {isPlaying ? (
-                <PauseIcon className="w-5 h-5 text-white group-hover:scale-110 transition-transform" />
+                <Icon name="pause" className="w-5 h-5 text-white group-hover:scale-110 transition-transform" />
               ) : (
-                <PlayIcon className="w-5 h-5 text-white ml-0.5 group-hover:scale-110 transition-transform" />
+                <Icon name="play" className="w-5 h-5 text-white ml-0.5 group-hover:scale-110 transition-transform" />
               )}
             </button>
           </div>

--- a/frontend/src/pages/battlePage/components/header/StageIndicator.tsx
+++ b/frontend/src/pages/battlePage/components/header/StageIndicator.tsx
@@ -1,8 +1,4 @@
-import BattleIcon from '@/assets/icon/battle.svg?react';
-import ShieldIcon from '@/assets/icon/shield.svg?react';
-import SwitchIcon from '@/assets/icon/switch.svg?react';
-import TimerIcon from '@/assets/icon/timer.svg?react';
-import MessageIcon from '@/assets/icon/message.svg?react';
+import Icon, { type IconName } from '@/commons/components/Icon';
 import { useBattleStore, selectBattleProgress } from '@/pages/battlePage/stores/battleStore';
 import type { BattleInfo, BattlePhase } from '@/commons/types/battle';
 import { useLoaderData } from 'react-router-dom';
@@ -12,7 +8,7 @@ interface PhaseStyle {
   message: string;
   container: string;
   icon: string;
-  IconComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  iconName: IconName;
 }
 
 const PHASE_CONFIG: Record<BattlePhase, PhaseStyle> = {
@@ -21,36 +17,35 @@ const PHASE_CONFIG: Record<BattlePhase, PhaseStyle> = {
     message: '배틀이 시작되기를 기다리고 있습니다.',
     container: 'bg-[#2B3440] border-[#9CA3AF]',
     icon: 'text-[#E5E7EB] w-7 h-7',
-    IconComponent: TimerIcon
+    iconName: 'timer'
   },
   OPINION_SHARE: {
     category: '의견 공유',
     message: '자유롭게 의견을 공유합니다.',
     container: 'bg-[#2E1F0A] border-[#FFA200]',
     icon: 'text-[#FFA200] w-6 h-6',
-    IconComponent: MessageIcon
+    iconName: 'message'
   },
   ATTACK: {
     category: '이의제기',
     message: '양 진영이 서로의 코드에 대해 공격합니다.',
     container: 'bg-[#3B1414] border-[#E33F12]',
     icon: 'text-[#FF3B30] w-6 h-6',
-    IconComponent: BattleIcon
+    iconName: 'battle'
   },
   DEFENSE: {
     category: '반박',
     message: '상대방의 공격을 방어합니다.',
     container: 'bg-[#0F2A4D] border-[#2B7FFF]',
     icon: 'text-[#4F8CFF] w-7 h-7',
-    IconComponent: ShieldIcon
+    iconName: 'shield'
   },
-
   TEAM_SWITCH: {
     category: '팀 전환',
     message: '자신의 진영을 변경합니다.',
     container: 'bg-[#2B0F3F] border-[#B300FF]',
     icon: 'text-[#C84DFF] w-7 h-7',
-    IconComponent: SwitchIcon
+    iconName: 'switch'
   }
 };
 
@@ -62,7 +57,7 @@ export default function StageIndicator() {
   const topics = battleInfo?.topics || [];
   const { round, phaseCount } = battleProgress;
   const phase = (battleProgress?.phase as BattlePhase) || 'PENDING';
-  const { IconComponent, category, message, container, icon } = PHASE_CONFIG[phase] || PHASE_CONFIG.PENDING;
+  const { iconName, category, message, container, icon } = PHASE_CONFIG[phase] || PHASE_CONFIG.PENDING;
   const phaseName = ['ATTACK', 'DEFENSE'].includes(phase) ? `${phaseCount}차 ${category}` : category;
 
   return (
@@ -70,7 +65,7 @@ export default function StageIndicator() {
       <div
         className={`w-14 h-14 rounded-xl flex items-center justify-center border-2 transition-all duration-300 ${container}`}
       >
-        <IconComponent className={icon} />
+        <Icon name={iconName} className={icon} />
       </div>
 
       <div className="text-left">

--- a/frontend/src/pages/battlePage/components/modals/TeamChangeModal/PhaseFlowCard.tsx
+++ b/frontend/src/pages/battlePage/components/modals/TeamChangeModal/PhaseFlowCard.tsx
@@ -1,4 +1,4 @@
-import { Zap, Shield, ArrowRight } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import TimelineMessage from './TimelineMessage';
 import type { PhaseFlowCardProps } from './types';
 
@@ -30,18 +30,18 @@ export default function PhaseFlowCard({ attackTeam, defenseTeam, attackMessage, 
         <div className="flex items-center justify-center gap-3">
           {/* 공격 팀 */}
           <div className="flex items-center gap-2">
-            <Zap className={`w-4 h-4 ${attackIconColor}`} />
+            <Icon name="zap" className={`w-4 h-4 ${attackIconColor}`} />
             <span className={`${attackTextColor} font-bold text-xs uppercase tracking-wider`}>
               {attackTeam} 이의제기
             </span>
           </div>
 
           {/* 화살표 */}
-          <ArrowRight className="w-4 h-4 text-gray-500" />
+          <Icon name="arrowRight" className="w-4 h-4 text-gray-500" />
 
           {/* 수비 팀 */}
           <div className="flex items-center gap-2">
-            <Shield className={`w-4 h-4 ${defenseIconColor}`} />
+            <Icon name="shield" className={`w-4 h-4 ${defenseIconColor}`} />
             <span className={`${defenseTextColor} font-bold text-xs uppercase tracking-wider`}>{defenseTeam} 반론</span>
           </div>
         </div>

--- a/frontend/src/pages/battlePage/components/modals/TeamChangeModal/VotingSection.tsx
+++ b/frontend/src/pages/battlePage/components/modals/TeamChangeModal/VotingSection.tsx
@@ -1,4 +1,4 @@
-import TimerIcon from '@/assets/icon/timer.svg?react';
+import Icon from '@/commons/components/Icon';
 import type { VotingSectionProps } from './types';
 
 /**
@@ -23,7 +23,7 @@ export default function VotingSection({
     <div className="flex flex-col items-center gap-2 border-t border-[#2d2d3f] pt-4">
       {/* 타이머 */}
       <div className="text-[#FF8904] text-2xl font-bold my-2 flex items-center">
-        <TimerIcon className="w-6 h-6 mr-2" />
+        <Icon name="timer" className="w-6 h-6 mr-2" />
         <span>{remainingTime}</span>
       </div>
 

--- a/frontend/src/pages/battlePage/components/progressBoard/StageIcon.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/StageIcon.tsx
@@ -1,7 +1,5 @@
-import MessageIcon from '@/assets/icon/message.svg?react';
-import BattleIcon from '@/assets/icon/battle.svg?react';
-import ShieldIcon from '@/assets/icon/shield.svg?react';
-import SwitchIcon from '@/assets/icon/switch.svg?react';
+import Icon from '@/commons/components/Icon';
+import type { IconName } from '@/commons/components/Icon';
 
 export function StageIcon({
   icon,
@@ -27,21 +25,6 @@ export function StageIcon({
   const iconClass = `w-5 h-5 transition-all`;
   const iconStyle = active ? { color: text } : { color: '#99A1AF' };
 
-  const renderIcon = () => {
-    switch (icon) {
-      case 'message':
-        return <MessageIcon className={iconClass} style={iconStyle} />;
-      case 'battle':
-        return <BattleIcon className={iconClass} style={iconStyle} />;
-      case 'shield':
-        return <ShieldIcon className={iconClass} style={iconStyle} />;
-      case 'switch':
-        return <SwitchIcon className={iconClass} style={iconStyle} />;
-      default:
-        return null;
-    }
-  };
-
   return (
     <div className="relative flex flex-col items-center gap-1 group">
       <div
@@ -59,7 +42,7 @@ export function StageIcon({
           borderColor: active ? border : '#364153'
         }}
       >
-        {renderIcon()}
+        <Icon name={icon as IconName} className={iconClass} style={iconStyle} />
       </div>
       {tooltip && (
         <div

--- a/frontend/src/pages/battlePage/components/progressBoard/StageList.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/StageList.tsx
@@ -1,5 +1,5 @@
 import { StageIcon } from './StageIcon';
-import DownArrowIcon from '@/assets/icon/downArrow.svg?react';
+import Icon from '@/commons/components/Icon';
 import type { BattlePhase } from '@/commons/types/battle';
 
 const COLOR_MAP = {
@@ -97,7 +97,7 @@ export function StageList({ round, phase, phaseCount }: StageListProps) {
             small={true}
             tooltip={stage.description}
           />
-          {index < STAGES.length - 1 && <DownArrowIcon className="-rotate-90 opacity-40" />}
+          {index < STAGES.length - 1 && <Icon name="downArrow" className="-rotate-90 opacity-40" />}
         </div>
       ))}
     </div>

--- a/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
@@ -1,5 +1,4 @@
-import ClockIcon from '@/assets/icon/clock.svg?react';
-import MessageIcon from '@/assets/icon/message.svg?react';
+import Icon from '@/commons/components/Icon';
 import { BookOpen } from 'lucide-react';
 
 interface BookmarkButtonProps {
@@ -28,7 +27,7 @@ export default function BookmarkButton({
         className="group relative bg-linear-to-r from-[#FF6900] to-[#FF8533] px-3 py-2 rounded-r-md shadow-md hover:shadow-lg transition-all duration-200 hover:translate-x-1 flex items-center gap-1"
         aria-label="문제 설명 보기"
       >
-        <MessageIcon className="w-3.5 h-3.5" />
+        <Icon name="message" className="w-3.5 h-3.5" />
         <span className="text-sm">문제 설명</span>
       </button>
 
@@ -38,7 +37,7 @@ export default function BookmarkButton({
         className="group relative bg-linear-to-r from-[#AD46FF] to-[#6BA3FF] px-3 py-2 rounded-r-md shadow-md hover:shadow-lg transition-all duration-200 hover:translate-x-1 flex items-center gap-1"
         aria-label="타임라인 보기"
       >
-        <ClockIcon className="w-3.5 h-3.5" />
+        <Icon name="clock" className="w-3.5 h-3.5" />
         <span className="text-sm">타임라인</span>
       </button>
 

--- a/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
@@ -1,5 +1,4 @@
 import Icon from '@/commons/components/Icon';
-import { BookOpen } from 'lucide-react';
 
 interface BookmarkButtonProps {
   onOpen: (tab: 'info' | 'timeline' | 'reference') => void;
@@ -48,7 +47,7 @@ export default function BookmarkButton({
           className="group relative bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-700 hover:to-emerald-700 px-3 py-2 rounded-r-md shadow-md hover:shadow-lg transition-all duration-200 hover:translate-x-1 flex items-center gap-1"
           aria-label="참고 자료 보기"
         >
-          <BookOpen className="w-3.5 h-3.5" />
+          <Icon name="bookOpen" className="w-3.5 h-3.5" />
           <span className="text-sm">참고 자료</span>
         </button>
       )}

--- a/frontend/src/pages/battlePage/components/sidebar/ReferenceSection.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/ReferenceSection.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Sparkles, ChevronUp } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import { useState } from 'react';
 import type { BattleReferenceData } from '@/commons/types/battle';
 import { TermCard, TeamReferencesAccordion } from '@/commons/components/reference';
@@ -19,7 +19,7 @@ export default function ReferenceSection({ referenceData }: ReferenceSectionProp
       <div className="p-4 space-y-4">
         {/* 헤더 */}
         <div className="flex items-center gap-2">
-          <BookOpen className="w-5 h-5 text-orange-500" />
+          <Icon name="bookOpen" className="w-5 h-5 text-orange-500" />
           <h2 className="text-white font-bold">AI 참고 자료</h2>
         </div>
 
@@ -31,7 +31,7 @@ export default function ReferenceSection({ referenceData }: ReferenceSectionProp
           >
             <div className="flex items-center gap-2">
               <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-yellow-600 to-orange-600 flex items-center justify-center shadow">
-                <Sparkles className="w-4 h-4 text-white" />
+                <Icon name="sparkles" className="w-4 h-4 text-white" />
               </div>
               <div className="text-left">
                 <h3 className="text-white font-semibold text-sm">핵심 개념</h3>
@@ -41,7 +41,7 @@ export default function ReferenceSection({ referenceData }: ReferenceSectionProp
             <div
               className={`text-yellow-400 transition-transform duration-200 ${expandedConcepts ? 'rotate-0' : 'rotate-180'}`}
             >
-              <ChevronUp className="w-5 h-5" />
+              <Icon name="chevronUp" className="w-5 h-5" />
             </div>
           </button>
 

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarHeader.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarHeader.tsx
@@ -1,6 +1,4 @@
-import MessageIcon from '@/assets/icon/message.svg?react';
-import ClockIcon from '@/assets/icon/clock.svg?react';
-import CloseIcon from '@/assets/icon/close.svg?react';
+import Icon from '@/commons/components/Icon';
 import { BookOpen } from 'lucide-react';
 
 export type SidebarTab = 'info' | 'timeline' | 'reference';
@@ -36,7 +34,7 @@ export default function SidebarHeader({ activeTab, onTabChange, onClose, hasRefe
               activeTab === 'info' ? 'text-white' : 'text-gray-400 hover:text-white'
             }`}
           >
-            <MessageIcon className="w-5 h-5" />
+            <Icon name="message" className="w-5 h-5" />
             문제 설명
           </button>
           <button
@@ -45,7 +43,7 @@ export default function SidebarHeader({ activeTab, onTabChange, onClose, hasRefe
               activeTab === 'timeline' ? 'text-white' : 'text-gray-400 hover:text-white'
             }`}
           >
-            <ClockIcon className="w-5 h-5" />
+            <Icon name="clock" className="w-5 h-5" />
             타임라인
           </button>
           {hasReferenceData && (
@@ -61,7 +59,7 @@ export default function SidebarHeader({ activeTab, onTabChange, onClose, hasRefe
           )}
         </div>
         <button onClick={onClose} className="text-gray-400 hover:text-white transition-colors" aria-label=" 닫기">
-          <CloseIcon className="w-5 h-5 " />
+          <Icon name="close" className="w-5 h-5 " />
         </button>
       </div>
       {/* 활성 탭 밑줄 */}

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarHeader.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarHeader.tsx
@@ -1,5 +1,4 @@
 import Icon from '@/commons/components/Icon';
-import { BookOpen } from 'lucide-react';
 
 export type SidebarTab = 'info' | 'timeline' | 'reference';
 
@@ -53,7 +52,7 @@ export default function SidebarHeader({ activeTab, onTabChange, onClose, hasRefe
                 activeTab === 'reference' ? 'text-white' : 'text-gray-400 hover:text-white'
               }`}
             >
-              <BookOpen className="w-5 h-5" />
+              <Icon name="bookOpen" className="w-5 h-5" />
               참고 자료
             </button>
           )}

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/PhaseCard.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/PhaseCard.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowRight } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import type { BattleDiscussion, BattleDefense } from '@/commons/types/battle';
 import PhaseHeader from './PhaseHeader';
 import MessageCard from './MessageCard';
@@ -46,8 +46,8 @@ export default function PhaseCard({ phase, challengeMessage, rebuttalMessage, is
           <MessageCard message={challengeMessage} team={challengeTeam} type="challenge" />
         </div>
         <div className={`flex items-center justify-center ${isWide ? 'px-2' : 'py-1'} bg-[#0a0a1a]`}>
-          <ArrowDown className={`w-4 h-4 ${isWide ? 'hidden' : ''} ${arrow}`} />
-          <ArrowRight className={`w-4 h-4 ${isWide ? '' : 'hidden'} ${arrow}`} />
+          <Icon name="arrowDown" className={`w-4 h-4 ${isWide ? 'hidden' : ''} ${arrow}`} />
+          <Icon name="arrowRight" className={`w-4 h-4 ${isWide ? '' : 'hidden'} ${arrow}`} />
         </div>
         <div className={`flex-1 ${rebuttal} to-transparent`}>
           <MessageCard message={rebuttalMessage} team={rebuttalTeam} type="rebuttal" />

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/PhaseHeader.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/PhaseHeader.tsx
@@ -1,4 +1,4 @@
-import { Zap, Shield, ArrowRight } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 
 interface PhaseHeaderProps {
   phase: 'attack-A' | 'attack-B';
@@ -10,12 +10,12 @@ export default function PhaseHeader({ phase }: PhaseHeaderProps) {
       <div className="px-2 py-1.5 bg-gradient-to-r from-orange-900/20 to-blue-900/20 border-b border-[#2d2d3f]">
         <div className="flex items-center justify-center gap-2">
           <div className="flex items-center gap-1">
-            <Zap className="w-3 h-3 text-orange-400" />
+            <Icon name="zap" className="w-3 h-3 text-orange-400" />
             <span className="text-blue-400 font-bold text-[0.563rem] uppercase">A팀 이의제기</span>
           </div>
-          <ArrowRight className="w-3 h-3 text-gray-500" />
+          <Icon name="arrowRight" className="w-3 h-3 text-gray-500" />
           <div className="flex items-center gap-1">
-            <Shield className="w-3 h-3 text-blue-400" />
+            <Icon name="shield" className="w-3 h-3 text-blue-400" />
             <span className="text-red-400 font-bold text-[0.563rem] uppercase">B팀 반론</span>
           </div>
         </div>
@@ -27,12 +27,12 @@ export default function PhaseHeader({ phase }: PhaseHeaderProps) {
     <div className="px-2 py-1.5 bg-gradient-to-r from-blue-900/20 to-red-900/20 border-b border-[#2d2d3f]">
       <div className="flex items-center justify-center gap-2">
         <div className="flex items-center gap-1">
-          <Zap className="w-3 h-3 text-red-400" />
+          <Icon name="zap" className="w-3 h-3 text-red-400" />
           <span className="text-red-400 font-bold text-[0.563rem] uppercase">B팀 이의제기</span>
         </div>
-        <ArrowRight className="w-3 h-3 text-gray-500" />
+        <Icon name="arrowRight" className="w-3 h-3 text-gray-500" />
         <div className="flex items-center gap-1">
-          <Shield className="w-3 h-3 text-blue-400" />
+          <Icon name="shield" className="w-3 h-3 text-blue-400" />
           <span className="text-blue-400 font-bold text-[0.563rem] uppercase">A팀 반론</span>
         </div>
       </div>

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/RoundHeader.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarTimelineSection/RoundHeader.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronUp } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 
 interface RoundHeaderProps {
   round: string;
@@ -28,7 +28,7 @@ export default function RoundHeader({ round, topic, isActive, isExpanded, onTogg
         </div>
       </div>
       <div className="text-gray-400">
-        {isExpanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        {isExpanded ? <Icon name="chevronUp" className="w-3 h-3" /> : <Icon name="chevronDown" className="w-3 h-3" />}
       </div>
     </button>
   );

--- a/frontend/src/pages/battleResultPage/components/CodeViewerSection.tsx
+++ b/frontend/src/pages/battleResultPage/components/CodeViewerSection.tsx
@@ -1,5 +1,5 @@
 import CodeViewer from '@/commons/components/CodeViewer';
-import TrophyIcon from '@/assets/icon/trophy.svg?react';
+import Icon from '@/commons/components/Icon';
 
 interface CodeComparisonSectionProps {
   codeA: string;
@@ -20,7 +20,7 @@ export default function CodeViewerSection({ codeA, codeB, language, winner }: Co
           <div className="flex justify-between items-center bg-[#1C398E]/50 px-6 h-[60px] text-[#8EC5FF] text-[16px]">
             <span>{language}</span>
             <span className="flex gap-2 items-center">
-              {winner === 'A' && <TrophyIcon className="w-[20px] h-[20px]" />}
+              {winner === 'A' && <Icon name="trophy" className="w-[20px] h-[20px]" />}
               <span>구현 A</span>
             </span>
           </div>
@@ -30,7 +30,7 @@ export default function CodeViewerSection({ codeA, codeB, language, winner }: Co
           <div className="flex justify-between items-center bg-[#82181A]/50 px-6 h-[60px] text-[#FFA2A2] text-[16px]">
             <span>{language}</span>
             <span className="flex gap-2 items-center">
-              {winner === 'B' && <TrophyIcon className="w-[20px] h-[20px]" />}
+              {winner === 'B' && <Icon name="trophy" className="w-[20px] h-[20px]" />}
               <span>구현 B</span>
             </span>
           </div>

--- a/frontend/src/pages/battleResultPage/components/MetricsCards.tsx
+++ b/frontend/src/pages/battleResultPage/components/MetricsCards.tsx
@@ -1,4 +1,4 @@
-import { Users, Eye, MessageSquare } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 
 interface MetricsCardsProps {
   totalParticipants: number;
@@ -17,7 +17,7 @@ export default function MetricsCards({ totalParticipants, totalViews, strategies
             <div className="text-5xl font-extrabold mb-2">{totalParticipants}</div>
           </div>
           <div className="bg-white/20 p-3 rounded-2xl">
-            <Users size={32} strokeWidth={2} />
+            <Icon name="peoples" className="w-8 h-8" />
           </div>
         </div>
       </div>
@@ -30,7 +30,7 @@ export default function MetricsCards({ totalParticipants, totalViews, strategies
             <div className="text-5xl font-extrabold mb-2">{totalViews.toLocaleString()}</div>
           </div>
           <div className="bg-white/20 p-3 rounded-2xl">
-            <Eye size={32} strokeWidth={2} />
+            <Icon name="eye" className="w-8 h-8" />
           </div>
         </div>
       </div>
@@ -43,7 +43,7 @@ export default function MetricsCards({ totalParticipants, totalViews, strategies
             <div className="text-5xl font-extrabold mb-2">{strategiesCount}</div>
           </div>
           <div className="bg-white/20 p-3 rounded-2xl">
-            <MessageSquare size={32} strokeWidth={2} />
+            <Icon name="message" className="w-8 h-8" />
           </div>
         </div>
       </div>

--- a/frontend/src/pages/battleResultPage/components/MvpCard.tsx
+++ b/frontend/src/pages/battleResultPage/components/MvpCard.tsx
@@ -1,4 +1,4 @@
-import { Crown, Award, ThumbsUp, Medal } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import type { Mvp, TimelineItem } from '../types';
 
 interface MvpCardProps {
@@ -33,7 +33,7 @@ export default function MvpCard({ mvpList, bestOpinion }: MvpCardProps) {
           {/* MVP 아이콘 및 뱃지 */}
           <div className="relative">
             <div className="bg-white/20 backdrop-blur-sm p-5 rounded-2xl border-2 border-white/30">
-              <Crown className="w-12 h-12 text-yellow-300" />
+              <Icon name="crown" className="w-12 h-12 text-yellow-300" />
             </div>
             <div className="absolute -top-2 -right-2 bg-yellow-400 text-orange-900 px-2.5 py-0.5 rounded-full text-xs font-bold border-2 border-white shadow-lg">
               MVP
@@ -64,14 +64,14 @@ export default function MvpCard({ mvpList, bestOpinion }: MvpCardProps) {
             {bestOpinion && (
               <div className="bg-black/20 backdrop-blur-sm rounded-xl p-4 border border-white/20">
                 <div className="flex items-start gap-2 mb-2">
-                  <Award className="w-4 h-4 text-yellow-300 flex-shrink-0 mt-1" />
+                  <Icon name="award" className="w-4 h-4 text-yellow-300 flex-shrink-0 mt-1" />
                   <div className="flex-1 text-left">
                     <div className="text-white/90 text-xs font-medium mb-1">가장 많은 좋아요를 받은 의견</div>
                     <p className="text-white text-sm leading-relaxed break-all">{bestOpinion.content}</p>
                   </div>
                 </div>
                 <div className="flex items-center justify-end gap-2 mt-3 pt-3 border-t border-white/10">
-                  <ThumbsUp className="w-4 h-4 text-yellow-300" />
+                  <Icon name="like" className="w-4 h-4 text-yellow-300" />
                   <span className="text-xl font-bold text-white">{bestOpinion.upvotes}</span>
                   <span className="text-white/80 text-sm">좋아요</span>
                 </div>
@@ -100,7 +100,7 @@ export default function MvpCard({ mvpList, bestOpinion }: MvpCardProps) {
                       className="flex items-center justify-between bg-black/10 rounded-lg px-3 py-2"
                     >
                       <div className="flex items-center gap-2">
-                        <Medal className={`w-4 h-4 ${index === 0 ? 'text-gray-300' : 'text-amber-900'}`} />
+                        <Icon name="medal" className={`w-4 h-4 ${index === 0 ? 'text-gray-300' : 'text-amber-900'}`} />
                         <span className="text-white/80 text-sm">{index + 2}등</span>
                         <span className="text-white font-medium">{runner.nickname}</span>
                       </div>

--- a/frontend/src/pages/battleResultPage/components/WinnerSection.tsx
+++ b/frontend/src/pages/battleResultPage/components/WinnerSection.tsx
@@ -1,4 +1,4 @@
-import TrophyIcon from '@/assets/icon/trophy.svg?react';
+import Icon from '@/commons/components/Icon';
 
 interface WinnerSectionProps {
   winner: 'A' | 'B' | 'DRAW';
@@ -37,7 +37,7 @@ export default function WinnerSection({
     <div className="max-w-7xl mx-auto mb-12">
       <div className={`${style.gradient} rounded-3xl p-8 md:p-12 text-center shadow-2xl ${style.shadow}`}>
         <div className="flex justify-center mb-4">
-          <TrophyIcon className="w-[48px] h-[48px]" />
+          <Icon name="trophy" className="w-[48px] h-[48px]" />
         </div>
         <div className="px-8 py-3 text-lg md:text-xl font-semibold mb-8">🎉 승리 팀: 코드 {winnerTeam}</div>
         <div className="flex items-center justify-center gap-4 md:gap-8 flex-wrap">

--- a/frontend/src/pages/battleResultPage/index.tsx
+++ b/frontend/src/pages/battleResultPage/index.tsx
@@ -7,7 +7,6 @@ import MetricsCards from './components/MetricsCards';
 import CodeViewerSection from './components/CodeViewerSection';
 import TimelineSection from './components/TimelineSection';
 import MvpCard from './components/MvpCard';
-import { Trophy, Activity } from 'lucide-react';
 import { useGetBattleResult } from './hooks/useGetBattleResult';
 
 export default function BattleResultPage() {
@@ -83,14 +82,14 @@ export default function BattleResultPage() {
           onClick={() => navigate('/main')}
           className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-pink-500 to-pink-600 hover:from-pink-600 hover:to-pink-700 rounded-lg font-bold text-white transition-all shadow-lg shadow-pink-500/30"
         >
-          <Trophy className="w-5 h-5" />
+          <Icon name="trophy" className="w-5 h-5" />
           다른 배틀 보기
         </button>
         <button
           onClick={() => navigate('/main')}
           className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 rounded-lg font-bold text-white transition-all shadow-lg shadow-green-500/30"
         >
-          <Activity className="w-5 h-5" />
+          <Icon name="activity" className="w-5 h-5" />
           배틀 다시 시작하기
         </button>
       </div>

--- a/frontend/src/pages/battleResultPage/index.tsx
+++ b/frontend/src/pages/battleResultPage/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import TrophyIcon from '@/assets/icon/trophy.svg?react';
+import Icon from '@/commons/components/Icon';
 import WinnerSection from './components/WinnerSection';
 import VoteChart from './components/VoteChartSector';
 import MetricsCards from './components/MetricsCards';
@@ -35,7 +35,7 @@ export default function BattleResultPage() {
     <div className="min-h-screen text-white p-6 md:p-10">
       <header className="text-center mb-10">
         <div className="flex justify-center items-center gap-2">
-          <TrophyIcon />
+          <Icon name="trophy" />
           <h1 className="text-3xl md:text-4xl font-bold">배틀 결과</h1>
         </div>
         <p className="text-slate-400">배틀 종료! 최종 결과를 확인하세요</p>

--- a/frontend/src/pages/entryPage/components/GameIntroduceSection.tsx
+++ b/frontend/src/pages/entryPage/components/GameIntroduceSection.tsx
@@ -1,6 +1,6 @@
 import Carousel from '@/commons/components/Carousel';
 import OnBoardingIntroduceCard from './OnBoardingIntroduceCard';
-import { ChevronDown } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 
 export default function GameIntroduceSection() {
   const handleScrollDown = () => {
@@ -54,7 +54,7 @@ export default function GameIntroduceSection() {
         onClick={handleScrollDown}
         className="relative z-10 mx-auto cursor-pointer text-white hover:text-orange-400 transition-colors"
       >
-        <ChevronDown size={28} />
+        <Icon name="chevronDown" className="w-7 h-7" />
       </button>
     </section>
   );

--- a/frontend/src/pages/entryPage/components/GameTitleSection.tsx
+++ b/frontend/src/pages/entryPage/components/GameTitleSection.tsx
@@ -1,4 +1,4 @@
-import { Play, ChevronDown } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import { useNavigate } from 'react-router-dom';
 import onBoardingBackgroundImage from '/images/onBoarding/gameLogo.png';
 import onBoardingPeoplesImage1 from '/images/onBoarding/onBoardingPeople1.png';
@@ -44,7 +44,7 @@ export default function GameTitleSection() {
             onClick={() => navigate('/main')}
             className="flex items-center justify-center gap-2 text-xl px-8 py-4 bg-gradient-to-r from-orange-500 to-red-600 border border-orange-300 rounded-xl cursor-pointer shadow-[0_10px_40px_rgba(251,146,60,0.6)]"
           >
-            <Play fill="currentColor" size={20} />
+            <Icon name="play" className="w-5 h-5" />
             <span>입장하기</span>
           </button>
 
@@ -53,7 +53,7 @@ export default function GameTitleSection() {
             className="flex items-center justify-center text-xl gap-2 px-8 py-4 bg-[#1a1b26] border border-gray-600 rounded-xl cursor-pointer shadow-[0_10px_40px_rgba(0,0,0,0.7)]"
           >
             <span>더 알아보기</span>
-            <ChevronDown size={20} />
+            <Icon name="chevronDown" className="w-5 h-5" />
           </button>
         </div>
       </div>

--- a/frontend/src/pages/errorPage/index.tsx
+++ b/frontend/src/pages/errorPage/index.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useRouteError, isRouteErrorResponse } from 'react-router-dom';
-import { AlertTriangle, Home } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import * as Sentry from '@sentry/react';
 import { useEffect } from 'react';
 
@@ -65,7 +65,7 @@ export default function ErrorPage() {
           <div className="relative">
             <div className="absolute inset-0 bg-orange-500/20 blur-2xl rounded-full"></div>
             <div className="relative bg-orange-500/10 p-6 rounded-full border border-orange-500/30">
-              <AlertTriangle className="w-12 h-12 text-orange-500" />
+              <Icon name="alertTriangle" className="w-12 h-12 text-orange-500" />
             </div>
           </div>
         </div>
@@ -95,7 +95,7 @@ export default function ErrorPage() {
             onClick={handleGoHome}
             className="flex items-center gap-2 px-8 py-4 bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 text-white font-bold rounded-lg transition-all duration-300 shadow-lg hover:shadow-orange-500/50"
           >
-            <Home className="w-5 h-5" />
+            <Icon name="home" className="w-5 h-5" />
             홈으로 돌아가기
           </button>
         </div>

--- a/frontend/src/pages/loginPage/index.tsx
+++ b/frontend/src/pages/loginPage/index.tsx
@@ -1,7 +1,4 @@
-import BattleIcon from '@/assets/icon/battle.svg?react';
-import GithubIcon from '@/assets/icon/github.svg?react';
-import KakaoIcon from '@/assets/icon/kakao.svg?react';
-import DevIcon from '@/assets/icon/dev.svg?react';
+import Icon from '@/commons/components/Icon';
 import { loginWithGitHub } from './api/loginWithGithub';
 import { loginWithKakao } from './api/loginWithKakao';
 import { useToastStore, selectAddToast } from '@/commons/stores/toastStore';
@@ -31,7 +28,7 @@ export default function LoginPage() {
         <div className="flex flex-col gap-4 lg:gap-6 items-center relative">
           <div className="absolute top-0 left-1/2 -translate-x-1/2 translate-y-1 w-12 h-12 lg:w-16 lg:h-16 bg-orange-500 rounded-xl blur-xl opacity-70 -z-10"></div>
           <div className="w-12 h-12 lg:w-16 lg:h-16 rounded-xl bg-orange-500 flex items-center justify-center relative z-10">
-            <BattleIcon className="w-8 h-8 lg:w-10 lg:h-10 text-white" />
+            <Icon name="battle" className="w-8 h-8 lg:w-10 lg:h-10 text-white" />
           </div>
           <h1 className="text-white text-4xl lg:text-5xl xl:text-6xl font-extrabold">코문철</h1>
         </div>
@@ -52,7 +49,7 @@ export default function LoginPage() {
             onClick={handleGitHubLogin}
             className="w-full flex items-center justify-center gap-3 px-5 lg:px-6 py-3 lg:py-4 bg-[#24292e] hover:bg-[#2d3339] rounded-xl transition-all duration-200 border border-[#364153] group"
           >
-            <GithubIcon className="w-5 h-5 lg:w-6 lg:h-6 text-white" />
+            <Icon name="github" className="w-5 h-5 lg:w-6 lg:h-6 text-white" />
             <span className="font-medium text-sm lg:text-base xl:text-lg">GitHub로 계속하기</span>
           </button>
 
@@ -66,12 +63,12 @@ export default function LoginPage() {
             onClick={handleKakaoLogin}
             className="w-full flex items-center justify-center gap-3 px-5 lg:px-6 py-3 lg:py-4 bg-[#FEE500] hover:bg-[#FDD835] rounded-xl transition-all duration-200 group"
           >
-            <KakaoIcon className="w-5 h-5 lg:w-6 lg:h-6 text-black" />
+            <Icon name="kakao" className="w-5 h-5 lg:w-6 lg:h-6 text-black" />
             <span className="text-black font-medium text-sm lg:text-base xl:text-lg">카카오로 계속하기</span>
           </button>
 
           <div className="mt-4 lg:mt-6 flex items-start gap-2 text-gray-400 text-xs lg:text-sm">
-            <DevIcon className="w-4 h-4 lg:w-5 lg:h-5 shrink-0 mt-0.5" />
+            <Icon name="dev" className="w-4 h-4 lg:w-5 lg:h-5 shrink-0 mt-0.5" />
             <p className="text-left leading-relaxed">로그인하면 코문철의 모든 기능을 이용할 수 있습니다.</p>
           </div>
         </div>

--- a/frontend/src/pages/mainPage/components/EmptyBattlesState.tsx
+++ b/frontend/src/pages/mainPage/components/EmptyBattlesState.tsx
@@ -1,5 +1,4 @@
-import BattleIcon from '@/assets/icon/battle.svg?react';
-import ClockIcon from '@/assets/icon/clock.svg?react';
+import Icon from '@/commons/components/Icon';
 
 interface EmptyBattlesStateProps {
   type: 'live' | 'past';
@@ -19,9 +18,9 @@ export default function EmptyBattlesState({ type, height = '18rem' }: EmptyBattl
           className={`h-20 w-20 rounded-full bg-gradient-to-br ${isLive ? 'from-orange-500/20 to-orange-600/20' : 'from-gray-500/20 to-gray-600/20'} flex items-center justify-center`}
         >
           {isLive ? (
-            <BattleIcon className="w-10 h-10 text-orange-500" />
+            <Icon name="battle" className="w-10 h-10 text-orange-500" />
           ) : (
-            <ClockIcon className="w-10 h-10 text-gray-500" />
+            <Icon name="clock" className="w-10 h-10 text-gray-500" />
           )}
         </div>
         {isLive && <div className="absolute inset-0 h-20 w-20 rounded-full bg-orange-500/30 animate-ping"></div>}

--- a/frontend/src/pages/mainPage/components/StatCard.tsx
+++ b/frontend/src/pages/mainPage/components/StatCard.tsx
@@ -1,4 +1,5 @@
 import { STAT_CONFIG, type StatType } from '../types/stat';
+import Icon from '@/commons/components/Icon';
 import IconBox from './IconBox';
 
 interface Props {
@@ -7,7 +8,7 @@ interface Props {
 }
 
 export default function StatCard({ type, value }: Props) {
-  const { label, text, bg, bgSoft, icon: Icon } = STAT_CONFIG[type];
+  const { label, text, bg, bgSoft, icon: iconName } = STAT_CONFIG[type];
 
   return (
     <div className="w-full rounded-2xl bg-[#1A1A2E] overflow-hidden">
@@ -15,7 +16,7 @@ export default function StatCard({ type, value }: Props) {
 
       <div className="flex items-center gap-4 p-6">
         <IconBox className={bgSoft}>
-          <Icon className={`w-6 h-6 ${text}`} />
+          <Icon name={iconName} className={`w-6 h-6 ${text}`} />
         </IconBox>
 
         <div className="flex flex-col text-left">

--- a/frontend/src/pages/mainPage/components/liveBattles/LiveBattleCard.tsx
+++ b/frontend/src/pages/mainPage/components/liveBattles/LiveBattleCard.tsx
@@ -1,7 +1,6 @@
 import { Link } from 'react-router-dom';
 import { type BattleCardItem, BATTLE_CATEGORY_CONFIG } from '../../types/battle';
-import PeopleIcon from '@/assets/icon/people.svg?react';
-import ClockIcon from '@/assets/icon/clock.svg?react';
+import Icon from '@/commons/components/Icon';
 import IconBox from '../IconBox';
 import Badge from '@/commons/components/Badge';
 
@@ -13,7 +12,7 @@ interface LiveBattleCardProps {
 export default function LiveBattleCard({ battleInform, isHot = false }: LiveBattleCardProps) {
   const { category, title, description, timeLabel, clientCount, id, status } = battleInform;
   const config = BATTLE_CATEGORY_CONFIG[category] || BATTLE_CATEGORY_CONFIG.ETC;
-  const { text, bg, bgSoft, icon: Icon } = config;
+  const { text, bg, bgSoft, icon: iconName } = config;
   return (
     <div className="w-full rounded-2xl bg-[#1A1A2E] overflow-hidden min-w-0">
       <div className={`h-1 w-full ${bg}`} />
@@ -22,7 +21,7 @@ export default function LiveBattleCard({ battleInform, isHot = false }: LiveBatt
         <div className="flex items-start justify-between min-w-0">
           <div className="flex items-center gap-3 min-w-0">
             <IconBox className={bgSoft}>
-              <Icon className={`w-6 h-6 ${text}`} />
+              <Icon name={iconName} className={`w-6 h-6 ${text}`} />
             </IconBox>
 
             <div className="flex flex-col text-left min-w-0">
@@ -48,11 +47,11 @@ export default function LiveBattleCard({ battleInform, isHot = false }: LiveBatt
         <div className="mt-auto flex items-center justify-between min-w-0">
           <div className="flex items-center gap-3 text-gray-400 text-sm">
             <div className="flex items-center gap-1">
-              <PeopleIcon className="w-4 h-4" />
+              <Icon name="people" className="w-4 h-4" />
               <span>{clientCount}</span>
             </div>
             <div className="flex items-center gap-1">
-              <ClockIcon className="w-4 h-4" />
+              <Icon name="clock" className="w-4 h-4" />
               <span>{timeLabel}</span>
             </div>
           </div>

--- a/frontend/src/pages/mainPage/components/pastBattles/PastBattleCard.tsx
+++ b/frontend/src/pages/mainPage/components/pastBattles/PastBattleCard.tsx
@@ -2,8 +2,7 @@ import { Link } from 'react-router-dom';
 import type { ClosedBattleItem } from '../../types/battle';
 import { TEAM_STYLE } from '../../types/team';
 import IconBox from '../IconBox';
-import ClockIcon from '@/assets/icon/clock.svg?react';
-import TrophyIcon from '@/assets/icon/trophy.svg?react';
+import Icon from '@/commons/components/Icon';
 import Badge from '@/commons/components/Badge';
 
 export default function PastBattleCard({ item }: { item: ClosedBattleItem }) {
@@ -18,7 +17,7 @@ export default function PastBattleCard({ item }: { item: ClosedBattleItem }) {
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-3">
             <IconBox className={teamStyle.bgSoft}>
-              <TrophyIcon className={`w-5 h-5 ${teamStyle.text}`} />
+              <Icon name="trophy" className={`w-5 h-5 ${teamStyle.text}`} />
             </IconBox>
 
             <div className="flex flex-col text-left">
@@ -46,7 +45,7 @@ export default function PastBattleCard({ item }: { item: ClosedBattleItem }) {
 
         <div className="mt-1 flex items-center justify-between text-gray-400 text-sm">
           <div className="flex items-center gap-1">
-            <ClockIcon className="w-4 h-4" />
+            <Icon name="clock" className="w-4 h-4" />
             <span>종료됨</span>
           </div>
 

--- a/frontend/src/pages/mainPage/index.tsx
+++ b/frontend/src/pages/mainPage/index.tsx
@@ -3,7 +3,7 @@ import BattleCategoryCard from '@/pages/mainPage/components/BattleCategoryCard';
 import LiveBattlesSection from './components/liveBattles/LiveBattlesSection';
 import PastBattlesSection from './components/pastBattles/PastBattlesSection';
 import { BATTLE_CATEGORY_CONFIG } from '@/pages/mainPage/types/battle';
-import BattleIcon from '@/assets/icon/battle.svg?react';
+import Icon from '@/commons/components/Icon';
 import Header from '@/commons/components/Header';
 import { useAuthStore, selectUser } from '@/commons/stores/authStore';
 import { useToastStore, selectAddToast } from '@/commons/stores/toastStore';
@@ -45,7 +45,7 @@ export default function MainPage() {
                 className="flex items-center rounded-xl px-5 py-3  bg-orange-500 shadow-[0_4px_6px_-4px_rgba(255,105,0,0.3),0_10px_15px_-3px_rgba(255,105,0,0.3)] hover:shadow-[0_0_25px_rgba(255,105,0,0.7)] transition-all duration-200"
               >
                 <div className="flex items-center gap-1 ">
-                  <BattleIcon className="w-5 h-5 text-white" />
+                  <Icon name="battle" className="w-5 h-5 text-white" />
                   <p> 새 배틀 생성</p>
                 </div>
               </button>

--- a/frontend/src/pages/mainPage/types/battle.ts
+++ b/frontend/src/pages/mainPage/types/battle.ts
@@ -1,11 +1,9 @@
+import type { IconName } from '@/commons/components/Icon';
+
 export type BattleCategory = 'ALGORITHM' | 'REFACTORING' | 'IMPLEMENTATION' | 'ETC';
 
 export type BattleStatus = 'OPEN' | 'CLOSED' | 'PENDING';
 export type WinnerTeam = 'A' | 'B' | 'DRAW';
-
-import TrophyIcon from '@/assets/icon/trophy.svg?react';
-import CrownIcon from '@/assets/icon/crown.svg?react';
-import BattleIcon from '@/assets/icon/battle.svg?react';
 
 export const BATTLE_CATEGORY_CONFIG: Record<
   BattleCategory,
@@ -13,10 +11,10 @@ export const BATTLE_CATEGORY_CONFIG: Record<
     key: BattleCategory;
     title: string;
     description: string;
-    text: string; // 아이콘 / 텍스트 컬러
-    bg: string; // 상단 바 / 강조 컬러
-    bgSoft: string; // IconBox 배경
-    icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+    text: string;
+    bg: string;
+    bgSoft: string;
+    icon: IconName;
   }
 > = {
   ALGORITHM: {
@@ -26,7 +24,7 @@ export const BATTLE_CATEGORY_CONFIG: Record<
     text: 'text-yellow-400',
     bg: 'bg-yellow-400',
     bgSoft: 'bg-yellow-400/15',
-    icon: TrophyIcon
+    icon: 'trophy'
   },
 
   REFACTORING: {
@@ -36,7 +34,7 @@ export const BATTLE_CATEGORY_CONFIG: Record<
     text: 'text-emerald-400',
     bg: 'bg-emerald-400',
     bgSoft: 'bg-emerald-400/15',
-    icon: BattleIcon
+    icon: 'battle'
   },
 
   IMPLEMENTATION: {
@@ -46,7 +44,7 @@ export const BATTLE_CATEGORY_CONFIG: Record<
     text: 'text-orange-400',
     bg: 'bg-orange-400',
     bgSoft: 'bg-orange-400/15',
-    icon: CrownIcon
+    icon: 'crown'
   },
 
   ETC: {
@@ -56,7 +54,7 @@ export const BATTLE_CATEGORY_CONFIG: Record<
     text: 'text-gray-400',
     bg: 'bg-gray-400',
     bgSoft: 'bg-gray-400/15',
-    icon: BattleIcon
+    icon: 'battle'
   }
 };
 

--- a/frontend/src/pages/mainPage/types/stat.ts
+++ b/frontend/src/pages/mainPage/types/stat.ts
@@ -1,6 +1,4 @@
-import TimeLineIcon from '@/assets/icon/timeline.svg?react';
-import PlusIcon from '@/assets/icon/plus.svg?react';
-import BattleIcon from '@/assets/icon/battle.svg?react';
+import type { IconName } from '@/commons/components/Icon';
 
 export type StatType = 'TOTAL_BATTLES' | 'LIVE_BATTLES' | 'TOTAL_USERS';
 
@@ -11,7 +9,7 @@ export const STAT_CONFIG: Record<
     text: string;
     bg: string;
     bgSoft: string;
-    icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+    icon: IconName;
   }
 > = {
   TOTAL_BATTLES: {
@@ -19,7 +17,7 @@ export const STAT_CONFIG: Record<
     text: 'text-orange-400',
     bg: 'bg-orange-400',
     bgSoft: 'bg-orange-400/15',
-    icon: TimeLineIcon
+    icon: 'timeline'
   },
 
   LIVE_BATTLES: {
@@ -27,7 +25,7 @@ export const STAT_CONFIG: Record<
     text: 'text-yellow-400',
     bg: 'bg-yellow-400',
     bgSoft: 'bg-yellow-400/15',
-    icon: PlusIcon
+    icon: 'plus'
   },
 
   TOTAL_USERS: {
@@ -35,6 +33,6 @@ export const STAT_CONFIG: Record<
     text: 'text-emerald-400',
     bg: 'bg-emerald-400',
     bgSoft: 'bg-emerald-400/15',
-    icon: BattleIcon
+    icon: 'battle'
   }
 };

--- a/frontend/src/pages/nicknamePage/index.tsx
+++ b/frontend/src/pages/nicknamePage/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import UserIcon from '@/assets/icon/user.svg?react';
+import Icon from '@/commons/components/Icon';
 import { useUpdateNickname } from './queries/useUpdateNickname';
 
 export default function NicknamePage() {
@@ -33,7 +33,7 @@ export default function NicknamePage() {
           <div className="absolute top-0 left-1/2 -translate-x-1/2 translate-y-1 w-12 h-12 lg:w-16 lg:h-16 bg-orange-500 rounded-xl blur-xl opacity-70 -z-10"></div>
           {/* 오렌지 배경 아이콘 */}
           <div className="w-12 h-12 lg:w-16 lg:h-16 rounded-xl bg-orange-500 flex items-center justify-center relative z-10">
-            <UserIcon className="w-8 h-8 lg:w-10 lg:h-10 text-white" />
+            <Icon name="user" className="w-8 h-8 lg:w-10 lg:h-10 text-white" />
           </div>
           <h1 className="text-white text-4xl lg:text-5xl xl:text-6xl font-extrabold">코문철</h1>
         </div>

--- a/frontend/src/pages/teamSelectPage/components/TeamCard.tsx
+++ b/frontend/src/pages/teamSelectPage/components/TeamCard.tsx
@@ -1,6 +1,6 @@
 import type { Team } from '@/commons/types/battle';
-import Sheild from '@/assets/icon/shield.svg?react';
-import Scale from '@/assets/icon/scale.svg?react';
+import Icon from '@/commons/components/Icon';
+import type { IconName } from '@/commons/components/Icon';
 
 interface TeamCardProps {
   team: Team;
@@ -30,7 +30,7 @@ const TEAM_STYLES = {
 
 export default function TeamCard({ team, label, description, isSelected, onClick }: TeamCardProps) {
   const styles = TEAM_STYLES[team];
-  const Icon = team === 'NONE' ? Scale : Sheild;
+  const iconName = (team === 'NONE' ? 'scale' : 'shield') as IconName;
 
   const getBorderClass = () => {
     return isSelected ? styles.button : 'border-[#2D2D3F]';
@@ -55,7 +55,7 @@ export default function TeamCard({ team, label, description, isSelected, onClick
     >
       {/* 아이콘 */}
       <div className={`team-card-icon-size rounded-full ${styles.icon} flex items-center justify-center`}>
-        <Icon className="team-card-icon-inner-size text-white" />
+        <Icon name={iconName} className="team-card-icon-inner-size text-white" />
       </div>
 
       {/* 라벨 */}

--- a/frontend/src/pages/teamSelectPage/components/TimelineItem.tsx
+++ b/frontend/src/pages/teamSelectPage/components/TimelineItem.tsx
@@ -1,7 +1,5 @@
 import type { TimelineItem as TimelineItemType } from '../types/teamSelect';
-import Like from '@/assets/icon/like.svg?react';
-import BattleIcon from '@/assets/icon/battle.svg?react';
-import ShieldIcon from '@/assets/icon/shield.svg?react';
+import Icon from '@/commons/components/Icon';
 
 interface TimelineItemProps extends TimelineItemType {
   allTimelines: TimelineItemType[];
@@ -71,9 +69,9 @@ export default function TimelineItem({
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-2">
           {type === 'ATTACK' ? (
-            <BattleIcon className={`w-5 h-5 ${typeStyle.icon}`} />
+            <Icon name="battle" className={`w-5 h-5 ${typeStyle.icon}`} />
           ) : (
-            <ShieldIcon className={`w-5 h-5 ${typeStyle.icon}`} />
+            <Icon name="shield" className={`w-5 h-5 ${typeStyle.icon}`} />
           )}
           <span className={`font-semibold ${typeStyle.icon}`}>{typeStyle.label}</span>
           <span className="text-white font-medium">{author}</span>
@@ -86,7 +84,7 @@ export default function TimelineItem({
       {relatedAttack && (
         <div className="mb-3 pl-4 border-l-2 border-[#4CAF50] bg-[#1E3A1E]/30 py-2 px-3 rounded">
           <div className="flex items-center gap-2 mb-1">
-            <BattleIcon className="w-4 h-4 text-[#4CAF50]" />
+            <Icon name="battle" className="w-4 h-4 text-[#4CAF50]" />
             <span className="text-[#4CAF50] text-xs font-semibold">이의제기</span>
             <span className="text-[#99A1AF] text-xs">by {relatedAttack.author}</span>
           </div>
@@ -99,7 +97,7 @@ export default function TimelineItem({
 
       {/* 좋아요 */}
       <div className="flex items-center gap-1">
-        <Like className="w-4 h-4 text-[#99A1AF]" />
+        <Icon name="like" className="w-4 h-4 text-[#99A1AF]" />
         <span className="text-[#99A1AF] text-xs">{upvotes}</span>
       </div>
     </div>

--- a/frontend/src/pages/teamSelectPage/components/steps/Step1BattleInfo.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/Step1BattleInfo.tsx
@@ -1,4 +1,5 @@
-import { TrendingUp, Swords, Users, Target, Clock, MessageSquare, Shield, Shuffle } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
+import type { IconName } from '@/commons/components/Icon';
 import type { BattlePhase } from '@/commons/types/battle';
 
 interface Step1BattleInfoProps {
@@ -15,43 +16,46 @@ interface Step1BattleInfoProps {
 }
 
 // Phase별 한글 레이블, 색상, 아이콘 매핑
-const PHASE_CONFIG = {
+const PHASE_CONFIG: Record<
+  BattlePhase,
+  { label: string; color: string; bgColor: string; borderColor: string; icon: IconName }
+> = {
   PENDING: {
     label: '대기 중',
     color: 'text-gray-400',
     bgColor: 'bg-gray-500/20',
     borderColor: 'border-gray-500/50',
-    icon: Clock
+    icon: 'clock'
   },
   OPINION_SHARE: {
     label: '의견 공유',
     color: 'text-green-400',
     bgColor: 'bg-green-500/20',
     borderColor: 'border-green-500/50',
-    icon: MessageSquare
+    icon: 'message'
   },
   ATTACK: {
     label: '이의제기',
     color: 'text-pink-400',
     bgColor: 'bg-pink-500/20',
     borderColor: 'border-pink-500/50',
-    icon: Swords
+    icon: 'battle'
   },
   DEFENSE: {
     label: '반박',
     color: 'text-purple-400',
     bgColor: 'bg-purple-500/20',
     borderColor: 'border-purple-500/50',
-    icon: Shield
+    icon: 'shield'
   },
   TEAM_SWITCH: {
     label: '진영 변경',
     color: 'text-yellow-400',
     bgColor: 'bg-yellow-500/20',
     borderColor: 'border-yellow-500/50',
-    icon: Shuffle
+    icon: 'shuffle'
   }
-} as const;
+};
 
 export default function Step1BattleInfo({
   title,
@@ -66,12 +70,11 @@ export default function Step1BattleInfo({
   phaseCount
 }: Step1BattleInfoProps) {
   const phaseConfig = currentPhase ? PHASE_CONFIG[currentPhase] : null;
-  const PhaseIcon = phaseConfig?.icon;
   return (
     <div className="flex flex-col items-center gap-4 w-full max-w-6xl mx-auto px-4">
       {/* 상단 섹션 */}
       <div className="text-center mb-4">
-        <TrendingUp className="battle-info-icon-size text-orange-500 mx-auto mb-2" />
+        <Icon name="trendingUp" className="battle-info-icon-size text-orange-500 mx-auto mb-2" />
         <h2 className="battle-info-title-size font-bold text-white mb-1">상황 요약</h2>
         <p className="battle-info-desc-size text-gray-400">현재 배틀 진행 현황을 확인하세요</p>
       </div>
@@ -81,7 +84,7 @@ export default function Step1BattleInfo({
         {/* 배틀 정보 카드 */}
         <div className="bg-[#16162a] rounded-lg battle-info-card-padding border border-[#2d2d3f] mb-4 shadow-lg w-full">
           <div className="flex items-center gap-2 mb-3">
-            <Swords className="battle-info-swords-size text-orange-500 flex-shrink-0" />
+            <Icon name="battle" className="battle-info-swords-size text-orange-500 flex-shrink-0" />
             <h3 className="text-white battle-info-title-size font-bold break-words min-w-0 text-left">{title}</h3>
           </div>
           <p className="text-gray-400 battle-info-desc-size mb-4 text-left break-words">{description}</p>
@@ -107,7 +110,7 @@ export default function Step1BattleInfo({
           <div className="bg-gradient-to-br from-orange-900/30 to-orange-800/10 rounded-lg battle-info-card-padding border border-orange-500/30 shadow-lg hover:shadow-orange-500/20 transition-all duration-300">
             <div className="flex items-center gap-3 mb-4">
               <div className="battle-info-stat-icon-size bg-orange-500/20 rounded-lg flex items-center justify-center border border-orange-500/40">
-                <Users className="battle-info-users-size text-orange-400" />
+                <Icon name="peoples" className="battle-info-users-size text-orange-400" />
               </div>
               <div>
                 <div className="text-orange-300/70 font-medium text-xs mb-1">총 참여자</div>
@@ -124,7 +127,7 @@ export default function Step1BattleInfo({
           <div className="bg-gradient-to-br from-blue-900/30 to-blue-800/10 rounded-lg battle-info-card-padding border border-blue-500/30 shadow-lg hover:shadow-blue-500/20 transition-all duration-300">
             <div className="flex items-center gap-3 mb-3">
               <div className="w-11 h-11 rounded-full bg-blue-600 flex items-center justify-center shadow-lg">
-                <Target className="battle-info-target-size text-white" />
+                <Icon name="target" className="battle-info-target-size text-white" />
               </div>
               <div className="flex-1">
                 <p className="text-gray-400 text-xs mb-1 text-left">진행 단계</p>
@@ -140,12 +143,12 @@ export default function Step1BattleInfo({
                     </div>
                   )}
 
-                  {phaseConfig && PhaseIcon && (
+                  {phaseConfig && (
                     <div className="flex items-center gap-2 flex-wrap">
                       <div
                         className={`px-3 py-1 ${phaseConfig.bgColor} border ${phaseConfig.borderColor} rounded-lg flex items-center gap-1.5`}
                       >
-                        <PhaseIcon className={`w-4 h-4 ${phaseConfig.color}`} />
+                        <Icon name={phaseConfig.icon} className={`w-4 h-4 ${phaseConfig.color}`} />
                         <span className={`${phaseConfig.color} text-sm font-bold`}>
                           {phaseConfig.label}
                           {(currentPhase === 'ATTACK' || currentPhase === 'DEFENSE') && phaseCount && (

--- a/frontend/src/pages/teamSelectPage/components/steps/Step2CodeCompare.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/Step2CodeCompare.tsx
@@ -1,4 +1,4 @@
-import { Code2 } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import CodeCarousel from '../CodeCarousel';
 
 interface Step2CodeCompareProps {
@@ -11,7 +11,7 @@ export default function Step2CodeCompare({ aCode, bCode, language }: Step2CodeCo
   return (
     <div className="flex flex-col items-center gap-4 w-full max-w-6xl mx-auto px-4">
       <div className="text-center mb-4">
-        <Code2 className="code-compare-icon-size text-orange-500 mx-auto mb-2" />
+        <Icon name="code2" className="code-compare-icon-size text-orange-500 mx-auto mb-2" />
         <h2 className="code-compare-title-size font-bold text-white mb-1">쟁점</h2>
         <p className="code-compare-desc-size text-gray-400">두 구현의 코드를 비교하고 분석하세요</p>
       </div>

--- a/frontend/src/pages/teamSelectPage/components/steps/Step3ReferenceData.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/Step3ReferenceData.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Sparkles, ChevronUp } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import { useState } from 'react';
 import type { BattleReferenceData } from '@/commons/types/battle';
 import { TermCard, TeamReferencesAccordion } from '@/commons/components/reference';
@@ -17,7 +17,7 @@ export default function ReferenceData({ referenceData }: ReferenceDataProps) {
   return (
     <div className="flex flex-col items-center gap-4 w-full max-w-6xl mx-auto px-4">
       <div className="text-center mb-4">
-        <BookOpen className="w-10 h-10 xl:w-12 xl:h-12 text-orange-500 mx-auto mb-2" />
+        <Icon name="bookOpen" className="w-10 h-10 xl:w-12 xl:h-12 text-orange-500 mx-auto mb-2" />
         <h2 className="text-xl xl:text-2xl font-bold text-white mb-1">참고 자료</h2>
         <p className="text-sm xl:text-base text-gray-400">AI가 선별한 배틀 관련 참고 자료를 확인하세요</p>
       </div>
@@ -31,7 +31,7 @@ export default function ReferenceData({ referenceData }: ReferenceDataProps) {
           >
             <div className="flex items-center gap-3">
               <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-yellow-600 to-orange-600 flex items-center justify-center shadow-lg">
-                <Sparkles className="w-5 h-5 text-white" />
+                <Icon name="sparkles" className="w-5 h-5 text-white" />
               </div>
               <div className="text-left">
                 <h3 className="text-white font-semibold text-lg">핵심 개념</h3>
@@ -41,7 +41,7 @@ export default function ReferenceData({ referenceData }: ReferenceDataProps) {
             <div
               className={`text-yellow-400 transition-transform duration-200 ${expandedConcepts ? 'rotate-0' : 'rotate-180'}`}
             >
-              <ChevronUp className="w-6 h-6" />
+              <Icon name="chevronUp" className="w-6 h-6" />
             </div>
           </button>
 

--- a/frontend/src/pages/teamSelectPage/components/steps/Step4Timeline.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/Step4Timeline.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { ChevronDown, ChevronUp, ThumbsUp, Zap, Shield, Flame, ArrowRight, Clock } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import type { BattleDiscussion, BattleDefense } from '@/commons/types/battle';
 
 interface Step3TimelineProps {
@@ -164,7 +164,7 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
             isTeamA ? 'bg-blue-600/20 border-blue-500/30' : 'bg-red-600/20 border-red-500/30'
           }`}
         >
-          <ThumbsUp className={`w-4 h-4 ${isTeamA ? 'text-blue-400' : 'text-red-400'}`} />
+          <Icon name="like" className={`w-4 h-4 ${isTeamA ? 'text-blue-400' : 'text-red-400'}`} />
           <span className={`font-bold ${isTeamA ? 'text-blue-300' : 'text-red-300'}`}>{message.upvotes}</span>
         </div>
       </div>
@@ -175,7 +175,7 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
     <div className="flex flex-col items-center gap-8 w-full max-w-6xl mx-auto">
       {/* 상단 섹션 */}
       <div className="text-center mb-8">
-        <Clock className="w-16 h-16 text-orange-500 mx-auto mb-4" />
+        <Icon name="clock" className="w-16 h-16 text-orange-500 mx-auto mb-4" />
         <h2 className="text-2xl font-bold text-white mb-2">타임라인</h2>
         <p className="text-gray-400">양측의 이의제기와 반박을 확인해보세요</p>
       </div>
@@ -185,7 +185,7 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
         {timelines.length === 0 ? (
           <div className="bg-[#1e1e2f] rounded-xl border border-[#2d2d3f] p-8">
             <div className="text-center text-gray-400">
-              <Flame className="w-12 h-12 mx-auto mb-3 text-gray-600" />
+              <Icon name="flame" className="w-12 h-12 mx-auto mb-3 text-gray-600" />
               <p className="text-lg font-medium mb-1">아직 이의제기가 없습니다</p>
               <p className="text-sm">배틀이 시작되면 여기에 표시됩니다</p>
             </div>
@@ -249,7 +249,7 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
                       {/* Status Indicator */}
                       {roundData.isActive && (
                         <div className="flex items-center gap-2 text-orange-400">
-                          <Flame className="w-5 h-5 animate-pulse" />
+                          <Icon name="flame" className="w-5 h-5 animate-pulse" />
                           <span className="text-sm font-bold">진행 중</span>
                         </div>
                       )}
@@ -264,7 +264,11 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
                     {/* Expand Icon */}
                     {!roundData.isFuture && (
                       <div className="text-gray-400">
-                        {isExpanded ? <ChevronUp className="w-5 h-5" /> : <ChevronDown className="w-5 h-5" />}
+                        {isExpanded ? (
+                          <Icon name="chevronUp" className="w-5 h-5" />
+                        ) : (
+                          <Icon name="chevronDown" className="w-5 h-5" />
+                        )}
                       </div>
                     )}
                   </button>
@@ -277,14 +281,14 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
                         <div className="px-6 py-3 bg-gradient-to-r from-orange-900/20 to-blue-900/20 border-b border-[#2d2d3f]">
                           <div className="flex items-center justify-center gap-3">
                             <div className="flex items-center gap-2">
-                              <Zap className="w-4 h-4 text-orange-400" />
+                              <Icon name="zap" className="w-4 h-4 text-orange-400" />
                               <span className="text-orange-400 font-bold text-xs uppercase tracking-wider">
                                 A 이의제기 (1차)
                               </span>
                             </div>
-                            <ArrowRight className="w-5 h-5 text-gray-500" />
+                            <Icon name="arrowRight" className="w-5 h-5 text-gray-500" />
                             <div className="flex items-center gap-2">
-                              <Shield className="w-4 h-4 text-blue-400" />
+                              <Icon name="shield" className="w-4 h-4 text-blue-400" />
                               <span className="text-blue-400 font-bold text-xs uppercase tracking-wider">B 반론</span>
                             </div>
                           </div>
@@ -297,7 +301,7 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
                             <div className="relative">
                               <div className="absolute inset-0 bg-orange-500/20 blur-lg rounded-full" />
                               <div className="relative bg-gradient-to-r from-orange-500 to-blue-600 w-12 h-12 rounded-full flex items-center justify-center border-2 border-orange-400/50 shadow-lg">
-                                <ArrowRight className="w-5 h-5 text-white font-bold" />
+                                <Icon name="arrowRight" className="w-5 h-5 text-white" />
                               </div>
                             </div>
                           </div>
@@ -312,14 +316,14 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
                         <div className="px-6 py-3 bg-gradient-to-r from-red-900/20 to-blue-900/20 border-b border-[#2d2d3f]">
                           <div className="flex items-center justify-center gap-3">
                             <div className="flex items-center gap-2">
-                              <Zap className="w-4 h-4 text-red-400" />
+                              <Icon name="zap" className="w-4 h-4 text-red-400" />
                               <span className="text-red-400 font-bold text-xs uppercase tracking-wider">
                                 B 이의제기 (1차)
                               </span>
                             </div>
-                            <ArrowRight className="w-5 h-5 text-gray-500" />
+                            <Icon name="arrowRight" className="w-5 h-5 text-gray-500" />
                             <div className="flex items-center gap-2">
-                              <Shield className="w-4 h-4 text-blue-400" />
+                              <Icon name="shield" className="w-4 h-4 text-blue-400" />
                               <span className="text-blue-400 font-bold text-xs uppercase tracking-wider">A 반론</span>
                             </div>
                           </div>
@@ -332,7 +336,7 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
                             <div className="relative">
                               <div className="absolute inset-0 bg-red-500/20 blur-lg rounded-full" />
                               <div className="relative bg-gradient-to-r from-red-500 to-blue-600 w-12 h-12 rounded-full flex items-center justify-center border-2 border-red-400/50 shadow-lg">
-                                <ArrowRight className="w-5 h-5 text-white font-bold" />
+                                <Icon name="arrowRight" className="w-5 h-5 text-white" />
                               </div>
                             </div>
                           </div>
@@ -347,14 +351,14 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
                         <div className="px-6 py-3 bg-gradient-to-r from-orange-900/20 to-blue-900/20 border-b border-[#2d2d3f]">
                           <div className="flex items-center justify-center gap-3">
                             <div className="flex items-center gap-2">
-                              <Zap className="w-4 h-4 text-orange-400" />
+                              <Icon name="zap" className="w-4 h-4 text-orange-400" />
                               <span className="text-orange-400 font-bold text-xs uppercase tracking-wider">
                                 A 이의제기 (2차)
                               </span>
                             </div>
-                            <ArrowRight className="w-5 h-5 text-gray-500" />
+                            <Icon name="arrowRight" className="w-5 h-5 text-gray-500" />
                             <div className="flex items-center gap-2">
-                              <Shield className="w-4 h-4 text-blue-400" />
+                              <Icon name="shield" className="w-4 h-4 text-blue-400" />
                               <span className="text-blue-400 font-bold text-xs uppercase tracking-wider">B 반론</span>
                             </div>
                           </div>
@@ -367,7 +371,7 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
                             <div className="relative">
                               <div className="absolute inset-0 bg-orange-500/20 blur-lg rounded-full" />
                               <div className="relative bg-gradient-to-r from-orange-500 to-blue-600 w-12 h-12 rounded-full flex items-center justify-center border-2 border-orange-400/50 shadow-lg">
-                                <ArrowRight className="w-5 h-5 text-white font-bold" />
+                                <Icon name="arrowRight" className="w-5 h-5 text-white" />
                               </div>
                             </div>
                           </div>
@@ -382,14 +386,14 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
                         <div className="px-6 py-3 bg-gradient-to-r from-red-900/20 to-blue-900/20 border-b border-[#2d2d3f]">
                           <div className="flex items-center justify-center gap-3">
                             <div className="flex items-center gap-2">
-                              <Zap className="w-4 h-4 text-red-400" />
+                              <Icon name="zap" className="w-4 h-4 text-red-400" />
                               <span className="text-red-400 font-bold text-xs uppercase tracking-wider">
                                 B 이의제기 (2차)
                               </span>
                             </div>
-                            <ArrowRight className="w-5 h-5 text-gray-500" />
+                            <Icon name="arrowRight" className="w-5 h-5 text-gray-500" />
                             <div className="flex items-center gap-2">
-                              <Shield className="w-4 h-4 text-blue-400" />
+                              <Icon name="shield" className="w-4 h-4 text-blue-400" />
                               <span className="text-blue-400 font-bold text-xs uppercase tracking-wider">A 반론</span>
                             </div>
                           </div>
@@ -402,7 +406,7 @@ export default function Step3Timeline({ topics, timelines, currentRound = 1, tot
                             <div className="relative">
                               <div className="absolute inset-0 bg-red-500/20 blur-lg rounded-full" />
                               <div className="relative bg-gradient-to-r from-red-500 to-blue-600 w-12 h-12 rounded-full flex items-center justify-center border-2 border-red-400/50 shadow-lg">
-                                <ArrowRight className="w-5 h-5 text-white font-bold" />
+                                <Icon name="arrowRight" className="w-5 h-5 text-white" />
                               </div>
                             </div>
                           </div>

--- a/frontend/src/pages/teamSelectPage/components/steps/Step5TeamSelect.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/Step5TeamSelect.tsx
@@ -1,4 +1,4 @@
-import { Flag } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import TeamCard from '../TeamCard';
 import type { Team } from '@/commons/types/battle';
 
@@ -12,7 +12,10 @@ export default function Step4TeamSelect({ onSelect, selectedTeam }: Step4TeamSel
     <div className="flex flex-col items-center gap-4 xl:gap-6 2xl:gap-8 w-full max-w-6xl mx-auto px-4">
       {/* 상단 섹션 */}
       <div className="text-center mb-4 xl:mb-6 2xl:mb-8">
-        <Flag className="w-10 h-10 xl:w-12 xl:h-12 2xl:w-16 2xl:h-16 text-orange-500 mx-auto mb-2 xl:mb-3 2xl:mb-4" />
+        <Icon
+          name="flag"
+          className="w-10 h-10 xl:w-12 xl:h-12 2xl:w-16 2xl:h-16 text-orange-500 mx-auto mb-2 xl:mb-3 2xl:mb-4"
+        />
         <h2 className="text-xl xl:text-2xl 2xl:text-3xl font-bold text-white mb-1 xl:mb-2">진영 선택</h2>
         <p className="text-sm xl:text-base text-gray-400">A팀, B팀 또는 중립 진영을 선택하세요</p>
       </div>

--- a/frontend/src/pages/teamSelectPage/index.tsx
+++ b/frontend/src/pages/teamSelectPage/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { selectIsLoggingIn, selectIsOAuth, selectUser, useAuthStore } from '@/commons/stores/authStore';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import { useStepFlow } from './hooks/useStepFlow';
 import StepIndicator from './components/StepIndicator';
 import StepNavigation from './components/StepNavigation';
@@ -159,7 +159,7 @@ export default function TeamSelectPage() {
                   className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-16 w-12 h-12 rounded-full bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white flex items-center justify-center transition-colors z-10"
                   aria-label="이전 단계"
                 >
-                  <ChevronLeft className="w-6 h-6" />
+                  <Icon name="chevronLeft" className="w-6 h-6" />
                 </button>
               )}
 
@@ -178,7 +178,7 @@ export default function TeamSelectPage() {
                   `}
                   aria-label="다음 단계"
                 >
-                  <ChevronRight className="w-6 h-6" />
+                  <Icon name="chevronRight" className="w-6 h-6" />
                 </button>
               )}
             </div>

--- a/frontend/src/pages/tutorialPage/components/TutorialModal.tsx
+++ b/frontend/src/pages/tutorialPage/components/TutorialModal.tsx
@@ -1,4 +1,4 @@
-import QuestionIcon from '@/assets/icon/question.svg?react';
+import Icon from '@/commons/components/Icon';
 
 interface TutorialModalProps {
   isOpen: boolean;
@@ -19,7 +19,7 @@ export default function TutorialModal({ isOpen, onStart, dontShowAgain, onDontSh
       <div className="relative max-w-md rounded-2xl bg-[#1E2432] border border-[#2D3648] shadow-2xl p-8">
         <div className="flex justify-center mb-6">
           <div className="w-15 h-15 rounded-full bg-gradient-to-br from-[#FF6900] to-[#FB2C36] flex items-center justify-center">
-            <QuestionIcon className="w-10 h-10 text-white" />
+            <Icon name="question" className="w-10 h-10 text-white" />
           </div>
         </div>
 

--- a/frontend/src/pages/tutorialPage/components/TutorialStepModal.tsx
+++ b/frontend/src/pages/tutorialPage/components/TutorialStepModal.tsx
@@ -5,7 +5,7 @@ import SpotlightOverlay from './SpotlightOverlay';
 import DiscussionInput from '@/pages/battlePage/components/discussion/DiscussionInput';
 import BattleProgressBoard from '@/pages/battlePage/components/progressBoard/ProgressBoard';
 import { TUTORIAL_STEPS, TOTAL_STEPS } from './const/tutorialSteps';
-import QuestionIcon from '@/assets/icon/question.svg?react';
+import Icon from '@/commons/components/Icon';
 
 const MODAL_WIDTH = 448;
 const MODAL_GAP = 32;
@@ -128,7 +128,7 @@ export default function TutorialStepModal({ isOpen, currentStep, onNext, onPrev 
         <div className="relative max-w-md rounded-2xl bg-[#1E2432] border-2 border-[#FF6900] shadow-2xl p-6">
           <div className="flex justify-center mb-4">
             <div className="w-14 h-14 rounded-full bg-gradient-to-br from-[#FF6900] to-[#FB2C36] flex items-center justify-center">
-              <QuestionIcon className="w-8 h-8 text-white" />
+              <Icon name="question" className="w-8 h-8 text-white" />
             </div>
           </div>
 

--- a/frontend/src/pages/tutorialPage/teamSelect/index.tsx
+++ b/frontend/src/pages/tutorialPage/teamSelect/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import Icon from '@/commons/components/Icon';
 import type { Team } from '@/commons/types/battle';
 import { useStepFlow } from '@/pages/teamSelectPage/hooks/useStepFlow';
 import StepIndicator from '@/pages/teamSelectPage/components/StepIndicator';
@@ -122,7 +122,7 @@ export default function TutorialTeamSelectPage() {
                   className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-16 w-12 h-12 rounded-full bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white flex items-center justify-center transition-colors z-10"
                   aria-label="이전 단계"
                 >
-                  <ChevronLeft className="w-6 h-6" />
+                  <Icon name="chevronLeft" className="w-6 h-6" />
                 </button>
               )}
 
@@ -140,7 +140,7 @@ export default function TutorialTeamSelectPage() {
                   `}
                   aria-label="다음 단계"
                 >
-                  <ChevronRight className="w-6 h-6" />
+                  <Icon name="chevronRight" className="w-6 h-6" />
                 </button>
               )}
             </div>


### PR DESCRIPTION
## 🔗 관련 이슈
closes #406

## ✅ 작업 내용
### **공용 `Icon` 컴포넌트 구현**

기존에는 아이콘이 필요한 각 컴포넌트마다 SVG/PNG 파일을 직접 import해서 사용하고 있었습니다.

```tsx
// 기존 방식
import BattleIcon from '@/assets/icon/battle.svg?react';
import { ChevronDown } from 'lucide-react';
import BronzePng from '@/assets/icon/bronze.png';

<BattleIcon className="w-4 h-4" />
<ChevronDown className="w-4 h-4" />
<img src={BronzePng} className="w-6 h-6" alt="bronze" />

```
다양한 type의 Icon들이 Icon 공용 컴포넌트 하나로 추상화 되어 `name prop` 하나로 아이콘을 지정하는 단일 인터페이스로 통합했습니다.


<br/>

### 적용한 Icon 리스트

```tsx

export const SVG_ICONS = {
  battle: BattleIcon,
  check: CheckIcon,
  clock: ClockIcon,
  close: CloseIcon,
  copy: CopyIcon,
  crown: CrownIcon,
  dev: DevIcon,
  downArrow: DownArrowIcon,
  exclamation: ExclamationIcon,
  eye: EyeIcon,
  github: GithubIcon,
  kakao: KakaoIcon,
  like: LikeIcon,
  message: MessageIcon,
  pause: PauseIcon,
  people: PeopleIcon,
  peoples: PeoplesIcon,
  play: PlayIcon,
  plus: PlusIcon,
  question: QuestionIcon,
  scale: ScaleIcon,
  send: SendIcon,
  shield: ShieldIcon,
  skip: SkipIcon,
  sound: SoundIcon,
  switch: SwitchIcon,
  timeline: TimelineIcon,
  timer: TimerIcon,
  trophy: TrophyIcon,
  user: UserIcon,
  vote: VoteIcon,
  world: WorldIcon,
  // lucide-react icons
  activity: lc(Activity),
  alertTriangle: lc(AlertTriangle),
  arrowDown: lc(ArrowDown),
  arrowRight: lc(ArrowRight),
  award: lc(Award),
  bookOpen: lc(BookOpen),
  chevronDown: lc(ChevronDown),
  chevronLeft: lc(ChevronLeft),
  chevronRight: lc(ChevronRight),
  chevronUp: lc(ChevronUp),
  code2: lc(Code2),
  externalLink: lc(ExternalLink),
  flag: lc(Flag),
  flame: lc(Flame),
  home: lc(Home),
  medal: lc(Medal),
  refreshCw: lc(RefreshCw),
  shuffle: lc(Shuffle),
  sparkles: lc(Sparkles),
  target: lc(Target),
  trendingUp: lc(TrendingUp),
  zap: lc(Zap)
} as const satisfies Record<string, SvgIconComponent>;

export const TIER_ICONS = {
  bronze: BronzePng,
  silver: SilverPng,
  gold: GoldPng,
  diamond: DiamondPng,
  master: MasterPng,
  grandmaster: GrandmasterPng
} as const satisfies Record<string, string>;
```

### 변경 후
```tsx
import Icon from '@/commons/components/Icon';

<Icon name="battle" className="w-4 h-4" />
<Icon name="chevronDown" className="w-4 h-4" />
<Icon name="bronze" className="w-6 h-6" alt="bronze" />
```


### 기존 Icon Import 하는 방식 제거 후 새롭게 만들어진 Icon 컴포넌트 사용 방식으로 수정 작업

총 38개 컴포넌트/페이지에서 개별 SVG/PNG import를 제거하고 공용 Icon 컴포넌트로 교체했습니다.

<br/>

## 💬 고민했던 부분

### SVG를 lazy import로 불러올지 여부

현재 `icons.ts`에서 모든 SVG를 정적으로 import하고 있습니다. 처음에는 이러면 소수의 icon을 쓰고자 불필요한 icon들까지 적재 시키는 문제가 생기지 않을까?  상황에 따라 필요한 SVG 파일들만 불러올 수 있도록 코드 스플리팅을 고려했지만, 아래 이유들로 인해 정적 import를 선택했습니다.


#### 1. 현재 사용되는 `vite-plugin-svgr`는  SVG는 JS 컴포넌트로 변환하여 번들에 포함 시켜준다고 하네요..?
현재 저희 프로젝트에서 SVG는 `vite-plugin-svgr`에 의해 JS 컴포넌트로 변환되어 번들에 포함되기에, 이미지 파일처럼 별도 네트워크 요청이 발생하는 리소스가 아닙니다. 그렇기에 lazy loading을 적용하더라도 요청 수를 줄이는 측면의 이점을 기대하기 어렵다고 생각했습니다. 오히려 아이콘별 chunk가 생성되어 렌더링 시 추가 요청이 발생되는 오버헤드가 생길 수 있어서... 현재 구조에서는 정적 import 방식이 더 적절하다고 판단했습니다. 

#### 2. 아이콘 특성상 lazy loading과 맞지 않음
사실상 첫 번째 이유 하나만으로도 충분하지만 다른 이유를 하나가 더 있다면.. 몇몇 아이콘들은 화면 전반에서 공통적으로 사용되며, 몇몇 아이콘은 초기 렌더링 시점부터 즉시 필요한 경우가 많습니다.
그래서 모든 icon들을 lazy loading을 적용한다고 하면 Suspense로 icon 로딩 ui를 띄워야 하는데, 사실 아이콘은 UI의 기본적인 구성 요소이기 때문에, 초기부터 렌더링 되어야 하지 않나 생각이 들더라구요. (다른 곳에도 suspense 처리 되는 ui가 있는데 페이지에 모든 부분 부분들이 로딩이면 쪼금...)

그래서 자주 사용되는 아이콘과 자주 사용되지 않는 아이콘을 구분하여 일부만 lazy loading하는 방식도 고려해봤는데 
분리 기준을 잡기 모호하다는 생각이 들었습니다. 

