### PR TITLE
[Refactor] 배틀 페이지 컴포넌트/훅 분리 및 응집도 개선

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "WebSearch",
+      "WebFetch(domain:frontend-fundamentals.com)"
+    ]
+  }
+}

--- a/frontend/src/pages/battlePage/components/BattleMainContent.tsx
+++ b/frontend/src/pages/battlePage/components/BattleMainContent.tsx
@@ -1,0 +1,63 @@
+import CodeSection from './codeview/CodeSection';
+import ChatSection from './chatting/ChatSection';
+import DiscussionVote from './discussion/DiscussionVote';
+import DiscussionInput from './discussion/DiscussionInput';
+
+interface BattleMainContentProps {
+  viewMode: 'split' | 'tab';
+  onViewChange: (mode: 'split' | 'tab') => void;
+  isSidebarOpen: boolean;
+  language: string;
+  codeA: string;
+  codeB: string;
+  onVote: (discussionId: number) => void;
+  shouldShowInput: boolean;
+  phase: string | undefined;
+  onDiscussionSubmit: (content: string) => void;
+}
+
+export default function BattleMainContent({
+  viewMode,
+  onViewChange,
+  isSidebarOpen,
+  language,
+  codeA,
+  codeB,
+  onVote,
+  shouldShowInput,
+  phase,
+  onDiscussionSubmit
+}: BattleMainContentProps) {
+  return (
+    <>
+      <main className="main-width-closed">
+        <div className="flex gap-2 py-4">
+          <div className="flex-1 min-w-0">
+            <CodeSection
+              onViewChange={onViewChange}
+              currentView={viewMode}
+              language={language}
+              codeA={codeA}
+              codeB={codeB}
+            />
+          </div>
+          <aside
+            className={`flex flex-col gap-4 transition-all duration-300 ${isSidebarOpen ? 'lounge-width-open' : 'lounge-width-closed'}`}
+          >
+            <DiscussionVote onVote={onVote} />
+            <ChatSection />
+          </aside>
+        </div>
+      </main>
+      <div
+        className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 z-5 px-4 pb-4 transition-all duration-500 ease-out ${
+          shouldShowInput ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0 pointer-events-none'
+        }`}
+      >
+        <div className="discussion-input-width">
+          {shouldShowInput && <DiscussionInput key={phase} onSubmit={onDiscussionSubmit} />}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/battlePage/components/BattleMainContent.tsx
+++ b/frontend/src/pages/battlePage/components/BattleMainContent.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from '../stores/battleStore';
 import { isInputDisabled } from '../utils/battlePhase';
@@ -8,20 +9,13 @@ import DiscussionVote from './discussion/DiscussionVote';
 import DiscussionInput from './discussion/DiscussionInput';
 
 interface BattleMainContentProps {
-  viewMode: 'split' | 'tab';
-  onViewChange: (mode: 'split' | 'tab') => void;
   isSidebarOpen: boolean;
   onVote: (discussionId: number) => void;
   onDiscussionSubmit: (content: string) => void;
 }
 
-export default function BattleMainContent({
-  viewMode,
-  onViewChange,
-  isSidebarOpen,
-  onVote,
-  onDiscussionSubmit
-}: BattleMainContentProps) {
+export default function BattleMainContent({ isSidebarOpen, onVote, onDiscussionSubmit }: BattleMainContentProps) {
+  const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const { id: battleId } = useParams<{ id: string }>();
   const { battleInfo: { language, aCode: codeA, bCode: codeB } = {} } = useGetBattleInfo(battleId!);
   const team = useBattleStore(selectSelectedTeam);
@@ -34,7 +28,7 @@ export default function BattleMainContent({
         <div className="flex gap-2 py-4">
           <div className="flex-1 min-w-0">
             <CodeSection
-              onViewChange={onViewChange}
+              onViewChange={setViewMode}
               currentView={viewMode}
               language={language ?? 'javascript'}
               codeA={codeA ?? ''}

--- a/frontend/src/pages/battlePage/components/BattleMainContent.tsx
+++ b/frontend/src/pages/battlePage/components/BattleMainContent.tsx
@@ -1,5 +1,7 @@
+import { useParams } from 'react-router-dom';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from '../stores/battleStore';
 import { isInputDisabled } from '../utils/battlePhase';
+import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
 import CodeSection from './codeview/CodeSection';
 import ChatSection from './chatting/ChatSection';
 import DiscussionVote from './discussion/DiscussionVote';
@@ -9,9 +11,6 @@ interface BattleMainContentProps {
   viewMode: 'split' | 'tab';
   onViewChange: (mode: 'split' | 'tab') => void;
   isSidebarOpen: boolean;
-  language: string;
-  codeA: string;
-  codeB: string;
   onVote: (discussionId: number) => void;
   onDiscussionSubmit: (content: string) => void;
 }
@@ -20,12 +19,11 @@ export default function BattleMainContent({
   viewMode,
   onViewChange,
   isSidebarOpen,
-  language,
-  codeA,
-  codeB,
   onVote,
   onDiscussionSubmit
 }: BattleMainContentProps) {
+  const { id: battleId } = useParams<{ id: string }>();
+  const { battleInfo: { language, aCode: codeA, bCode: codeB } = {} } = useGetBattleInfo(battleId!);
   const team = useBattleStore(selectSelectedTeam);
   const phase = useBattleStore(selectBattleProgress)?.phase;
   const shouldShowInput = !isInputDisabled(team, phase);
@@ -38,9 +36,9 @@ export default function BattleMainContent({
             <CodeSection
               onViewChange={onViewChange}
               currentView={viewMode}
-              language={language}
-              codeA={codeA}
-              codeB={codeB}
+              language={language ?? 'javascript'}
+              codeA={codeA ?? ''}
+              codeB={codeB ?? ''}
             />
           </div>
           <aside

--- a/frontend/src/pages/battlePage/components/BattleMainContent.tsx
+++ b/frontend/src/pages/battlePage/components/BattleMainContent.tsx
@@ -1,3 +1,5 @@
+import { useBattleStore, selectBattleProgress, selectSelectedTeam } from '../stores/battleStore';
+import { isInputDisabled } from '../utils/battlePhase';
 import CodeSection from './codeview/CodeSection';
 import ChatSection from './chatting/ChatSection';
 import DiscussionVote from './discussion/DiscussionVote';
@@ -11,8 +13,6 @@ interface BattleMainContentProps {
   codeA: string;
   codeB: string;
   onVote: (discussionId: number) => void;
-  shouldShowInput: boolean;
-  phase: string | undefined;
   onDiscussionSubmit: (content: string) => void;
 }
 
@@ -24,10 +24,12 @@ export default function BattleMainContent({
   codeA,
   codeB,
   onVote,
-  shouldShowInput,
-  phase,
   onDiscussionSubmit
 }: BattleMainContentProps) {
+  const team = useBattleStore(selectSelectedTeam);
+  const phase = useBattleStore(selectBattleProgress)?.phase;
+  const shouldShowInput = !isInputDisabled(team, phase);
+
   return (
     <>
       <main className="main-width-closed">

--- a/frontend/src/pages/battlePage/components/header/BattleTopBar.tsx
+++ b/frontend/src/pages/battlePage/components/header/BattleTopBar.tsx
@@ -1,6 +1,5 @@
 import { useParams } from 'react-router-dom';
 import Button from '@/commons/components/Button';
-import { useBattleStore, selectBattleProgress } from '../../stores/battleStore';
 import SoundSettingsButton, { type BGMOption } from './SoundSettingsButton';
 import BattleHeader from './index';
 import InviteLinkButton from '@/pages/battleCreatePage/components/InviteLinkButton';
@@ -14,18 +13,13 @@ interface BattleTopBarProps {
 
 export default function BattleTopBar({ onLeave, bgmOptions }: BattleTopBarProps) {
   const { id: battleId } = useParams<{ id: string }>();
-  const { battleInfo: { inviteCode } = {} } = useGetBattleInfo(battleId!);
-  const battleProgress = useBattleStore(selectBattleProgress);
+  const {
+    battleInfo: { inviteCode }
+  } = useGetBattleInfo(battleId!);
   const { isSkipEnabled, toggleSkip, totalSkips } = usePhaseSkip();
 
-  const isActive =
-    battleProgress &&
-    (battleProgress.phase as string) !== 'PENDING' &&
-    battleProgress.expiredAt != null &&
-    battleProgress.startedAt;
-
   return (
-    <div className={`transition-all duration-300 main-width-closed ${isActive}`}>
+    <div className="transition-all duration-300 main-width-closed">
       <div className="flex items-center justify-between gap-4 mt-10 mb-8">
         <Button
           variant="secondary"

--- a/frontend/src/pages/battlePage/components/header/BattleTopBar.tsx
+++ b/frontend/src/pages/battlePage/components/header/BattleTopBar.tsx
@@ -3,25 +3,17 @@ import { useBattleStore, selectBattleProgress } from '../../stores/battleStore';
 import SoundSettingsButton, { type BGMOption } from './SoundSettingsButton';
 import BattleHeader from './index';
 import InviteLinkButton from '@/pages/battleCreatePage/components/InviteLinkButton';
+import { usePhaseSkip } from '../../hooks/usePhaseSkip';
 
 interface BattleTopBarProps {
   onLeave: () => void;
   inviteCode?: string;
   bgmOptions: BGMOption[];
-  isSkipEnabled: boolean;
-  toggleSkip: () => void;
-  totalSkips: number;
 }
 
-export default function BattleTopBar({
-  onLeave,
-  inviteCode,
-  bgmOptions,
-  isSkipEnabled,
-  toggleSkip,
-  totalSkips
-}: BattleTopBarProps) {
+export default function BattleTopBar({ onLeave, inviteCode, bgmOptions }: BattleTopBarProps) {
   const battleProgress = useBattleStore(selectBattleProgress);
+  const { isSkipEnabled, toggleSkip, totalSkips } = usePhaseSkip();
 
   const isActive =
     battleProgress &&

--- a/frontend/src/pages/battlePage/components/header/BattleTopBar.tsx
+++ b/frontend/src/pages/battlePage/components/header/BattleTopBar.tsx
@@ -1,17 +1,20 @@
+import { useParams } from 'react-router-dom';
 import Button from '@/commons/components/Button';
 import { useBattleStore, selectBattleProgress } from '../../stores/battleStore';
 import SoundSettingsButton, { type BGMOption } from './SoundSettingsButton';
 import BattleHeader from './index';
 import InviteLinkButton from '@/pages/battleCreatePage/components/InviteLinkButton';
 import { usePhaseSkip } from '../../hooks/usePhaseSkip';
+import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
 
 interface BattleTopBarProps {
   onLeave: () => void;
-  inviteCode?: string;
   bgmOptions: BGMOption[];
 }
 
-export default function BattleTopBar({ onLeave, inviteCode, bgmOptions }: BattleTopBarProps) {
+export default function BattleTopBar({ onLeave, bgmOptions }: BattleTopBarProps) {
+  const { id: battleId } = useParams<{ id: string }>();
+  const { battleInfo: { inviteCode } = {} } = useGetBattleInfo(battleId!);
   const battleProgress = useBattleStore(selectBattleProgress);
   const { isSkipEnabled, toggleSkip, totalSkips } = usePhaseSkip();
 

--- a/frontend/src/pages/battlePage/components/header/BattleTopBar.tsx
+++ b/frontend/src/pages/battlePage/components/header/BattleTopBar.tsx
@@ -1,0 +1,53 @@
+import Button from '@/commons/components/Button';
+import { useBattleStore, selectBattleProgress } from '../../stores/battleStore';
+import SoundSettingsButton, { type BGMOption } from './SoundSettingsButton';
+import BattleHeader from './index';
+import InviteLinkButton from '@/pages/battleCreatePage/components/InviteLinkButton';
+
+interface BattleTopBarProps {
+  onLeave: () => void;
+  inviteCode?: string;
+  bgmOptions: BGMOption[];
+  isSkipEnabled: boolean;
+  toggleSkip: () => void;
+  totalSkips: number;
+}
+
+export default function BattleTopBar({
+  onLeave,
+  inviteCode,
+  bgmOptions,
+  isSkipEnabled,
+  toggleSkip,
+  totalSkips
+}: BattleTopBarProps) {
+  const battleProgress = useBattleStore(selectBattleProgress);
+
+  const isActive =
+    battleProgress &&
+    (battleProgress.phase as string) !== 'PENDING' &&
+    battleProgress.expiredAt != null &&
+    battleProgress.startedAt;
+
+  return (
+    <div className={`transition-all duration-300 main-width-closed ${isActive}`}>
+      <div className="flex items-center justify-between gap-4 mt-10 mb-8">
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onLeave}
+          className="shrink-0 w-[100px] sm:w-auto sm:min-w-[100px]"
+        >
+          ← 돌아가기
+        </Button>
+        <div className="shrink-0 flex items-center gap-2">
+          {inviteCode && <InviteLinkButton inviteCode={inviteCode} />}
+        </div>
+      </div>
+      <div className="flex items-center justify-between">
+        <SoundSettingsButton bgmOptions={bgmOptions} />
+        <BattleHeader isSkipEnabled={isSkipEnabled} toggleSkip={toggleSkip} totalSkips={totalSkips} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/battlePage/components/modals/BattleModals.tsx
+++ b/frontend/src/pages/battlePage/components/modals/BattleModals.tsx
@@ -1,6 +1,8 @@
+import { useParams } from 'react-router-dom';
 import type { Team } from '@/commons/types/battle';
 import { useTeamVoteResult } from '../../hooks/useTeamVoteResult';
 import { usePhaseSkip } from '../../hooks/usePhaseSkip';
+import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
 import TeamChangeModal from './TeamChangeModal';
 import ConnectionErrorModal from './ConnectionErrorModal';
 import DiscussionModal from '../effects/DiscussionModal';
@@ -22,7 +24,6 @@ interface RoundModal {
 }
 
 interface BattleModalsProps {
-  battleTopics: string[];
   effectModal: EffectModal;
   onHideEffect: () => void;
   roundModal: RoundModal;
@@ -33,7 +34,6 @@ interface BattleModalsProps {
 }
 
 export default function BattleModals({
-  battleTopics,
   effectModal,
   onHideEffect,
   roundModal,
@@ -42,6 +42,8 @@ export default function BattleModals({
   isTeamChangeModalOpen,
   onCloseTeamChangeModal
 }: BattleModalsProps) {
+  const { id: battleId } = useParams<{ id: string }>();
+  const { battleInfo: { topics: battleTopics } = {} } = useGetBattleInfo(battleId!);
   const { voteResult, isModalOpen: isVoteResultModalOpen, closeModal: closeVoteResultModal } = useTeamVoteResult();
   const { isModalOpen: isPhaseSkipModalOpen, closeModal: closeSkipModal } = usePhaseSkip();
 
@@ -49,7 +51,7 @@ export default function BattleModals({
     <>
       <TeamChangeModal
         isOpen={isTeamChangeModalOpen}
-        topics={battleTopics}
+        topics={battleTopics ?? []}
         handleTeamChange={handleTeamChange}
         onClose={onCloseTeamChangeModal}
       />

--- a/frontend/src/pages/battlePage/components/modals/BattleModals.tsx
+++ b/frontend/src/pages/battlePage/components/modals/BattleModals.tsx
@@ -1,8 +1,9 @@
 import { useParams } from 'react-router-dom';
-import type { Team } from '@/commons/types/battle';
 import { useTeamVoteResult } from '../../hooks/useTeamVoteResult';
 import { usePhaseSkip } from '../../hooks/usePhaseSkip';
 import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
+import type { EffectModalState } from '../../hooks/useEffectModal';
+import type { RoundUpdateState } from '../../hooks/useRoundUpdateModal';
 import TeamChangeModal from './TeamChangeModal';
 import ConnectionErrorModal from './ConnectionErrorModal';
 import DiscussionModal from '../effects/DiscussionModal';
@@ -10,23 +11,10 @@ import SkipModal from '../effects/SkipModal';
 import TeamVoteResultModal from '../effects/TeamVoteResultModal';
 import RoundUpdateModal from '../effects/RoundUpdateModal';
 
-interface EffectModal {
-  isOpen: boolean;
-  team: Team;
-  content: string;
-  type: 'attack' | 'defense';
-}
-
-interface RoundModal {
-  isPending: boolean;
-  round: number;
-  topic: string;
-}
-
 interface BattleModalsProps {
-  effectModal: EffectModal;
+  effectModal: EffectModalState;
   onHideEffect: () => void;
-  roundModal: RoundModal;
+  roundModal: RoundUpdateState;
   onHideRoundEffect: () => void;
   handleTeamChange: (team: 'A' | 'B' | 'NONE') => void;
   isTeamChangeModalOpen: boolean;

--- a/frontend/src/pages/battlePage/components/modals/BattleModals.tsx
+++ b/frontend/src/pages/battlePage/components/modals/BattleModals.tsx
@@ -1,0 +1,91 @@
+import type { Team } from '@/commons/types/battle';
+import { useTeamVoteResult } from '../../hooks/useTeamVoteResult';
+import { usePhaseSkip } from '../../hooks/usePhaseSkip';
+import TeamChangeModal from './TeamChangeModal';
+import ConnectionErrorModal from './ConnectionErrorModal';
+import DiscussionModal from '../effects/DiscussionModal';
+import SkipModal from '../effects/SkipModal';
+import TeamVoteResultModal from '../effects/TeamVoteResultModal';
+import RoundUpdateModal from '../effects/RoundUpdateModal';
+
+interface EffectModal {
+  isOpen: boolean;
+  team: Team;
+  content: string;
+  type: 'attack' | 'defense';
+}
+
+interface RoundModal {
+  isPending: boolean;
+  round: number;
+  topic: string;
+}
+
+interface BattleModalsProps {
+  battleTopics: string[];
+  effectModal: EffectModal;
+  onHideEffect: () => void;
+  roundModal: RoundModal;
+  onHideRoundEffect: () => void;
+  handleTeamChange: (team: 'A' | 'B' | 'NONE') => void;
+  isTeamChangeModalOpen: boolean;
+  onCloseTeamChangeModal: () => void;
+}
+
+export default function BattleModals({
+  battleTopics,
+  effectModal,
+  onHideEffect,
+  roundModal,
+  onHideRoundEffect,
+  handleTeamChange,
+  isTeamChangeModalOpen,
+  onCloseTeamChangeModal
+}: BattleModalsProps) {
+  const { voteResult, isModalOpen: isVoteResultModalOpen, closeModal: closeVoteResultModal } = useTeamVoteResult();
+  const { isModalOpen: isPhaseSkipModalOpen, closeModal: closeSkipModal } = usePhaseSkip();
+
+  return (
+    <>
+      <TeamChangeModal
+        isOpen={isTeamChangeModalOpen}
+        topics={battleTopics}
+        handleTeamChange={handleTeamChange}
+        onClose={onCloseTeamChangeModal}
+      />
+
+      {!isPhaseSkipModalOpen && effectModal.isOpen && effectModal.team !== 'NONE' && (
+        <DiscussionModal
+          isOpen={effectModal.isOpen}
+          team={effectModal.team}
+          content={effectModal.content}
+          type={effectModal.type}
+          onClose={onHideEffect}
+        />
+      )}
+
+      {isPhaseSkipModalOpen && <SkipModal isOpen={true} onClose={closeSkipModal} />}
+
+      {isVoteResultModalOpen && voteResult && (
+        <TeamVoteResultModal
+          isOpen={isVoteResultModalOpen}
+          round={voteResult.round}
+          teamACount={voteResult.after.teamA}
+          teamBCount={voteResult.after.teamB}
+          teamABefore={voteResult.before.teamA}
+          teamBBefore={voteResult.before.teamB}
+          teamAPercentage={(voteResult.after.teamA / (voteResult.after.teamA + voteResult.after.teamB)) * 100}
+          teamBPercentage={(voteResult.after.teamB / (voteResult.after.teamA + voteResult.after.teamB)) * 100}
+          leadingTeam={voteResult.dominantTeam === 'NONE' ? null : voteResult.dominantTeam}
+          onClose={closeVoteResultModal}
+        />
+      )}
+
+      {roundModal.isPending && !isVoteResultModalOpen && (
+        <RoundUpdateModal isOpen={true} round={roundModal.round} topic={roundModal.topic} onClose={onHideRoundEffect} />
+      )}
+
+      <ConnectionErrorModal />
+    </>
+  );
+}

--- a/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
+++ b/frontend/src/pages/battlePage/components/progressBoard/ProgressBoard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { selectBattleProgress, useBattleStore } from '../../stores/battleStore';
+import { isBattleActive } from '../../utils/battlePhase';
 import { CollapseButton } from './CollapseButton';
 import { ExpandButton } from './ExpandButton';
 import { ProgressBar } from './ProgressBar';
@@ -9,15 +10,9 @@ export default function BattleProgressBoard() {
   const battleProgress = useBattleStore(selectBattleProgress);
   const [collapsed, setCollapsed] = useState(false);
 
-  const shouldShow =
-    battleProgress &&
-    (battleProgress.phase as string) !== 'PENDING' &&
-    battleProgress.expiredAt != null &&
-    battleProgress.startedAt != null;
-
   return (
     <div className="fixed top-0 left-0 right-0 z-10 flex justify-center pointer-events-none">
-      {shouldShow && (
+      {isBattleActive(battleProgress) && (
         <div
           data-tutorial="progress-board"
           className={`

--- a/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/BookmarkButton.tsx
@@ -1,19 +1,18 @@
+import { useParams } from 'react-router-dom';
 import Icon from '@/commons/components/Icon';
 import Button from '@/commons/components/Button';
+import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
 
 interface BookmarkButtonProps {
   onOpen: (tab: 'info' | 'timeline' | 'reference') => void;
   isOpen: boolean;
   highlight?: boolean;
-  hasReferenceData?: boolean;
 }
 
-export default function BookmarkButton({
-  onOpen,
-  isOpen,
-  highlight = false,
-  hasReferenceData = false
-}: BookmarkButtonProps) {
+export default function BookmarkButton({ onOpen, isOpen, highlight = false }: BookmarkButtonProps) {
+  const { id: battleId } = useParams<{ id: string }>();
+  const { battleInfo } = useGetBattleInfo(battleId!);
+  const hasReferenceData = !!battleInfo?.referenceData;
   if (isOpen) return null;
 
   return (
@@ -21,7 +20,6 @@ export default function BookmarkButton({
       className={`fixed left-0 top-1/2 -translate-y-1/2 flex flex-col gap-2 ${highlight ? 'z-[120]' : 'z-30'}`}
       data-tutorial="sidebar-buttons"
     >
-      {/* 문제 설명 */}
       <Button
         onClick={() => onOpen('info')}
         rounded="r-md"
@@ -33,7 +31,6 @@ export default function BookmarkButton({
         <span className="text-sm">문제 설명</span>
       </Button>
 
-      {/* 타임라인 */}
       <Button
         onClick={() => onOpen('timeline')}
         rounded="r-md"
@@ -45,7 +42,6 @@ export default function BookmarkButton({
         <span className="text-sm">타임라인</span>
       </Button>
 
-      {/* 참고 자료 */}
       {hasReferenceData && (
         <Button
           onClick={() => onOpen('reference')}

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarTrigger.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarTrigger.tsx
@@ -2,9 +2,10 @@ import { useParams } from 'react-router-dom';
 import Icon from '@/commons/components/Icon';
 import Button from '@/commons/components/Button';
 import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
+import type { SidebarTab } from './SidebarHeader';
 
 interface SidebarTriggerProps {
-  onOpen: (tab: 'info' | 'timeline' | 'reference') => void;
+  onOpen: (tab: SidebarTab) => void;
   isOpen: boolean;
   highlight?: boolean;
 }

--- a/frontend/src/pages/battlePage/components/sidebar/SidebarTrigger.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/SidebarTrigger.tsx
@@ -3,13 +3,13 @@ import Icon from '@/commons/components/Icon';
 import Button from '@/commons/components/Button';
 import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
 
-interface BookmarkButtonProps {
+interface SidebarTriggerProps {
   onOpen: (tab: 'info' | 'timeline' | 'reference') => void;
   isOpen: boolean;
   highlight?: boolean;
 }
 
-export default function BookmarkButton({ onOpen, isOpen, highlight = false }: BookmarkButtonProps) {
+export default function SidebarTrigger({ onOpen, isOpen, highlight = false }: SidebarTriggerProps) {
   const { id: battleId } = useParams<{ id: string }>();
   const { battleInfo } = useGetBattleInfo(battleId!);
   const hasReferenceData = !!battleInfo?.referenceData;

--- a/frontend/src/pages/battlePage/components/sidebar/index.tsx
+++ b/frontend/src/pages/battlePage/components/sidebar/index.tsx
@@ -1,21 +1,16 @@
 import { useState, useRef, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import SidebarHeader, { type SidebarTab } from './SidebarHeader';
 import BattleInfoSection from './BattleInfoSection';
 import ReferenceSection from './ReferenceSection';
 import { useResize } from '../../hooks/useResize';
 import SidebarTimelineSection from './SidebarTimelineSection';
-import type { BattleReferenceData } from '@/commons/types/battle';
+import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
 
 interface BattleSidebarProps {
   isOpen: boolean;
   onClose: () => void;
-  title: string;
-  description: string;
-  language: string;
-  category: string;
-  topics: string[];
   raiseZIndex?: boolean;
-  referenceData?: BattleReferenceData | null;
   activeTab: SidebarTab;
   onActiveTabChange: (tab: SidebarTab) => void;
 }
@@ -23,16 +18,13 @@ interface BattleSidebarProps {
 export default function BattleSidebar({
   isOpen,
   onClose,
-  title,
-  description,
-  language,
-  category,
-  topics,
   raiseZIndex = false,
-  referenceData,
   activeTab = 'info',
   onActiveTabChange
 }: BattleSidebarProps) {
+  const { id: battleId } = useParams<{ id: string }>();
+  const { battleInfo } = useGetBattleInfo(battleId!);
+  const { title, description, language, category, topics, referenceData } = battleInfo ?? {};
   const { width, isResizing, setIsResizing } = useResize({
     initialWidth: 400
   });
@@ -73,9 +65,16 @@ export default function BattleSidebar({
   const renderContent = () => {
     switch (activeTab) {
       case 'info':
-        return <BattleInfoSection title={title} description={description} language={language} category={category} />;
+        return (
+          <BattleInfoSection
+            title={title ?? ''}
+            description={description ?? ''}
+            language={language ?? 'javascript'}
+            category={category ?? 'ALGORITHM'}
+          />
+        );
       case 'timeline':
-        return <SidebarTimelineSection isWide={isWideLayout} topics={topics} />;
+        return <SidebarTimelineSection isWide={isWideLayout} topics={topics ?? []} />;
       case 'reference':
         return referenceData ? <ReferenceSection referenceData={referenceData} /> : null;
       default:

--- a/frontend/src/pages/battlePage/hooks/useBattle.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattle.ts
@@ -8,14 +8,13 @@ import { useBattleDiscussions } from './useBattleDiscussions';
 import { useBattleTimeline } from './useBattleTimeline';
 import { useBattleTeam } from './useBattleTeam';
 import { useAuthStore } from '@/commons/stores/authStore';
+import useModal from '@/commons/hooks/useModal';
 
 interface UseBattle {
   battleId?: string;
-  onOpenTeamChangeModal: () => void;
-  onCloseTeamChangeModal: () => void;
 }
 
-export function useBattle({ battleId, onOpenTeamChangeModal, onCloseTeamChangeModal }: UseBattle) {
+export function useBattle({ battleId }: UseBattle) {
   const location = useLocation();
   const selectedTeamFromState = (location.state as { selectedTeam?: 'A' | 'B' | 'NONE' })?.selectedTeam;
   const user = useAuthStore((state) => state.user);
@@ -40,6 +39,12 @@ export function useBattle({ battleId, onOpenTeamChangeModal, onCloseTeamChangeMo
     });
   }, [battleId, selectedTeamFromState, user]);
 
+  const {
+    isOpen: isTeamChangeModalOpen,
+    openModal: openTeamChangeModal,
+    closeModal: closeTeamChangeModal
+  } = useModal(false);
+
   useBattleSocket();
   useBattleSocketErrorHandling();
 
@@ -47,8 +52,8 @@ export function useBattle({ battleId, onOpenTeamChangeModal, onCloseTeamChangeMo
   const { roundModal, hideRoundEffect } = useBattleProgress();
   const { effectModal, hideEffect } = useBattleTimeline();
   const { handleTeamChange } = useBattleTeam({
-    onOpenTeamChangeModal,
-    onCloseTeamChangeModal
+    onOpenTeamChangeModal: openTeamChangeModal,
+    onCloseTeamChangeModal: closeTeamChangeModal
   });
 
   return {
@@ -58,6 +63,8 @@ export function useBattle({ battleId, onOpenTeamChangeModal, onCloseTeamChangeMo
     effectModal,
     hideEffect,
     hideRoundEffect,
-    handleTeamChange
+    handleTeamChange,
+    isTeamChangeModalOpen,
+    closeTeamChangeModal
   };
 }

--- a/frontend/src/pages/battlePage/hooks/useBattleLeave.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleLeave.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { soundManager } from '@/commons/utils/soundManager';
+import { useBattleStore } from '../stores/battleStore';
+import { selectUser, useAuthStore } from '@/commons/stores/authStore';
+
+export function useBattleLeave() {
+  const navigate = useNavigate();
+  const user = useAuthStore(selectUser);
+  const leaveBattle = useBattleStore((s) => s.leaveBattle);
+  const hasLeftRef = useRef(false);
+
+  const safeLeaveBattle = useCallback(() => {
+    if (hasLeftRef.current) return;
+    hasLeftRef.current = true;
+    leaveBattle();
+  }, [leaveBattle]);
+
+  useEffect(() => {
+    const handlePageHide = () => {
+      soundManager.stopAllBGM();
+      safeLeaveBattle();
+    };
+
+    const handleBeforeUnload = () => {
+      soundManager.stopAllBGM();
+      safeLeaveBattle();
+    };
+
+    window.addEventListener('pagehide', handlePageHide);
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('pagehide', handlePageHide);
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      soundManager.stopAllBGM();
+      safeLeaveBattle();
+    };
+  }, [safeLeaveBattle]);
+
+  const handleLeaveBattle = useCallback(() => {
+    if (!user) return;
+    navigate('/main');
+    safeLeaveBattle();
+  }, [user, navigate, safeLeaveBattle]);
+
+  return { handleLeaveBattle };
+}

--- a/frontend/src/pages/battlePage/hooks/useBattleSound.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSound.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { soundManager } from '@/commons/utils/soundManager';
+
+export const BGM_OPTIONS = [
+  { key: 'lofi', label: 'LoFi', src: '/sounds/lofi.mp3' },
+  { key: 'chill', label: 'Chill', src: '/sounds/chill.mp3' },
+  { key: 'groove', label: 'Groove', src: '/sounds/groove.mp3' },
+  { key: 'hiphop', label: 'Hip Hop', src: '/sounds/hiphop.mp3' },
+  { key: 'jazz', label: 'Jazz', src: '/sounds/jazz.mp3' },
+  { key: 'rock', label: 'Rock', src: '/sounds/rock.mp3' },
+  { key: 'romantic', label: 'Romantic', src: '/sounds/romantic.mp3' }
+];
+
+export default function useBattleSound() {
+  useEffect(() => {
+    soundManager.preload('timerWarning', '/sounds/timerSound.wav');
+    soundManager.preload('notificationPing', '/sounds/notificationPing.mp3');
+    soundManager.preload('swoosh', '/sounds/swoosh.mp3');
+    soundManager.preload('swordSlash', '/sounds/swordSlash.mp3');
+    soundManager.preload('fanfare', '/sounds/fanfare.mp3');
+    soundManager.preload('click', '/sounds/click.mp3');
+    soundManager.preload('click2', '/sounds/click2.mp3');
+
+    BGM_OPTIONS.forEach((bgm) => {
+      soundManager.preloadBGM(bgm.key, bgm.src);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!soundManager.getCurrentBGM()) {
+      soundManager.playBGM(BGM_OPTIONS[0].key);
+    }
+  }, []);
+
+  return { bgmOptions: BGM_OPTIONS };
+}

--- a/frontend/src/pages/battlePage/hooks/useEffectModal.ts
+++ b/frontend/src/pages/battlePage/hooks/useEffectModal.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import type { Team } from '@/commons/types/battle';
 import { soundManager } from '@/commons/utils/soundManager';
 
-interface EffectModalState {
+export interface EffectModalState {
   isOpen: boolean;
   team: Team;
   content: string;

--- a/frontend/src/pages/battlePage/hooks/useRoundUpdateModal.ts
+++ b/frontend/src/pages/battlePage/hooks/useRoundUpdateModal.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { soundManager } from '@/commons/utils/soundManager';
 
 // vote result modal이 먼저 떠야하기에 isPending으로 관리
-interface RoundUpdateState {
+export interface RoundUpdateState {
   isPending: boolean;
   round: number;
   topic: string;

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -5,6 +5,7 @@ import { useBattle } from './hooks/useBattle';
 import { useTeamVoteResult } from './hooks/useTeamVoteResult';
 import useModal from '@/commons/hooks/useModal';
 import { soundManager } from '@/commons/utils/soundManager';
+import useBattleSound from './hooks/useBattleSound';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from './stores/battleStore';
 import { isInputDisabled } from './utils/battlePhase';
 import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
@@ -42,15 +43,7 @@ export default function BattlePage() {
   const battleProgress = useBattleStore(selectBattleProgress);
   const hasLeftRef = useRef(false);
 
-  const BGM_OPTIONS = [
-    { key: 'lofi', label: 'LoFi', src: '/sounds/lofi.mp3' },
-    { key: 'chill', label: 'Chill', src: '/sounds/chill.mp3' },
-    { key: 'groove', label: 'Groove', src: '/sounds/groove.mp3' },
-    { key: 'hiphop', label: 'Hip Hop', src: '/sounds/hiphop.mp3' },
-    { key: 'jazz', label: 'Jazz', src: '/sounds/jazz.mp3' },
-    { key: 'rock', label: 'Rock', src: '/sounds/rock.mp3' },
-    { key: 'romantic', label: 'Romantic', src: '/sounds/romantic.mp3' }
-  ];
+  const { bgmOptions } = useBattleSound();
 
   const safeLeaveBattle = useCallback(() => {
     if (hasLeftRef.current) return;
@@ -79,28 +72,6 @@ export default function BattlePage() {
       safeLeaveBattle();
     };
   }, [safeLeaveBattle]);
-
-  // 사운드 초기화
-  useEffect(() => {
-    soundManager.preload('timerWarning', '/sounds/timerSound.wav');
-    soundManager.preload('notificationPing', '/sounds/notificationPing.mp3');
-    soundManager.preload('swoosh', '/sounds/swoosh.mp3');
-    soundManager.preload('swordSlash', '/sounds/swordSlash.mp3');
-    soundManager.preload('fanfare', '/sounds/fanfare.mp3');
-    soundManager.preload('click', '/sounds/click.mp3');
-    soundManager.preload('click2', '/sounds/click2.mp3');
-
-    BGM_OPTIONS.forEach((bgm) => {
-      soundManager.preloadBGM(bgm.key, bgm.src);
-    });
-  }, []);
-
-  // 배틀 페이지 진입 시 BGM 자동 재생
-  useEffect(() => {
-    if (!soundManager.getCurrentBGM()) {
-      soundManager.playBGM(BGM_OPTIONS[0].key);
-    }
-  }, []);
 
   const {
     isOpen: isTeamChangeModalOpen,
@@ -188,7 +159,7 @@ export default function BattlePage() {
             </div>
           </div>
           <div className="flex items-center justify-between">
-            <SoundSettingsButton bgmOptions={BGM_OPTIONS} />
+            <SoundSettingsButton bgmOptions={bgmOptions} />
             <BattleHeader isSkipEnabled={isSkipEnabled} toggleSkip={toggleSkip} totalSkips={totalSkips} />
           </div>
         </div>

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import Button from '@/commons/components/Button';
 import { useParams } from 'react-router-dom';
 import { useBattle } from './hooks/useBattle';
 import { useTeamVoteResult } from './hooks/useTeamVoteResult';
@@ -10,7 +9,7 @@ import { useBattleStore, selectBattleProgress, selectSelectedTeam } from './stor
 import { isInputDisabled } from './utils/battlePhase';
 import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
 
-import BattleHeader from './components/header';
+import BattleTopBar from './components/header/BattleTopBar';
 import CodeSection from './components/codeview/CodeSection';
 import ChatSection from './components/chatting/ChatSection';
 import DiscussionInput from './components/discussion/DiscussionInput';
@@ -23,10 +22,8 @@ import DiscussionModal from './components/effects/DiscussionModal';
 import BattleProgressBoard from './components/progressBoard/ProgressBoard';
 import TeamVoteResultModal from './components/effects/TeamVoteResultModal';
 import RoundUpdateModal from './components/effects/RoundUpdateModal';
-import SoundSettingsButton from './components/header/SoundSettingsButton';
 import SkipModal from './components/effects/SkipModal';
 import { usePhaseSkip } from './hooks/usePhaseSkip';
-import InviteLinkButton from '@/pages/battleCreatePage/components/InviteLinkButton';
 
 type Tab = 'info' | 'timeline' | 'reference';
 
@@ -71,7 +68,6 @@ export default function BattlePage() {
 
   return (
     <div className="text-white relative">
-      {/* 책갈피 버튼 */}
       <BookmarkButton
         onOpen={(tab) => {
           setActiveSidebarTab(tab);
@@ -81,7 +77,6 @@ export default function BattlePage() {
         hasReferenceData={!!battleInfo?.referenceData}
       />
 
-      {/* 사이드바 */}
       <BattleSidebar
         isOpen={isSidebarOpen}
         onClose={handleCloseSidebar}
@@ -95,35 +90,16 @@ export default function BattlePage() {
         onActiveTabChange={setActiveSidebarTab}
       />
 
-      {/* 메인 콘텐츠 */}
       <div className="flex flex-col items-center">
         <BattleProgressBoard />
-        <div
-          className={`transition-all duration-300 main-width-closed ${
-            battleProgress &&
-            (battleProgress.phase as string) !== 'PENDING' &&
-            battleProgress.expiredAt != null &&
-            battleProgress.startedAt
-          }`}
-        >
-          <div className="flex items-center justify-between gap-4 mt-10 mb-8">
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={handleLeaveBattle}
-              className="shrink-0 w-[100px] sm:w-auto sm:min-w-[100px]"
-            >
-              ← 돌아가기
-            </Button>
-            <div className="shrink-0 flex items-center gap-2">
-              {battleInfo?.inviteCode && <InviteLinkButton inviteCode={battleInfo.inviteCode} />}
-            </div>
-          </div>
-          <div className="flex items-center justify-between">
-            <SoundSettingsButton bgmOptions={bgmOptions} />
-            <BattleHeader isSkipEnabled={isSkipEnabled} toggleSkip={toggleSkip} totalSkips={totalSkips} />
-          </div>
-        </div>
+        <BattleTopBar
+          onLeave={handleLeaveBattle}
+          inviteCode={battleInfo?.inviteCode}
+          bgmOptions={bgmOptions}
+          isSkipEnabled={isSkipEnabled}
+          toggleSkip={toggleSkip}
+          totalSkips={totalSkips}
+        />
         <main className="main-width-closed">
           <div className="flex gap-2 py-4">
             <div className="flex-1 min-w-0">

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -4,8 +4,6 @@ import { useBattle } from './hooks/useBattle';
 import useModal from '@/commons/hooks/useModal';
 import useBattleSound from './hooks/useBattleSound';
 import { useBattleLeave } from './hooks/useBattleLeave';
-import { useBattleStore, selectBattleProgress, selectSelectedTeam } from './stores/battleStore';
-import { isInputDisabled } from './utils/battlePhase';
 import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
 import BattleTopBar from './components/header/BattleTopBar';
 import BattleMainContent from './components/BattleMainContent';
@@ -22,8 +20,6 @@ export default function BattlePage() {
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
   const [activeSidebarTab, setActiveSidebarTab] = useState<Tab>('info');
-  const battleProgress = useBattleStore(selectBattleProgress);
-
   const { bgmOptions } = useBattleSound();
   const { handleLeaveBattle } = useBattleLeave();
 
@@ -38,10 +34,6 @@ export default function BattlePage() {
     isTeamChangeModalOpen,
     closeTeamChangeModal
   } = useBattle({ battleId });
-
-  const team = useBattleStore(selectSelectedTeam);
-  const phase = battleProgress?.phase;
-  const shouldShowInput = !isInputDisabled(team, phase);
 
   return (
     <div className="text-white relative">
@@ -78,8 +70,6 @@ export default function BattlePage() {
           codeA={battleInfo?.aCode || ''}
           codeB={battleInfo?.bCode || ''}
           onVote={handleVote}
-          shouldShowInput={shouldShowInput}
-          phase={phase}
           onDiscussionSubmit={handleDiscussionSubmit}
         />
         <BattleModals

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -11,14 +11,13 @@ import BattleSidebar from './components/sidebar';
 import BookmarkButton from './components/sidebar/BookmarkButton';
 import BattleModals from './components/modals/BattleModals';
 import BattleProgressBoard from './components/progressBoard/ProgressBoard';
-
-type Tab = 'info' | 'timeline' | 'reference';
+import type { SidebarTab } from './components/sidebar/SidebarHeader';
 
 export default function BattlePage() {
   const { id: battleId } = useParams<{ id: string }>();
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
-  const [activeSidebarTab, setActiveSidebarTab] = useState<Tab>('info');
+  const [activeSidebarTab, setActiveSidebarTab] = useState<SidebarTab>('info');
 
   const { bgmOptions } = useBattleSound();
   const { handleLeaveBattle } = useBattleLeave();

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState } from 'react';
 import Button from '@/commons/components/Button';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useBattle } from './hooks/useBattle';
 import { useTeamVoteResult } from './hooks/useTeamVoteResult';
 import useModal from '@/commons/hooks/useModal';
-import { soundManager } from '@/commons/utils/soundManager';
 import useBattleSound from './hooks/useBattleSound';
+import { useBattleLeave } from './hooks/useBattleLeave';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from './stores/battleStore';
 import { isInputDisabled } from './utils/battlePhase';
 import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
@@ -25,7 +25,6 @@ import TeamVoteResultModal from './components/effects/TeamVoteResultModal';
 import RoundUpdateModal from './components/effects/RoundUpdateModal';
 import SoundSettingsButton from './components/header/SoundSettingsButton';
 import SkipModal from './components/effects/SkipModal';
-import { selectUser, useAuthStore } from '@/commons/stores/authStore';
 import { usePhaseSkip } from './hooks/usePhaseSkip';
 import InviteLinkButton from '@/pages/battleCreatePage/components/InviteLinkButton';
 
@@ -33,45 +32,14 @@ type Tab = 'info' | 'timeline' | 'reference';
 
 export default function BattlePage() {
   const { id: battleId } = useParams<{ id: string }>();
-  const navigate = useNavigate();
   const { battleInfo: battleInfoData } = useGetBattleInfo(battleId!);
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
   const [activeSidebarTab, setActiveSidebarTab] = useState<Tab>('info');
-  const user = useAuthStore(selectUser);
-  const leaveBattle = useBattleStore((s) => s.leaveBattle);
   const battleProgress = useBattleStore(selectBattleProgress);
-  const hasLeftRef = useRef(false);
 
   const { bgmOptions } = useBattleSound();
-
-  const safeLeaveBattle = useCallback(() => {
-    if (hasLeftRef.current) return;
-    hasLeftRef.current = true;
-    leaveBattle();
-  }, [leaveBattle]);
-
-  useEffect(() => {
-    const handlePageHide = () => {
-      soundManager.stopAllBGM();
-      safeLeaveBattle();
-    };
-
-    const handleBeforeUnload = () => {
-      soundManager.stopAllBGM();
-      safeLeaveBattle();
-    };
-
-    window.addEventListener('pagehide', handlePageHide);
-    window.addEventListener('beforeunload', handleBeforeUnload);
-
-    return () => {
-      window.removeEventListener('pagehide', handlePageHide);
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-      soundManager.stopAllBGM();
-      safeLeaveBattle();
-    };
-  }, [safeLeaveBattle]);
+  const { handleLeaveBattle } = useBattleLeave();
 
   const {
     isOpen: isTeamChangeModalOpen,
@@ -95,18 +63,11 @@ export default function BattlePage() {
     totalSkips
   } = usePhaseSkip();
 
-  // Phase와 Team 정보 가져오기
   const team = useBattleStore(selectSelectedTeam);
   const phase = battleProgress?.phase;
   const shouldShowInput = !isInputDisabled(team, phase);
 
   const battleInfo = battleInfoData;
-
-  const handleLeaveBattle = () => {
-    if (!user) return;
-    navigate('/main');
-    safeLeaveBattle();
-  };
 
   return (
     <div className="text-white relative">
@@ -182,7 +143,6 @@ export default function BattlePage() {
             </aside>
           </div>
         </main>
-        {/* DiscussionInput - 화면 중앙 하단에 fixed */}
         <div
           className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 z-5 px-4 pb-4 transition-all duration-500 ease-out ${
             shouldShowInput ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0 pointer-events-none'

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -20,7 +20,7 @@ type Tab = 'info' | 'timeline' | 'reference';
 
 export default function BattlePage() {
   const { id: battleId } = useParams<{ id: string }>();
-  const { battleInfo: battleInfoData } = useGetBattleInfo(battleId!);
+  const { battleInfo } = useGetBattleInfo(battleId!);
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
   const [activeSidebarTab, setActiveSidebarTab] = useState<Tab>('info');
@@ -46,8 +46,6 @@ export default function BattlePage() {
   const team = useBattleStore(selectSelectedTeam);
   const phase = battleProgress?.phase;
   const shouldShowInput = !isInputDisabled(team, phase);
-
-  const battleInfo = battleInfoData;
 
   return (
     <div className="text-white relative">

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -10,10 +10,7 @@ import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
 import { usePhaseSkip } from './hooks/usePhaseSkip';
 
 import BattleTopBar from './components/header/BattleTopBar';
-import CodeSection from './components/codeview/CodeSection';
-import ChatSection from './components/chatting/ChatSection';
-import DiscussionInput from './components/discussion/DiscussionInput';
-import DiscussionVote from './components/discussion/DiscussionVote';
+import BattleMainContent from './components/BattleMainContent';
 import BattleSidebar from './components/sidebar';
 import BookmarkButton from './components/sidebar/BookmarkButton';
 import BattleModals from './components/modals/BattleModals';
@@ -86,34 +83,18 @@ export default function BattlePage() {
           toggleSkip={toggleSkip}
           totalSkips={totalSkips}
         />
-        <main className="main-width-closed">
-          <div className="flex gap-2 py-4">
-            <div className="flex-1 min-w-0">
-              <CodeSection
-                onViewChange={setViewMode}
-                currentView={viewMode}
-                language={battleInfo?.language || 'javascript'}
-                codeA={battleInfo?.aCode || ''}
-                codeB={battleInfo?.bCode || ''}
-              />
-            </div>
-            <aside
-              className={`flex flex-col gap-4 transition-all duration-300 ${isSidebarOpen ? 'lounge-width-open' : 'lounge-width-closed'}`}
-            >
-              <DiscussionVote onVote={handleVote} />
-              <ChatSection />
-            </aside>
-          </div>
-        </main>
-        <div
-          className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 z-5 px-4 pb-4 transition-all duration-500 ease-out ${
-            shouldShowInput ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0 pointer-events-none'
-          }`}
-        >
-          <div className="discussion-input-width">
-            {shouldShowInput && <DiscussionInput key={phase} onSubmit={handleDiscussionSubmit} />}
-          </div>
-        </div>
+        <BattleMainContent
+          viewMode={viewMode}
+          onViewChange={setViewMode}
+          isSidebarOpen={isSidebarOpen}
+          language={battleInfo?.language || 'javascript'}
+          codeA={battleInfo?.aCode || ''}
+          codeB={battleInfo?.bCode || ''}
+          onVote={handleVote}
+          shouldShowInput={shouldShowInput}
+          phase={phase}
+          onDiscussionSubmit={handleDiscussionSubmit}
+        />
         <BattleModals
           battleTopics={battleInfo?.topics ?? []}
           effectModal={effectModal}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useBattle } from './hooks/useBattle';
-import { useTeamVoteResult } from './hooks/useTeamVoteResult';
 import useModal from '@/commons/hooks/useModal';
 import useBattleSound from './hooks/useBattleSound';
 import { useBattleLeave } from './hooks/useBattleLeave';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from './stores/battleStore';
 import { isInputDisabled } from './utils/battlePhase';
 import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
+import { usePhaseSkip } from './hooks/usePhaseSkip';
 
 import BattleTopBar from './components/header/BattleTopBar';
 import CodeSection from './components/codeview/CodeSection';
@@ -16,14 +16,8 @@ import DiscussionInput from './components/discussion/DiscussionInput';
 import DiscussionVote from './components/discussion/DiscussionVote';
 import BattleSidebar from './components/sidebar';
 import BookmarkButton from './components/sidebar/BookmarkButton';
-import TeamChangeModal from './components/modals/TeamChangeModal';
-import ConnectionErrorModal from './components/modals/ConnectionErrorModal';
-import DiscussionModal from './components/effects/DiscussionModal';
+import BattleModals from './components/modals/BattleModals';
 import BattleProgressBoard from './components/progressBoard/ProgressBoard';
-import TeamVoteResultModal from './components/effects/TeamVoteResultModal';
-import RoundUpdateModal from './components/effects/RoundUpdateModal';
-import SkipModal from './components/effects/SkipModal';
-import { usePhaseSkip } from './hooks/usePhaseSkip';
 
 type Tab = 'info' | 'timeline' | 'reference';
 
@@ -39,26 +33,18 @@ export default function BattlePage() {
   const { handleLeaveBattle } = useBattleLeave();
 
   const {
-    isOpen: isTeamChangeModalOpen,
-    openModal: handleOpenTeamChangeModal,
-    closeModal: handleCloseTeamChangeModal
-  } = useModal(false);
+    handleVote,
+    handleDiscussionSubmit,
+    effectModal,
+    hideEffect,
+    hideRoundEffect,
+    roundModal,
+    handleTeamChange,
+    isTeamChangeModalOpen,
+    closeTeamChangeModal
+  } = useBattle({ battleId });
 
-  const { handleVote, handleDiscussionSubmit, effectModal, hideEffect, hideRoundEffect, roundModal, handleTeamChange } =
-    useBattle({
-      battleId,
-      onOpenTeamChangeModal: handleOpenTeamChangeModal,
-      onCloseTeamChangeModal: handleCloseTeamChangeModal
-    });
-
-  const { voteResult, isModalOpen: isVoteResultModalOpen, closeModal: closeVoteResultModal } = useTeamVoteResult();
-  const {
-    isModalOpen: isPhaseSkipModalOpen,
-    closeModal: closeSkipModal,
-    isSkipEnabled,
-    toggleSkip,
-    totalSkips
-  } = usePhaseSkip();
+  const { isSkipEnabled, toggleSkip, totalSkips } = usePhaseSkip();
 
   const team = useBattleStore(selectSelectedTeam);
   const phase = battleProgress?.phase;
@@ -128,42 +114,16 @@ export default function BattlePage() {
             {shouldShowInput && <DiscussionInput key={phase} onSubmit={handleDiscussionSubmit} />}
           </div>
         </div>
-        {battleInfo && (
-          <TeamChangeModal
-            isOpen={isTeamChangeModalOpen}
-            topics={battleInfo.topics}
-            handleTeamChange={handleTeamChange}
-            onClose={handleCloseTeamChangeModal}
-          />
-        )}
-        {!isPhaseSkipModalOpen && effectModal.isOpen && effectModal.team !== 'NONE' && (
-          <DiscussionModal
-            isOpen={effectModal.isOpen}
-            team={effectModal.team}
-            content={effectModal.content}
-            type={effectModal.type}
-            onClose={hideEffect}
-          />
-        )}
-        {isPhaseSkipModalOpen && <SkipModal isOpen={true} onClose={closeSkipModal} />}
-        {isVoteResultModalOpen && voteResult && (
-          <TeamVoteResultModal
-            isOpen={isVoteResultModalOpen}
-            round={voteResult.round}
-            teamACount={voteResult.after.teamA}
-            teamBCount={voteResult.after.teamB}
-            teamABefore={voteResult.before.teamA}
-            teamBBefore={voteResult.before.teamB}
-            teamAPercentage={(voteResult.after.teamA / (voteResult.after.teamA + voteResult.after.teamB)) * 100}
-            teamBPercentage={(voteResult.after.teamB / (voteResult.after.teamA + voteResult.after.teamB)) * 100}
-            leadingTeam={voteResult.dominantTeam === 'NONE' ? null : voteResult.dominantTeam}
-            onClose={closeVoteResultModal}
-          />
-        )}
-        {roundModal.isPending && !isVoteResultModalOpen && (
-          <RoundUpdateModal isOpen={true} round={roundModal.round} topic={roundModal.topic} onClose={hideRoundEffect} />
-        )}
-        <ConnectionErrorModal />
+        <BattleModals
+          battleTopics={battleInfo?.topics ?? []}
+          effectModal={effectModal}
+          onHideEffect={hideEffect}
+          roundModal={roundModal}
+          onHideRoundEffect={hideRoundEffect}
+          handleTeamChange={handleTeamChange}
+          isTeamChangeModalOpen={isTeamChangeModalOpen}
+          onCloseTeamChangeModal={closeTeamChangeModal}
+        />
       </div>
     </div>
   );

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -8,7 +8,7 @@ import { useBattleLeave } from './hooks/useBattleLeave';
 import BattleTopBar from './components/header/BattleTopBar';
 import BattleMainContent from './components/BattleMainContent';
 import BattleSidebar from './components/sidebar';
-import BookmarkButton from './components/sidebar/BookmarkButton';
+import SidebarTrigger from './components/sidebar/SidebarTrigger';
 import BattleModals from './components/modals/BattleModals';
 import BattleProgressBoard from './components/progressBoard/ProgressBoard';
 import type { SidebarTab } from './components/sidebar/SidebarHeader';
@@ -36,7 +36,7 @@ export default function BattlePage() {
 
   return (
     <div className="text-white relative">
-      <BookmarkButton
+      <SidebarTrigger
         onOpen={(tab) => {
           setActiveSidebarTab(tab);
           handleOpenSidebar();

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -7,8 +7,6 @@ import { useBattleLeave } from './hooks/useBattleLeave';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from './stores/battleStore';
 import { isInputDisabled } from './utils/battlePhase';
 import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
-import { usePhaseSkip } from './hooks/usePhaseSkip';
-
 import BattleTopBar from './components/header/BattleTopBar';
 import BattleMainContent from './components/BattleMainContent';
 import BattleSidebar from './components/sidebar';
@@ -41,8 +39,6 @@ export default function BattlePage() {
     closeTeamChangeModal
   } = useBattle({ battleId });
 
-  const { isSkipEnabled, toggleSkip, totalSkips } = usePhaseSkip();
-
   const team = useBattleStore(selectSelectedTeam);
   const phase = battleProgress?.phase;
   const shouldShowInput = !isInputDisabled(team, phase);
@@ -73,14 +69,7 @@ export default function BattlePage() {
 
       <div className="flex flex-col items-center">
         <BattleProgressBoard />
-        <BattleTopBar
-          onLeave={handleLeaveBattle}
-          inviteCode={battleInfo?.inviteCode}
-          bgmOptions={bgmOptions}
-          isSkipEnabled={isSkipEnabled}
-          toggleSkip={toggleSkip}
-          totalSkips={totalSkips}
-        />
+        <BattleTopBar onLeave={handleLeaveBattle} inviteCode={battleInfo?.inviteCode} bgmOptions={bgmOptions} />
         <BattleMainContent
           viewMode={viewMode}
           onViewChange={setViewMode}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -15,7 +15,6 @@ import type { SidebarTab } from './components/sidebar/SidebarHeader';
 
 export default function BattlePage() {
   const { id: battleId } = useParams<{ id: string }>();
-  const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
   const [activeSidebarTab, setActiveSidebarTab] = useState<SidebarTab>('info');
 
@@ -55,8 +54,6 @@ export default function BattlePage() {
         <BattleProgressBoard />
         <BattleTopBar onLeave={handleLeaveBattle} bgmOptions={bgmOptions} />
         <BattleMainContent
-          viewMode={viewMode}
-          onViewChange={setViewMode}
           isSidebarOpen={isSidebarOpen}
           onVote={handleVote}
           onDiscussionSubmit={handleDiscussionSubmit}

--- a/frontend/src/pages/battlePage/index.tsx
+++ b/frontend/src/pages/battlePage/index.tsx
@@ -4,7 +4,7 @@ import { useBattle } from './hooks/useBattle';
 import useModal from '@/commons/hooks/useModal';
 import useBattleSound from './hooks/useBattleSound';
 import { useBattleLeave } from './hooks/useBattleLeave';
-import { useGetBattleInfo } from '@/commons/hooks/useGetBattleInfo';
+
 import BattleTopBar from './components/header/BattleTopBar';
 import BattleMainContent from './components/BattleMainContent';
 import BattleSidebar from './components/sidebar';
@@ -16,10 +16,10 @@ type Tab = 'info' | 'timeline' | 'reference';
 
 export default function BattlePage() {
   const { id: battleId } = useParams<{ id: string }>();
-  const { battleInfo } = useGetBattleInfo(battleId!);
   const [viewMode, setViewMode] = useState<'split' | 'tab'>('split');
   const { isOpen: isSidebarOpen, openModal: handleOpenSidebar, closeModal: handleCloseSidebar } = useModal(false);
   const [activeSidebarTab, setActiveSidebarTab] = useState<Tab>('info');
+
   const { bgmOptions } = useBattleSound();
   const { handleLeaveBattle } = useBattleLeave();
 
@@ -43,37 +43,26 @@ export default function BattlePage() {
           handleOpenSidebar();
         }}
         isOpen={isSidebarOpen}
-        hasReferenceData={!!battleInfo?.referenceData}
       />
 
       <BattleSidebar
         isOpen={isSidebarOpen}
         onClose={handleCloseSidebar}
-        title={battleInfo?.title || ''}
-        description={battleInfo?.description || ''}
-        language={battleInfo?.language || 'javascript'}
-        category={battleInfo?.category || 'ALGORITHM'}
-        topics={battleInfo?.topics || []}
-        referenceData={battleInfo?.referenceData}
         activeTab={activeSidebarTab}
         onActiveTabChange={setActiveSidebarTab}
       />
 
       <div className="flex flex-col items-center">
         <BattleProgressBoard />
-        <BattleTopBar onLeave={handleLeaveBattle} inviteCode={battleInfo?.inviteCode} bgmOptions={bgmOptions} />
+        <BattleTopBar onLeave={handleLeaveBattle} bgmOptions={bgmOptions} />
         <BattleMainContent
           viewMode={viewMode}
           onViewChange={setViewMode}
           isSidebarOpen={isSidebarOpen}
-          language={battleInfo?.language || 'javascript'}
-          codeA={battleInfo?.aCode || ''}
-          codeB={battleInfo?.bCode || ''}
           onVote={handleVote}
           onDiscussionSubmit={handleDiscussionSubmit}
         />
         <BattleModals
-          battleTopics={battleInfo?.topics ?? []}
           effectModal={effectModal}
           onHideEffect={hideEffect}
           roundModal={roundModal}

--- a/frontend/src/pages/battlePage/utils/battlePhase.ts
+++ b/frontend/src/pages/battlePage/utils/battlePhase.ts
@@ -1,4 +1,13 @@
-import type { BattlePhase, Team } from '@/commons/types/battle';
+import type { BattlePhase, BattleProgressState, Team } from '@/commons/types/battle';
+
+export const isBattleActive = (battleProgress: BattleProgressState | null): battleProgress is BattleProgressState => {
+  if (!battleProgress) return false;
+  return (
+    (battleProgress.phase as string) !== 'PENDING' &&
+    battleProgress.expiredAt != null &&
+    battleProgress.startedAt != null
+  );
+};
 
 export const isMyTeamAttacking = (team: Team, phase?: BattlePhase): boolean => {
   if (!phase) return false;
@@ -9,7 +18,6 @@ export const isInputDisabled = (team: Team, phase?: BattlePhase, disabled = fals
   if (disabled) return true;
   if (!phase) return true;
 
-  // 공격/방어 페이즈가 아니면 입력 불가
   if (phase !== 'ATTACK' && phase !== 'DEFENSE') return true;
   if (team === 'NONE') return true;
 

--- a/frontend/src/pages/tutorialPage/battle/index.tsx
+++ b/frontend/src/pages/tutorialPage/battle/index.tsx
@@ -12,7 +12,7 @@ import ChatSection from '@/pages/battlePage/components/chatting/ChatSection';
 import DiscussionInput from '@/pages/battlePage/components/discussion/DiscussionInput';
 import DiscussionVote from '@/pages/battlePage/components/discussion/DiscussionVote';
 import BattleSidebar from '@/pages/battlePage/components/sidebar';
-import BookmarkButton from '@/pages/battlePage/components/sidebar/BookmarkButton';
+import SidebarTrigger from '@/pages/battlePage/components/sidebar/SidebarTrigger';
 import TutorialModal from '@/pages/tutorialPage/components/TutorialModal';
 import TutorialStepModal from '@/pages/tutorialPage/components/TutorialStepModal';
 import BattleProgressBoard from '@/pages/battlePage/components/progressBoard/ProgressBoard';
@@ -110,7 +110,7 @@ export default function TutorialBattlePage() {
 
   return (
     <div className="text-white relative">
-      <BookmarkButton
+      <SidebarTrigger
         onOpen={(tab) => {
           setActiveSidebarTab(tab);
           handleOpenSidebar();

--- a/frontend/src/pages/tutorialPage/battle/index.tsx
+++ b/frontend/src/pages/tutorialPage/battle/index.tsx
@@ -117,19 +117,12 @@ export default function TutorialBattlePage() {
         }}
         isOpen={isSidebarOpen}
         highlight={isTutorialOpen && currentStep === 'sidebar'}
-        hasReferenceData={!!battleInfo.referenceData}
       />
 
       <BattleSidebar
         isOpen={isSidebarOpen}
         onClose={handleCloseSidebar}
-        title={battleInfo.title}
-        description={battleInfo.description}
-        language={battleInfo.language}
-        category={battleInfo.category}
-        topics={battleInfo.topics}
         raiseZIndex={isTutorialOpen && currentStep === 'sidebarPanel'}
-        referenceData={battleInfo.referenceData}
         activeTab={activeSidebarTab}
         onActiveTabChange={setActiveSidebarTab}
       />
@@ -156,14 +149,7 @@ export default function TutorialBattlePage() {
         />
 
         <BattleProgressBoard />
-        <div
-          className={`transition-all duration-300 main-width-closed ${
-            battleProgress &&
-            (battleProgress.phase as string) !== 'PENDING' &&
-            battleProgress.expiredAt != null &&
-            battleProgress.startedAt
-          }`}
-        >
+        <div className="transition-all duration-300 main-width-closed">
           <div className="flex items-center justify-between mt-10 mb-8">
             <Button variant="secondary" size="sm" onClick={handleLeaveBattle}>
               ← 돌아가기


### PR DESCRIPTION
## 🔗 관련 이슈  
Closes #417


## ✅ 작업 내용  
### 배틀 페이지 리펙토링 배경  

기존 `BattlePage/index.tsx`가 거의 260줄짜리 단일 파일이었는데, UI, 사운드, 소켓, 모달, 퇴장 처리까지 다 한 곳에 몰려 있었습니다.
그래서 조금만 건드려도 영향 범위가 넓어서 유지보수가 꽤 빡센 구조였기에, **컴포넌트 분리 + 훅 분리 + 상태 위치 정리**  이 세 가지를 기준으로 구조를 정리했습니다.

(우선 기존 BattleHook에 대한 리펙토링은 추후 진행할 예정으로 이번 PR에 포함하지 않았습니다.)

<br/>

### 1. BattlePage/index 화면 영역 단위 컴포넌트 분리
기존에 battlePage 루트 컴포넌트에서 BattleSidebar와, BattleProgressBoard 같은 영역 단위 컴포넌트가 일부분 분리 되어있었지만, 나머지 메인 영역, 모달 Layer 관련 로직들이 널부러져 있었습니다. 이 코드들이 루트 페이지에서 가장 많은 줄 수를 차지하며,  책임 단위가 애매해서 코드 읽기가 꽤 힘든 상태였습니다.

그래서 메인 영역, 모달 Layer 영역, 게임 TopBar 영역 컴포넌트들을 만들어 추가적으로 책임 단위를 분리했습니다.

#### 분리

- `BattleTopBar`  
  -> 뒤로가기, 초대 링크, 사운드, 페이즈 관련 UI

- `BattleMainContent`  
  -> 코드뷰 + 채팅 / 토론 / 투표 영역

- `BattleModals`  
  -> 팀 변경, 스킵, 결과, 에러 등 모달 묶음

#### 분리 후 루트 컴포넌트 JSX 부분 
```tsx
 <div className="text-white relative">
      <SidebarTrigger
        onOpen={(tab) => {
          setActiveSidebarTab(tab);
          handleOpenSidebar();
        }}
        isOpen={isSidebarOpen}
      />

      <BattleSidebar
        isOpen={isSidebarOpen}
        onClose={handleCloseSidebar}
        activeTab={activeSidebarTab}
        onActiveTabChange={setActiveSidebarTab}
      />

      <div className="flex flex-col items-center">
        <BattleProgressBoard />
        <BattleTopBar onLeave={handleLeaveBattle} bgmOptions={bgmOptions} />
        <BattleMainContent
          isSidebarOpen={isSidebarOpen}
          onVote={handleVote}
          onDiscussionSubmit={handleDiscussionSubmit}
        />
        <BattleModals
          effectModal={effectModal}
          onHideEffect={hideEffect}
          roundModal={roundModal}
          onHideRoundEffect={hideRoundEffect}
          handleTeamChange={handleTeamChange}
          isTeamChangeModalOpen={isTeamChangeModalOpen}
          onCloseTeamChangeModal={closeTeamChangeModal}
        />
      </div>
    </div>
```

분리와 동시에  각 컴포넌트가 필요한 store/hook을 직접 가져가게 하고 진짜 필요한 콜백만 props로 넘기는 방식으로 정리하여 
최대한 props drilling 줄이는 쪽으로 선택했습니다.

<br/>

### 2. 루트 컴포넌트내에서 사운드 초기화, 퇴장 처리, 스킵 로직 커스텀훅으로  분리  
루트 컴포넌트에서 사운드 초기화, 퇴장 처리, 스킵 로직이 그냥 그대로 통짜로 박혀 있는 상태였습니다.
그래서 최대한 파일의 복잡도를 낮추기 위해 분리했습니다. 

#### 루트 컴포넌트에서 커스텀 훅으로 분리한 로직들

- `useBattleSound`  
  -> BGM 옵션 + 사운드 init / cleanup 처리 담당 

- `useBattleLeave`  
  -> 중복 퇴장 방지 (`hasLeftRef`), 페이지 이탈 처리, 소켓 leave  처리 담당 

- `usePhaseSkip`  
  -> 스킵 상태 (`isSkipEnabled`, `totalSkips`, `toggleSkip`)  처리 담당 

<br/>

### 3. 상태 / 로직 위치 정리  
몇몇 로직과 상태들이 실제로 쓰는 위치랑 떨어져 있어서 흐름 따라가기가 어렵고 불필요하게 묶여 있는 부분들 때문에 코드가 더 난잡해지더라구요 그래서 실제로 쓰이는곳으로 옮겼습니다.

뭐 그리고 tanstack-query로 데이터를 패칭하는 경우 어짜피 인메모리에 캐싱되어있기 때문에 굳이 부모 쪽에서 데이터를 받아와서 prop으로 내려줄 필요 없더라구요 

#### 변경  

- `shouldShowInput`  
  -> `BattlePage` → `BattleMainContent` 내부로 이동  

- `battleInfo` fetch  
  -> 중앙 관리 제거  
  -> 각 컴포넌트에서 `useGetBattleInfo`로 직접 조회 (
뭐 그리고 tanstack-query로 데이터를 패칭하는 경우 어짜피 인메모리에 캐싱되어있기 때문에 굳이 부모 쪽에서 데이터를 받아와서 prop으로 내려줄 필요 없더라구요 )

  (`BookmarkButton`, `BattleSidebar`, `BattleTopBar`, `BattleModals` 등)


<br/>

### 4. isBattleActive 유틸 함수 추출  

여러 곳에서 아래 로직이 반복되고 있었습니다.

```ts
battleProgress &&
(battleProgress.phase as string) !== 'PENDING' &&
battleProgress.expiredAt != null &&
battleProgress.startedAt != null
```

그래서 `battlePhase.ts`로 분리해서   `isBattleActive` 함수로 통합했습니다.

<br/>

### 그외...
BookmarkButton -> SidebarTrigger 컴포넌트 이름 변경 (역할 불일치로 인해 어울리는 이름 매칭)
viewMode 상태를 BattlePage -> BattleMainContent 내부로 이동
SidebarTrigger onOpen prop 타입을 인라인 유니온('info' | 'timeline' | 'reference')에서 SidebarTab으로 교체

## 💬 고민했던 부분  
### 훅 분리 기준  

처음에는 “재사용 가능한가?” 기준으로 보려고 했는데   정리하다 보니   **이 로직이 지금 위치에 있는 게 맞는가**  
이 기준이 더 중요하다고 느껴서  그 기준으로 분리했습니다.
