### PR TITLE
[Refactor] 파편화된 버튼 스타일 공용 컴포넌트로 단일화 

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(xargs grep:*)"
-    ]
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(npx playwright:*)"
-    ]
-  }
-}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "react-syntax-highlighter": "^16.1.0",
     "recharts": "^3.6.0",
     "socket.io-client": "^4.8.1",
+    "tailwind-merge": "^3.5.0",
     "zustand": "^5.0.9"
   },
   "devDependencies": {

--- a/frontend/src/commons/components/Button.tsx
+++ b/frontend/src/commons/components/Button.tsx
@@ -1,0 +1,67 @@
+import { forwardRef } from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+  variant?: 'primary' | 'secondary' | 'ghost';
+  size?: 'sm' | 'md' | 'lg';
+  rounded?: 'sm' | 'md' | 'lg' | 'xl' | 'full' | 'none' | 'r-md' | 'r-lg' | 'r-xl';
+  fullWidth?: boolean;
+}
+
+const VARIANT_STYLES = {
+  primary: 'bg-orange-500 hover:bg-orange-600 text-white font-semibold',
+  secondary: 'bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white',
+  ghost: 'bg-transparent border border-[#2b2b3e] text-gray-200 hover:bg-[#1a1a2e]'
+} as const;
+
+const SIZE_STYLES = {
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-5 py-2.5 text-sm',
+  lg: 'px-8 py-4 text-base'
+} as const;
+
+const DEFAULT_ROUNDED = {
+  sm: 'rounded-md',
+  md: 'rounded-lg',
+  lg: 'rounded-xl'
+} as const;
+
+const ROUNDED_STYLES = {
+  sm: 'rounded-sm',
+  md: 'rounded-md',
+  lg: 'rounded-lg',
+  xl: 'rounded-xl',
+  full: 'rounded-full',
+  none: 'rounded-none',
+  'r-md': 'rounded-r-md',
+  'r-lg': 'rounded-r-lg',
+  'r-xl': 'rounded-r-xl'
+} as const;
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { children, variant = 'primary', size = 'md', rounded, fullWidth = false, className = '', ...props },
+  ref
+) {
+  const roundedClass = rounded ? ROUNDED_STYLES[rounded] : DEFAULT_ROUNDED[size];
+
+  return (
+    <button
+      ref={ref}
+      className={twMerge(
+        'inline-flex items-center justify-center gap-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+        VARIANT_STYLES[variant],
+        SIZE_STYLES[size],
+        roundedClass,
+        fullWidth && 'w-full',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+});
+
+export default Button;

--- a/frontend/src/commons/components/ErrorBoundary/SectionErrorFallback.tsx
+++ b/frontend/src/commons/components/ErrorBoundary/SectionErrorFallback.tsx
@@ -1,4 +1,5 @@
 import Icon from '@/commons/components/Icon';
+import Button from '@/commons/components/Button';
 
 interface SectionErrorFallbackProps {
   error: Error;
@@ -30,13 +31,13 @@ export default function SectionErrorFallback({
           <p className="text-sm text-gray-400">{error.message}</p>
         </div>
 
-        <button
+        <Button
           onClick={reset}
           className="flex items-center gap-2 px-6 py-3 bg-orange-500 hover:bg-orange-600 text-white font-medium rounded-lg transition-colors duration-200"
         >
           <Icon name="refreshCw" className="w-4 h-4" />
           다시 시도
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/commons/components/UserProfileDropdown.tsx
+++ b/frontend/src/commons/components/UserProfileDropdown.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Icon from './Icon';
 import { useLogout } from '@/commons/hooks/useLogout';
+import Button from '@/commons/components/Button';
 
 interface UserProfileDropdownProps {
   user: {
@@ -41,11 +42,8 @@ export default function UserProfileDropdown({ user }: UserProfileDropdownProps) 
   return (
     <div className="relative" ref={dropdownRef}>
       {/* 사용자 프로필 버튼 */}
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 px-3 py-1.5 hover:bg-[#1A1A2E] rounded-lg transition-colors"
-      >
-        <div className="w-8 h-8 rounded-full bg-linear-to-br from-orange-500 via-orange-600 to-orange-700 flex items-center justify-center shadow-lg ">
+      <Button onClick={() => setIsOpen(!isOpen)} variant="ghost" className="px-3 py-1.5 border-none hover:bg-[#1A1A2E]">
+        <div className="w-8 h-8 rounded-full bg-linear-to-br from-orange-500 via-orange-600 to-orange-700 flex items-center justify-center shadow-lg">
           {user.avatarUrl ? (
             <img src={user.avatarUrl} alt={user.nickname} className="w-full h-full rounded-full object-cover" />
           ) : (
@@ -53,59 +51,69 @@ export default function UserProfileDropdown({ user }: UserProfileDropdownProps) 
           )}
         </div>
         <span className="text-white text-sm font-medium">{user.nickname}</span>
-      </button>
+      </Button>
 
       {/* 드롭다운 메뉴 */}
       {isOpen && (
         <div className="absolute right-0 top-full mt-2 w-64 bg-[#1A1A2E] rounded-xl border border-[#2D2D3F] shadow-2xl overflow-hidden z-50">
           {/* 메뉴 아이템 */}
           <div className="py-2">
-            <button
+            <Button
+              variant="ghost"
+              fullWidth
               onClick={() => {
                 navigate('/nickname');
                 setIsOpen(false);
               }}
-              className="w-full px-4 py-2 text-left text-white text-sm hover:bg-[#24292e] transition-colors"
+              className="px-4 py-2 border-none justify-start text-sm hover:bg-[#24292e]"
             >
               닉네임 변경
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="ghost"
+              fullWidth
               onClick={() => {
                 navigate('/profile');
                 setIsOpen(false);
               }}
-              className="w-full px-4 py-2 text-left text-white text-sm hover:bg-[#24292e] transition-colors"
+              className="px-4 py-2 border-none justify-start text-sm hover:bg-[#24292e]"
             >
               내 프로필
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="ghost"
+              fullWidth
               onClick={() => {
                 navigate('/my-battles');
                 setIsOpen(false);
               }}
-              className="w-full px-4 py-2 text-left text-white text-sm hover:bg-[#24292e] transition-colors"
+              className="px-4 py-2 border-none justify-start text-sm hover:bg-[#24292e]"
             >
               내 배틀
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="ghost"
+              fullWidth
               onClick={() => {
                 navigate('/settings');
                 setIsOpen(false);
               }}
-              className="w-full px-4 py-2 text-left text-white text-sm hover:bg-[#24292e] transition-colors"
+              className="px-4 py-2 border-none justify-start text-sm hover:bg-[#24292e]"
             >
               설정
-            </button>
+            </Button>
           </div>
 
           {/* 로그아웃 버튼 */}
           <div className="border-t border-[#2D2D3F] py-2">
-            <button
+            <Button
+              variant="ghost"
+              fullWidth
               onClick={handleLogout}
-              className="w-full px-4 py-2 text-left text-red-400 text-sm hover:bg-[#24292e] transition-colors flex items-center gap-2"
+              className="px-4 py-2 border-none justify-start text-sm text-red-400 hover:bg-[#24292e] hover:text-red-400"
             >
-              <span className="text-red-400">로그아웃</span>
-            </button>
+              로그아웃
+            </Button>
           </div>
         </div>
       )}

--- a/frontend/src/pages/battleCreatePage/components/InviteLinkButton.tsx
+++ b/frontend/src/pages/battleCreatePage/components/InviteLinkButton.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Icon from '@/commons/components/Icon';
+import Button from '@/commons/components/Button';
 
 interface InviteLinkProps {
   inviteCode: string;
@@ -21,10 +22,12 @@ export default function InviteLinkButton({ inviteCode }: InviteLinkProps) {
   };
 
   return (
-    <button
+    <Button
+      variant="secondary"
+      size="sm"
       onClick={handleCopy}
-      className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors flex items-center justify-center gap-2 text-sm w-[100px] sm:w-auto sm:min-w-[100px]"
       title="링크 복사"
+      className="w-[100px] sm:w-auto sm:min-w-[100px]"
     >
       {copied ? (
         <>
@@ -37,6 +40,6 @@ export default function InviteLinkButton({ inviteCode }: InviteLinkProps) {
           <span className="text-sm hidden sm:inline">친구 초대</span>
         </>
       )}
-    </button>
+    </Button>
   );
 }

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -6,6 +6,7 @@ import { selectUser, useAuthStore } from '@/commons/stores/authStore';
 import { useToastStore, selectAddToast } from '@/commons/stores/toastStore';
 import { useCreateBattle } from './hooks/useCreateBattle';
 import LoadingOverlay from '@/commons/components/LoadingOverlay';
+import Button from '@/commons/components/Button';
 import type { BattleType, BattleLanguage, BattlePlayTime } from './api/types';
 
 const LANGUAGE_OPTIONS: Array<{ label: string; value: BattleLanguage }> = [
@@ -92,12 +93,14 @@ export default function BattleCreatePage() {
       <div className="min-h-screen w-full px-6 py-8">
         <div className="mx-auto create-max-width">
           <div className="flex items-center justify-start gap-4 mt-10 mb-8">
-            <button
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={() => window.history.back()}
-              className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors shrink-0 text-sm w-[100px] sm:w-auto sm:min-w-[100px]"
+              className="shrink-0 w-[100px] sm:w-auto sm:min-w-[100px]"
             >
               ← 돌아가기
-            </button>
+            </Button>
           </div>
 
           <div className="mt-4 rounded-2xl border border-[#2b2b3e] bg-[#121226] shadow-[0_18px_35px_rgba(0,0,0,0.35)]">
@@ -229,23 +232,19 @@ export default function BattleCreatePage() {
                 <BattleTopicInput rounds={rounds} selectedTopics={topics} onTopicsChange={setTopics} />
 
                 <div className="flex items-center justify-end gap-3 pt-2">
-                  <button
-                    type="button"
-                    onClick={() => (window.location.href = '/main')}
-                    className="rounded-xl border border-[#2b2b3e] bg-transparent px-5 py-3 text-gray-200 hover:bg-[#1a1a2e] transition-colors"
-                  >
+                  <Button type="button" variant="ghost" onClick={() => (window.location.href = '/main')}>
                     취소
-                  </button>
+                  </Button>
 
-                  <button
+                  <Button
                     type="button"
                     disabled={!canSubmit || isPending}
                     onClick={handleSubmit}
                     data-testid="create-battle-button"
-                    className="inline-flex items-center gap-2 rounded-xl bg-orange-500 px-5 py-3 font-semibold text-white shadow-[0_12px_24px_rgba(255,105,0,0.25)] hover:bg-orange-400 disabled:cursor-not-allowed disabled:bg-orange-500/50 transition-colors"
+                    className="shadow-[0_12px_24px_rgba(255,105,0,0.25)] hover:bg-orange-400 disabled:bg-orange-500/50"
                   >
                     배틀 생성하기
-                  </button>
+                  </Button>
                 </div>
               </div>
             </div>

--- a/frontend/src/pages/battlePage/components/chatting/ChatInput.tsx
+++ b/frontend/src/pages/battlePage/components/chatting/ChatInput.tsx
@@ -1,5 +1,6 @@
 import Icon from '@/commons/components/Icon';
 import { useState } from 'react';
+import Button from '@/commons/components/Button';
 
 interface ChatInputProps {
   onSend: (message: string) => void;
@@ -32,9 +33,9 @@ export default function ChatInput({ onSend }: ChatInputProps) {
           placeholder="메시지를 입력하세요..."
           className="flex-1 bg-[#2D2D3F] border border-[#3D3D4F] rounded-md px-3 py-2.5 text-xs text-white placeholder-[#666] focus:outline-none focus:border-[#FF6900]"
         />
-        <button onClick={handleSend} className="p-2.5 rounded-md bg-[#3D3D4F] hover:bg-[#4D4D5F] transition-colors">
+        <Button onClick={handleSend} variant="secondary" className="p-2.5 rounded-md bg-[#3D3D4F] hover:bg-[#4D4D5F] transition-colors">
           <Icon name="send" />
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/pages/battlePage/components/header/SoundSettingsButton.tsx
+++ b/frontend/src/pages/battlePage/components/header/SoundSettingsButton.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react';
 import Icon from '@/commons/components/Icon';
 import SoundSettingsPopover from './SoundSettingsPopover';
+import Button from '@/commons/components/Button';
 
 export interface BGMOption {
   key: string;
@@ -18,14 +19,15 @@ export default function SoundSettingsButton({ bgmOptions }: SoundSettingsButtonP
 
   return (
     <div className="fixed top-4 right-4 z-10">
-      <button
+      <Button
         ref={soundButtonRef}
+        variant="secondary"
         onClick={() => setIsSoundSettingsOpen(!isSoundSettingsOpen)}
-        className="flex items-center justify-center w-11 h-11 rounded-xl bg-[#2D2D3F]/80 hover:bg-[#3D3D4F] text-white transition-all shadow-lg border border-white/10"
         aria-label="사운드 설정"
+        className="w-11 h-11 p-0 rounded-xl bg-[#2D2D3F]/80 shadow-lg border border-white/10"
       >
         <Icon name="sound" className="w-6 h-6" />
-      </button>
+      </Button>
       <SoundSettingsPopover
         isOpen={isSoundSettingsOpen}
         onClose={() => setIsSoundSettingsOpen(false)}

--- a/frontend/src/pages/battlePage/components/header/SoundSettingsPopover.tsx
+++ b/frontend/src/pages/battlePage/components/header/SoundSettingsPopover.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { soundManager } from '@/commons/utils/soundManager';
 import Icon from '@/commons/components/Icon';
 import VolumeSlider from './VolumeSlider';
+import Button from '@/commons/components/Button';
 
 interface BGMOption {
   key: string;
@@ -102,13 +103,14 @@ export default function SoundSettingsPopover({ isOpen, onClose, anchorEl, bgmOpt
     >
       <div className="relative flex items-center mb-6">
         <h3 className="flex-1 text-sm font-bold text-white text-center">사운드 설정</h3>
-        <button
+        <Button
           onClick={onClose}
-          className="absolute right-0 w-7 h-7 flex items-center justify-center rounded-full hover:bg-white/10 text-gray-400 hover:text-white transition-all"
+          variant="ghost"
           aria-label="닫기"
+          className="absolute right-0 w-7 h-7 p-0 rounded-full border-none hover:bg-white/10 text-gray-400 hover:text-white"
         >
           <Icon name="close" className="w-4 h-4" />
-        </button>
+        </Button>
       </div>
 
       <div className="space-y-6">
@@ -129,17 +131,18 @@ export default function SoundSettingsPopover({ isOpen, onClose, anchorEl, bgmOpt
                 </option>
               ))}
             </select>
-            <button
+            <Button
               onClick={togglePlayPause}
-              className="w-10 h-10 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 flex items-center justify-center transition-all active:scale-95 group"
+              variant="ghost"
               aria-label={isPlaying ? '일시정지' : '재생'}
+              className="w-10 h-10 p-0 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 active:scale-95"
             >
               {isPlaying ? (
                 <Icon name="pause" className="w-5 h-5 text-white group-hover:scale-110 transition-transform" />
               ) : (
                 <Icon name="play" className="w-5 h-5 text-white ml-0.5 group-hover:scale-110 transition-transform" />
               )}
-            </button>
+            </Button>
           </div>
         </div>
 

--- a/frontend/src/pages/battlePage/components/header/index.tsx
+++ b/frontend/src/pages/battlePage/components/header/index.tsx
@@ -1,4 +1,5 @@
 import ParticipantRatioBar from './ParticipantRatioBar';
+import Button from '@/commons/components/Button';
 import StageIndicator from './StageIndicator';
 import BattleTimer from './BattleTimer';
 import TeamCounter from './TeamCounter';
@@ -50,13 +51,14 @@ export default function BattleHeader({ isSkipEnabled, toggleSkip, totalSkips }: 
         <StageIndicator />
         <div className="flex flex-col items-center justify-center" data-tutorial="timer">
           {phase === 'PENDING' ? (
-            <button
+            <Button
               type="button"
               onClick={handleStart}
-              className="px-5 py-3 rounded-lg border border-[#FF6900] text-[#FF6900] hover:bg-[#FF6900]/10"
+              variant="ghost"
+              className="border-[#FF6900] text-[#FF6900] hover:bg-[#FF6900]/10 hover:text-[#FF6900]"
             >
               배틀 시작
-            </button>
+            </Button>
           ) : (
             <>
               <BattleTimer />

--- a/frontend/src/pages/battlePage/components/modals/ConnectionErrorModal.tsx
+++ b/frontend/src/pages/battlePage/components/modals/ConnectionErrorModal.tsx
@@ -1,4 +1,5 @@
 import { useBattleStore } from '../../stores/battleStore';
+import Button from '@/commons/components/Button';
 
 interface ModalContent {
   title: string;
@@ -75,12 +76,12 @@ export default function ConnectionErrorModal() {
 
         {content.showReconnectButton && (
           <div className="flex justify-center">
-            <button
+            <Button
               onClick={handleReconnect}
-              className="rounded-xl bg-gradient-to-r from-[#2B7FFF] to-[#1a5fd9] px-8 py-3.5 font-bold text-white transition-all duration-200 hover:scale-105 hover:shadow-lg hover:shadow-[#2B7FFF]/50"
+              className="rounded-xl bg-gradient-to-r from-[#2B7FFF] to-[#1a5fd9] px-8 py-3.5 font-bold hover:scale-105 hover:shadow-lg hover:shadow-[#2B7FFF]/50"
             >
               다시 연결
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
@@ -1,4 +1,5 @@
 import Icon from '@/commons/components/Icon';
+import Button from '@/commons/components/Button';
 
 interface BookmarkButtonProps {
   onOpen: (tab: 'info' | 'timeline' | 'reference') => void;
@@ -21,35 +22,41 @@ export default function BookmarkButton({
       data-tutorial="sidebar-buttons"
     >
       {/* 문제 설명 */}
-      <button
+      <Button
         onClick={() => onOpen('info')}
-        className="group relative bg-linear-to-r from-[#FF6900] to-[#FF8533] px-3 py-2 rounded-r-md shadow-md hover:shadow-lg transition-all duration-200 hover:translate-x-1 flex items-center gap-1"
+        rounded="r-md"
+        size="sm"
+        className="group relative bg-linear-to-r from-[#FF6900] to-[#FF8533] shadow-md hover:shadow-lg hover:translate-x-1"
         aria-label="문제 설명 보기"
       >
         <Icon name="message" className="w-3.5 h-3.5" />
         <span className="text-sm">문제 설명</span>
-      </button>
+      </Button>
 
       {/* 타임라인 */}
-      <button
+      <Button
         onClick={() => onOpen('timeline')}
-        className="group relative bg-linear-to-r from-[#AD46FF] to-[#6BA3FF] px-3 py-2 rounded-r-md shadow-md hover:shadow-lg transition-all duration-200 hover:translate-x-1 flex items-center gap-1"
+        rounded="r-md"
+        size="sm"
+        className="group relative bg-linear-to-r from-[#AD46FF] to-[#6BA3FF] shadow-md hover:shadow-lg hover:translate-x-1"
         aria-label="타임라인 보기"
       >
         <Icon name="clock" className="w-3.5 h-3.5" />
         <span className="text-sm">타임라인</span>
-      </button>
+      </Button>
 
       {/* 참고 자료 */}
       {hasReferenceData && (
-        <button
+        <Button
           onClick={() => onOpen('reference')}
-          className="group relative bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-700 hover:to-emerald-700 px-3 py-2 rounded-r-md shadow-md hover:shadow-lg transition-all duration-200 hover:translate-x-1 flex items-center gap-1"
+          rounded="r-md"
+          size="sm"
+          className="group relative bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-700 hover:to-emerald-700 shadow-md hover:shadow-lg hover:translate-x-1"
           aria-label="참고 자료 보기"
         >
           <Icon name="bookOpen" className="w-3.5 h-3.5" />
           <span className="text-sm">참고 자료</span>
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarHeader.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarHeader.tsx
@@ -1,4 +1,5 @@
 import Icon from '@/commons/components/Icon';
+import Button from '@/commons/components/Button';
 
 export type SidebarTab = 'info' | 'timeline' | 'reference';
 
@@ -27,39 +28,41 @@ export default function SidebarHeader({ activeTab, onTabChange, onClose, hasRefe
     <div>
       <div className="flex items-center justify-between px-6 pt-5 pb-4">
         <div className="flex gap-4 flex-1">
-          <button
+          <Button
             onClick={() => onTabChange('info')}
-            className={`flex items-center gap-2 px-2 py-2 text-sm font-bold transition-colors ${
-              activeTab === 'info' ? 'text-white' : 'text-gray-400 hover:text-white'
-            }`}
+            variant="ghost"
+            className={`px-2 py-2 text-sm font-bold border-none ${activeTab === 'info' ? 'text-white' : 'text-gray-400 hover:text-white'}`}
           >
             <Icon name="message" className="w-5 h-5" />
             문제 설명
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={() => onTabChange('timeline')}
-            className={`flex items-center gap-2 px-2 py-2 text-sm font-bold transition-colors ${
-              activeTab === 'timeline' ? 'text-white' : 'text-gray-400 hover:text-white'
-            }`}
+            variant="ghost"
+            className={`px-2 py-2 text-sm font-bold border-none ${activeTab === 'timeline' ? 'text-white' : 'text-gray-400 hover:text-white'}`}
           >
             <Icon name="clock" className="w-5 h-5" />
             타임라인
-          </button>
+          </Button>
           {hasReferenceData && (
-            <button
+            <Button
               onClick={() => onTabChange('reference')}
-              className={`flex items-center gap-2 px-2 py-2 text-sm font-bold transition-colors ${
-                activeTab === 'reference' ? 'text-white' : 'text-gray-400 hover:text-white'
-              }`}
+              variant="ghost"
+              className={`px-2 py-2 text-sm font-bold border-none ${activeTab === 'reference' ? 'text-white' : 'text-gray-400 hover:text-white'}`}
             >
               <Icon name="bookOpen" className="w-5 h-5" />
               참고 자료
-            </button>
+            </Button>
           )}
         </div>
-        <button onClick={onClose} className="text-gray-400 hover:text-white transition-colors" aria-label=" 닫기">
-          <Icon name="close" className="w-5 h-5 " />
-        </button>
+        <Button
+          onClick={onClose}
+          variant="ghost"
+          aria-label="닫기"
+          className="p-0 border-none text-gray-400 hover:text-white hover:bg-transparent"
+        >
+          <Icon name="close" className="w-5 h-5" />
+        </Button>
       </div>
       {/* 활성 탭 밑줄 */}
       <div className={`h-0.5 transition-all duration-300 ${getUnderlineColor()}`} />

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import Button from '@/commons/components/Button';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useBattle } from './hooks/useBattle';
 import { useTeamVoteResult } from './hooks/useTeamVoteResult';
@@ -174,12 +175,14 @@ export default function BattlePage() {
           }`}
         >
           <div className="flex items-center justify-between gap-4 mt-10 mb-8">
-            <button
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={handleLeaveBattle}
-              className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors shrink-0 text-sm w-[100px] sm:w-auto sm:min-w-[100px]"
+              className="shrink-0 w-[100px] sm:w-auto sm:min-w-[100px]"
             >
               ← 돌아가기
-            </button>
+            </Button>
             <div className="shrink-0 flex items-center gap-2">
               {battleInfo?.inviteCode && <InviteLinkButton inviteCode={battleInfo.inviteCode} />}
             </div>

--- a/frontend/src/pages/battleResultPage/index.tsx
+++ b/frontend/src/pages/battleResultPage/index.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import Icon from '@/commons/components/Icon';
+import Button from '@/commons/components/Button';
 import WinnerSection from './components/WinnerSection';
 import VoteChart from './components/VoteChartSector';
 import MetricsCards from './components/MetricsCards';
@@ -78,20 +79,20 @@ export default function BattleResultPage() {
       <TimelineSection timelines={battleData.timeline} topics={battleData.topics} />
 
       <div className="max-w-7xl mx-auto mb-12 flex gap-4 justify-center">
-        <button
+        <Button
           onClick={() => navigate('/main')}
-          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-pink-500 to-pink-600 hover:from-pink-600 hover:to-pink-700 rounded-lg font-bold text-white transition-all shadow-lg shadow-pink-500/30"
+          className="bg-gradient-to-r from-pink-500 to-pink-600 hover:from-pink-600 hover:to-pink-700 font-bold shadow-lg shadow-pink-500/30"
         >
           <Icon name="trophy" className="w-5 h-5" />
           다른 배틀 보기
-        </button>
-        <button
+        </Button>
+        <Button
           onClick={() => navigate('/main')}
-          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 rounded-lg font-bold text-white transition-all shadow-lg shadow-green-500/30"
+          className="bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 font-bold shadow-lg shadow-green-500/30"
         >
           <Icon name="activity" className="w-5 h-5" />
           배틀 다시 시작하기
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/pages/entryPage/components/GameIntroduceSection.tsx
+++ b/frontend/src/pages/entryPage/components/GameIntroduceSection.tsx
@@ -1,6 +1,7 @@
 import Carousel from '@/commons/components/Carousel';
 import OnBoardingIntroduceCard from './OnBoardingIntroduceCard';
 import Icon from '@/commons/components/Icon';
+import Button from '@/commons/components/Button';
 
 export default function GameIntroduceSection() {
   const handleScrollDown = () => {
@@ -50,12 +51,13 @@ export default function GameIntroduceSection() {
           />
         </Carousel>
       </div>
-      <button
+      <Button
         onClick={handleScrollDown}
-        className="relative z-10 mx-auto cursor-pointer text-white hover:text-orange-400 transition-colors"
+        variant="ghost"
+        className="relative z-10 mx-auto border-none text-white hover:text-orange-400 hover:bg-transparent p-0"
       >
         <Icon name="chevronDown" className="w-7 h-7" />
-      </button>
+      </Button>
     </section>
   );
 }

--- a/frontend/src/pages/entryPage/components/GameTitleSection.tsx
+++ b/frontend/src/pages/entryPage/components/GameTitleSection.tsx
@@ -1,5 +1,6 @@
 import Icon from '@/commons/components/Icon';
 import { useNavigate } from 'react-router-dom';
+import Button from '@/commons/components/Button';
 import onBoardingBackgroundImage from '/images/onBoarding/gameLogo.png';
 import onBoardingPeoplesImage1 from '/images/onBoarding/onBoardingPeople1.png';
 import onBoardingPeoplesImage2 from '/images/onBoarding/onBoardingPeople2.png';
@@ -40,21 +41,24 @@ export default function GameTitleSection() {
 
       <div className="relative z-30">
         <div className="flex gap-12 items-center justify-center">
-          <button
+          <Button
             onClick={() => navigate('/main')}
-            className="flex items-center justify-center gap-2 text-xl px-8 py-4 bg-gradient-to-r from-orange-500 to-red-600 border border-orange-300 rounded-xl cursor-pointer shadow-[0_10px_40px_rgba(251,146,60,0.6)]"
+            size="lg"
+            className="text-xl bg-gradient-to-r from-orange-500 to-red-600 border border-orange-300 shadow-[0_10px_40px_rgba(251,146,60,0.6)]"
           >
             <Icon name="play" className="w-5 h-5" />
             <span>입장하기</span>
-          </button>
+          </Button>
 
-          <button
+          <Button
             onClick={handleScrollDown}
-            className="flex items-center justify-center text-xl gap-2 px-8 py-4 bg-[#1a1b26] border border-gray-600 rounded-xl cursor-pointer shadow-[0_10px_40px_rgba(0,0,0,0.7)]"
+            size="lg"
+            variant="ghost"
+            className="text-xl bg-[#1a1b26] border-gray-600 shadow-[0_10px_40px_rgba(0,0,0,0.7)]"
           >
             <span>더 알아보기</span>
             <Icon name="chevronDown" className="w-5 h-5" />
-          </button>
+          </Button>
         </div>
       </div>
     </section>

--- a/frontend/src/pages/errorPage/index.tsx
+++ b/frontend/src/pages/errorPage/index.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useRouteError, isRouteErrorResponse } from 'react-router-dom';
 import Icon from '@/commons/components/Icon';
+import Button from '@/commons/components/Button';
 import * as Sentry from '@sentry/react';
 import { useEffect } from 'react';
 
@@ -91,13 +92,10 @@ export default function ErrorPage() {
         </div>
 
         <div className="flex justify-center mb-8">
-          <button
-            onClick={handleGoHome}
-            className="flex items-center gap-2 px-8 py-4 bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 text-white font-bold rounded-lg transition-all duration-300 shadow-lg hover:shadow-orange-500/50"
-          >
+          <Button onClick={handleGoHome} size="lg" className="font-bold shadow-lg hover:shadow-orange-500/50">
             <Icon name="home" className="w-5 h-5" />
             홈으로 돌아가기
-          </button>
+          </Button>
         </div>
         <hr className="border-[#1E2939]" />
         <div className="grid grid-cols-3 gap-4 text-center">

--- a/frontend/src/pages/invitePage/index.tsx
+++ b/frontend/src/pages/invitePage/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import Button from '@/commons/components/Button';
 
 export default function InvitePage() {
   const { inviteCode } = useParams<{ inviteCode: string }>();
@@ -30,12 +31,9 @@ export default function InvitePage() {
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
           <p className="text-white text-lg mb-4">유효하지 않은 초대 링크입니다.</p>
-          <button
-            onClick={() => navigate('/main')}
-            className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors"
-          >
+          <Button variant="secondary" size="sm" onClick={() => navigate('/main')}>
             메인으로 돌아가기
-          </button>
+          </Button>
         </div>
       </div>
     );

--- a/frontend/src/pages/loginPage/index.tsx
+++ b/frontend/src/pages/loginPage/index.tsx
@@ -1,4 +1,5 @@
 import Icon from '@/commons/components/Icon';
+import Button from '@/commons/components/Button';
 import { loginWithGitHub } from './api/loginWithGithub';
 import { loginWithKakao } from './api/loginWithKakao';
 import { useToastStore, selectAddToast } from '@/commons/stores/toastStore';
@@ -45,13 +46,14 @@ export default function LoginPage() {
           <h2 className="text-white text-2xl lg:text-3xl font-bold">로그인</h2>
           <p className="text-gray-400 text-sm lg:text-base text-center">소셜 계정으로 간편하게 시작하세요</p>
 
-          <button
+          <Button
             onClick={handleGitHubLogin}
-            className="w-full flex items-center justify-center gap-3 px-5 lg:px-6 py-3 lg:py-4 bg-[#24292e] hover:bg-[#2d3339] rounded-xl transition-all duration-200 border border-[#364153] group"
+            fullWidth
+            className="bg-[#24292e] hover:bg-[#2d3339] rounded-xl border border-[#364153] px-5 lg:px-6 py-3 lg:py-4"
           >
             <Icon name="github" className="w-5 h-5 lg:w-6 lg:h-6 text-white" />
             <span className="font-medium text-sm lg:text-base xl:text-lg">GitHub로 계속하기</span>
-          </button>
+          </Button>
 
           <div className="flex items-center gap-3 w-full">
             <div className="flex-1 h-px bg-[#2D2D3F]"></div>
@@ -59,13 +61,14 @@ export default function LoginPage() {
             <div className="flex-1 h-px bg-[#2D2D3F]"></div>
           </div>
 
-          <button
+          <Button
             onClick={handleKakaoLogin}
-            className="w-full flex items-center justify-center gap-3 px-5 lg:px-6 py-3 lg:py-4 bg-[#FEE500] hover:bg-[#FDD835] rounded-xl transition-all duration-200 group"
+            fullWidth
+            className="bg-[#FEE500] hover:bg-[#FDD835] text-black rounded-xl px-5 lg:px-6 py-3 lg:py-4"
           >
             <Icon name="kakao" className="w-5 h-5 lg:w-6 lg:h-6 text-black" />
             <span className="text-black font-medium text-sm lg:text-base xl:text-lg">카카오로 계속하기</span>
-          </button>
+          </Button>
 
           <div className="mt-4 lg:mt-6 flex items-start gap-2 text-gray-400 text-xs lg:text-sm">
             <Icon name="dev" className="w-4 h-4 lg:w-5 lg:h-5 shrink-0 mt-0.5" />

--- a/frontend/src/pages/mainPage/index.tsx
+++ b/frontend/src/pages/mainPage/index.tsx
@@ -5,6 +5,7 @@ import PastBattlesSection from './components/pastBattles/PastBattlesSection';
 import { BATTLE_CATEGORY_CONFIG } from '@/pages/mainPage/types/battle';
 import Icon from '@/commons/components/Icon';
 import Header from '@/commons/components/Header';
+import Button from '@/commons/components/Button';
 import { useAuthStore, selectUser } from '@/commons/stores/authStore';
 import { useToastStore, selectAddToast } from '@/commons/stores/toastStore';
 
@@ -40,15 +41,12 @@ export default function MainPage() {
             <p className=" text-gray-400">두 가지 코드 구현 중 어떤 게 더 나은지 실시간 투표로 결정하세요</p>
 
             <div className="mt-6 flex gap-3">
-              <button
+              <Button
                 onClick={handleCreateBattle}
-                className="flex items-center rounded-xl px-5 py-3  bg-orange-500 shadow-[0_4px_6px_-4px_rgba(255,105,0,0.3),0_10px_15px_-3px_rgba(255,105,0,0.3)] hover:shadow-[0_0_25px_rgba(255,105,0,0.7)] transition-all duration-200"
+                className="shadow-[0_4px_6px_-4px_rgba(255,105,0,0.3),0_10px_15px_-3px_rgba(255,105,0,0.3)] hover:shadow-[0_0_25px_rgba(255,105,0,0.7)]"
               >
-                <div className="flex items-center gap-1 ">
-                  <Icon name="battle" className="w-5 h-5 text-white" />
-                  <p> 새 배틀 생성</p>
-                </div>
-              </button>
+                <Icon name="battle" className="w-5 h-5 text-white" />새 배틀 생성
+              </Button>
 
               <Link
                 to="/tutorial/team-select"

--- a/frontend/src/pages/nicknamePage/index.tsx
+++ b/frontend/src/pages/nicknamePage/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import Icon from '@/commons/components/Icon';
 import { useUpdateNickname } from './queries/useUpdateNickname';
+import Button from '@/commons/components/Button';
 
 export default function NicknamePage() {
   const [inputNickname, setInputNickname] = useState('');
@@ -66,13 +67,15 @@ export default function NicknamePage() {
               {error && <p className="mt-2 text-red-400 text-xs lg:text-sm">{error}</p>}
             </div>
 
-            <button
+            <Button
               disabled={isPending}
               type="submit"
-              className="w-full px-5 lg:px-6 py-3 lg:py-4 rounded-xl font-semibold text-sm lg:text-base xl:text-lg bg-linear-to-r from-orange-500 to-orange-600 text-white shadow-lg shadow-orange-500/30 transition-all duration-200 hover:from-orange-400 hover:to-orange-500 hover:shadow-orange-500/40 active:scale-[0.97] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:shadow-none disabled:hover:from-orange-500 disabled:hover:to-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-400/50"
+              fullWidth
+              size="lg"
+              className="shadow-lg shadow-orange-500/30 active:scale-[0.97] focus:ring-2 focus:ring-orange-400/50"
             >
               {isPending ? '설정 중...' : '시작하기'}
-            </button>
+            </Button>
           </form>
         </div>
       </div>

--- a/frontend/src/pages/teamSelectPage/components/StepNavigation.tsx
+++ b/frontend/src/pages/teamSelectPage/components/StepNavigation.tsx
@@ -1,4 +1,5 @@
 import type { Step } from '../types/teamSelect';
+import Button from '@/commons/components/Button';
 
 interface StepNavigationProps {
   currentStep: Step;
@@ -46,20 +47,14 @@ export default function StepNavigation({
 
       {/* 마지막 단계에서만 중앙에 완료 버튼 */}
       {isLastStep && (
-        <button
+        <Button
           onClick={onSubmit}
           disabled={!canGoNext || isSubmitting}
-          className={`
-            px-8 py-3 rounded-lg font-medium transition-colors
-            ${
-              canGoNext && !isSubmitting
-                ? 'bg-[#FF6900] hover:bg-[#FF8533] text-white'
-                : 'bg-[#2D2D3F] text-[#99A1AF] cursor-not-allowed'
-            }
-          `}
+          variant={canGoNext && !isSubmitting ? 'primary' : 'secondary'}
+          size="lg"
         >
           {isSubmitting ? '로그인 중...' : '진영 선택 완료'}
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/frontend/src/pages/teamSelectPage/index.tsx
+++ b/frontend/src/pages/teamSelectPage/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Button from '@/commons/components/Button';
 import { selectIsLoggingIn, selectIsOAuth, selectUser, useAuthStore } from '@/commons/stores/authStore';
 import { useNavigate, useParams } from 'react-router-dom';
 import Icon from '@/commons/components/Icon';
@@ -123,12 +124,14 @@ export default function TeamSelectPage() {
         {/* Header */}
         <div className="relative mb-8">
           <div className="flex items-center justify-between gap-4">
-            <button
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={() => navigate('/main')}
-              className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors shrink-0 text-sm w-[100px] sm:w-auto sm:min-w-[100px]"
+              className="shrink-0 w-[100px] sm:w-auto sm:min-w-[100px]"
             >
               ← 돌아가기
-            </button>
+            </Button>
             <h1 className="text-3xl font-bold text-white absolute left-1/2 -translate-x-1/2 pointer-events-none">
               배틀 참가하기
             </h1>
@@ -154,32 +157,27 @@ export default function TeamSelectPage() {
 
               {/* 이전 버튼 - 콘텐츠 왼쪽 */}
               {currentStep > 1 && (
-                <button
+                <Button
                   onClick={goToPrev}
-                  className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-16 w-12 h-12 rounded-full bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white flex items-center justify-center transition-colors z-10"
+                  variant="secondary"
                   aria-label="이전 단계"
+                  className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-16 w-12 h-12 p-0 rounded-full z-10"
                 >
                   <Icon name="chevronLeft" className="w-6 h-6" />
-                </button>
+                </Button>
               )}
 
               {/* 다음 버튼 - 콘텐츠 오른쪽 */}
               {currentStep < totalSteps && (
-                <button
+                <Button
                   onClick={goToNext}
                   disabled={!canGoNext}
-                  className={`
-                    absolute right-0 top-1/2 -translate-y-1/2 translate-x-16 w-12 h-12 rounded-full flex items-center justify-center transition-colors z-10
-                    ${
-                      canGoNext
-                        ? 'bg-[#FF6900] hover:bg-[#FF8533] text-white'
-                        : 'bg-[#2D2D3F] text-[#99A1AF] cursor-not-allowed'
-                    }
-                  `}
+                  variant={canGoNext ? 'primary' : 'secondary'}
                   aria-label="다음 단계"
+                  className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-16 w-12 h-12 p-0 rounded-full z-10"
                 >
                   <Icon name="chevronRight" className="w-6 h-6" />
-                </button>
+                </Button>
               )}
             </div>
           </div>

--- a/frontend/src/pages/tutorialPage/battle/index.tsx
+++ b/frontend/src/pages/tutorialPage/battle/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import Button from '@/commons/components/Button';
 import { useLocation, useNavigate, useLoaderData } from 'react-router-dom';
 import type { BattleInfo, Team } from '@/commons/types/battle';
 import useModal from '@/commons/hooks/useModal';
@@ -164,12 +165,9 @@ export default function TutorialBattlePage() {
           }`}
         >
           <div className="flex items-center justify-between mt-10 mb-8">
-            <button
-              onClick={handleLeaveBattle}
-              className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors"
-            >
+            <Button variant="secondary" size="sm" onClick={handleLeaveBattle}>
               ← 돌아가기
-            </button>
+            </Button>
           </div>
           <BattleHeader isSkipEnabled={false} toggleSkip={() => {}} totalSkips={0} />
         </div>

--- a/frontend/src/pages/tutorialPage/components/TutorialModal.tsx
+++ b/frontend/src/pages/tutorialPage/components/TutorialModal.tsx
@@ -1,4 +1,5 @@
 import Icon from '@/commons/components/Icon';
+import Button from '@/commons/components/Button';
 
 interface TutorialModalProps {
   isOpen: boolean;
@@ -41,12 +42,13 @@ export default function TutorialModal({ isOpen, onStart, dontShowAgain, onDontSh
           <span className="text-xs text-[#99A1AF]">다시 보지 않기</span>
         </label>
 
-        <button
+        <Button
           onClick={handleStart}
-          className="w-full h-12 rounded-lg bg-gradient-to-r from-[#FF6900] to-[#FB2C36] hover:from-[#FF7A1A] hover:to-[#FC3D47] text-white text-base font-bold transition-all shadow-lg shadow-orange-500/30"
+          fullWidth
+          className="h-12 rounded-lg bg-gradient-to-r from-[#FF6900] to-[#FB2C36] hover:from-[#FF7A1A] hover:to-[#FC3D47] text-base font-bold shadow-lg shadow-orange-500/30"
         >
           시작하기
-        </button>
+        </Button>
 
         <div className="flex items-center justify-center gap-1 mt-4">
           <span className="text-[0.625rem] text-[#6A7282]">💡 우측 상단</span>

--- a/frontend/src/pages/tutorialPage/components/TutorialStepModal.tsx
+++ b/frontend/src/pages/tutorialPage/components/TutorialStepModal.tsx
@@ -6,6 +6,7 @@ import DiscussionInput from '@/pages/battlePage/components/discussion/Discussion
 import BattleProgressBoard from '@/pages/battlePage/components/progressBoard/ProgressBoard';
 import { TUTORIAL_STEPS, TOTAL_STEPS } from './const/tutorialSteps';
 import Icon from '@/commons/components/Icon';
+import Button from '@/commons/components/Button';
 
 const MODAL_WIDTH = 448;
 const MODAL_GAP = 32;
@@ -178,21 +179,22 @@ export default function TutorialStepModal({ isOpen, currentStep, onNext, onPrev 
           </div>
 
           <div className="flex gap-2">
-            <button
+            <Button
               onClick={onPrev}
               disabled={stepNumber === 1}
-              className="flex-1 h-11 rounded-lg bg-[#2D3648] hover:bg-[#3A4255] disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors flex items-center justify-center gap-1"
+              variant="secondary"
+              className="flex-1 h-11 rounded-lg bg-[#2D3648] hover:bg-[#3A4255] text-sm font-medium"
             >
               <span>←</span>
               <span>이전</span>
-            </button>
-            <button
+            </Button>
+            <Button
               onClick={onNext}
-              className="flex-1 h-11 rounded-lg bg-gradient-to-r from-[#FF6900] to-[#FB2C36] hover:from-[#FF7A1A] hover:to-[#FC3D47] text-white text-sm font-bold transition-all shadow-lg shadow-orange-500/30 flex items-center justify-center gap-1"
+              className="flex-1 h-11 rounded-lg bg-gradient-to-r from-[#FF6900] to-[#FB2C36] hover:from-[#FF7A1A] hover:to-[#FC3D47] text-sm font-bold shadow-lg shadow-orange-500/30"
             >
               <span>{isLastStep ? '완료' : '다음'}</span>
               <span>→</span>
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/tutorialPage/teamSelect/components/TutorialIntroModal.tsx
+++ b/frontend/src/pages/tutorialPage/teamSelect/components/TutorialIntroModal.tsx
@@ -1,3 +1,5 @@
+import Button from '@/commons/components/Button';
+
 interface TutorialIntroModalProps {
   isOpen: boolean;
   step: 0 | 1;
@@ -36,22 +38,24 @@ export default function TutorialIntroModal({ isOpen, step, onNext, onStart }: Tu
         )}
         <div className="mt-6">
           {step === 0 && (
-            <button
+            <Button
               type="button"
               onClick={onNext}
-              className="w-full h-11 rounded-lg text-sm font-semibold transition-colors bg-gradient-to-r from-[#FF6900] to-[#FB2C36] text-white"
+              fullWidth
+              className="h-11 rounded-lg text-sm font-semibold bg-gradient-to-r from-[#FF6900] to-[#FB2C36]"
             >
               다음
-            </button>
+            </Button>
           )}
           {step === 1 && (
-            <button
+            <Button
               type="button"
               onClick={onStart}
-              className="w-full h-11 rounded-lg text-sm font-semibold transition-colors bg-gradient-to-r from-[#FF6900] to-[#FB2C36] text-white"
+              fullWidth
+              className="h-11 rounded-lg text-sm font-semibold bg-gradient-to-r from-[#FF6900] to-[#FB2C36]"
             >
               시작하기
-            </button>
+            </Button>
           )}
         </div>
       </div>

--- a/frontend/src/pages/tutorialPage/teamSelect/index.tsx
+++ b/frontend/src/pages/tutorialPage/teamSelect/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Icon from '@/commons/components/Icon';
+import Button from '@/commons/components/Button';
 import type { Team } from '@/commons/types/battle';
 import { useStepFlow } from '@/pages/teamSelectPage/hooks/useStepFlow';
 import StepIndicator from '@/pages/teamSelectPage/components/StepIndicator';
@@ -97,12 +98,9 @@ export default function TutorialTeamSelectPage() {
       />
       <div className="max-w-7xl mx-auto">
         <div className="flex items-center justify-between mb-8">
-          <button
-            onClick={() => navigate('/main')}
-            className="px-4 py-2 rounded-lg bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white transition-colors"
-          >
+          <Button variant="secondary" size="sm" onClick={() => navigate('/main')}>
             ← 돌아가기
-          </button>
+          </Button>
           <h1 className="text-3xl font-bold text-white">튜토리얼 참가하기</h1>
           <div className="w-24" />
         </div>
@@ -117,31 +115,26 @@ export default function TutorialTeamSelectPage() {
               {renderStep()}
 
               {currentStep > 1 && (
-                <button
+                <Button
                   onClick={goToPrev}
-                  className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-16 w-12 h-12 rounded-full bg-[#2D2D3F] hover:bg-[#3D3D4F] text-white flex items-center justify-center transition-colors z-10"
+                  variant="secondary"
                   aria-label="이전 단계"
+                  className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-16 w-12 h-12 p-0 rounded-full z-10"
                 >
                   <Icon name="chevronLeft" className="w-6 h-6" />
-                </button>
+                </Button>
               )}
 
               {currentStep < totalSteps && (
-                <button
+                <Button
                   onClick={goToNext}
                   disabled={!canGoNext}
-                  className={`
-                    absolute right-0 top-1/2 -translate-y-1/2 translate-x-16 w-12 h-12 rounded-full flex items-center justify-center transition-colors z-10
-                    ${
-                      canGoNext
-                        ? 'bg-[#FF6900] hover:bg-[#FF8533] text-white'
-                        : 'bg-[#2D2D3F] text-[#99A1AF] cursor-not-allowed'
-                    }
-                  `}
+                  variant={canGoNext ? 'primary' : 'secondary'}
                   aria-label="다음 단계"
+                  className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-16 w-12 h-12 p-0 rounded-full z-10"
                 >
                   <Icon name="chevronRight" className="w-6 h-6" />
-                </button>
+                </Button>
               )}
             </div>
           </div>

--- a/frontend/tsconfig.e2e.tsbuildinfo
+++ b/frontend/tsconfig.e2e.tsbuildinfo
@@ -1,0 +1,1 @@
+{"root":["./e2e/battle.spec.ts","./e2e/battlecreate.spec.ts","./e2e/main.spec.ts","./e2e/teamselect.spec.ts","./e2e/tutorialteamselect.spec.ts","./e2e/helpers/auth.ts","./e2e/helpers/mockdata.ts","./e2e/helpers/socket.ts"],"version":"5.9.3"}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       socket.io-client:
         specifier: ^4.8.1
         version: 4.8.1
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
       zustand:
         specifier: ^5.0.9
         version: 5.0.9(@types/react@19.2.7)(immer@11.1.3)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
@@ -4935,6 +4938,9 @@ packages:
   synckit@0.11.11:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
@@ -10426,6 +10432,8 @@ snapshots:
   synckit@0.11.11:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.1.18: {}
 


### PR DESCRIPTION
## 🔗 관련 이슈
closes #408

## ✅ 작업 내용


**공용 Button 컴포넌트 생성**
- `variant` / `size` / `rounded` / `fullWidth` props로 디자인 시스템 통일
- `forwardRef`로 ref 전달 지원
- `twMerge`를 통해 `className` prop으로 기본 스타일을 안전하게 오버라이드 가능
- 기본 `rounded`는 size에 따라 자동 적용, `rounded` prop으로 커스텀 가능

```tsx
interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  children: ReactNode;
  variant?: 'primary' | 'secondary' | 'ghost';
  size?: 'sm' | 'md' | 'lg';
  rounded?: 'sm' | 'md' | 'lg' | 'xl' | 'full' | 'none' | 'r-md' | 'r-lg' | 'r-xl';
  fullWidth?: boolean;
}
```

<br/>

**전체 페이지 button 태그 대체**
- 22개 파일의 인라인 `<button>` 태그를 공용 `<Button>` 컴포넌트로 교체
- 그라디언트 등 context-specific 스타일은 `className` 오버라이드로 처리

<br />

## 📸 참고 사항

아코디언 토글, 탭 스위처, 카드형 버튼, 토글 스위치, 캐러셀로 사용되는 몇몇 컴포넌트 이름에 button을 포함하고 있는 것들이 있었는데 이런 것들은 공용 Button으로 교체하기 보다는, 추후 페이지 별 리펙토링 시작 할 때 용도에 맞는 컴포넌트명으로 변경할 예정입니다.

<br />

### Button 컴포넌트 사용 예시 
```tsx
// 기본
<Button>배틀 생성하기</Button>

// variant
<Button variant="secondary">돌아가기</Button>
<Button variant="ghost">취소</Button>

// size
<Button size="sm">복사</Button>
<Button size="lg">시작하기</Button>

// fullWidth
<Button fullWidth size="lg">시작하기</Button>

// rounded 커스텀 (BookmarkButton)
<Button rounded="r-md" size="sm" className="bg-gradient-to-r from-[#FF6900] to-[#FF8533]">
  문제 설명
</Button>

// 아이콘 + 텍스트
<Button size="lg">
  <Home className="w-5 h-5" />
  홈으로 돌아가기
</Button>

// className 오버라이드 (그라디언트)
<Button className="bg-gradient-to-r from-[#FF6900] to-[#FB2C36]">
  시작하기
</Button>

// ref 전달 (SoundSettingsButton)
<Button ref={soundButtonRef} variant="secondary" className="w-11 h-11 p-0 rounded-xl">
  <SoundIcon className="w-6 h-6" />
</Button>

// disabled
<Button disabled={!canSubmit}>제출</Button>
```
