### PR TITLE
refactor: @cmc/types 공유 패키지 생성 및 프론트·백엔드 타입/소켓 이벤트 통합

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,6 +22,9 @@ COPY backend/prisma ./backend/prisma
 # Prisma Client 생성
 RUN pnpm -C backend prisma:generate
 
+# Build shared packages
+RUN pnpm -C packages/types build
+
 # Build backend
 RUN pnpm -C backend build
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -101,6 +101,7 @@
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",
     "moduleNameMapper": {
+      "^@cmc/types$": "<rootDir>/../../packages/types/src/index.ts",
       "^src/(.*)$": "<rootDir>/$1",
       "^generated/prisma/(.*)$": "<rootDir>/../generated/prisma/$1.ts",
       "^generated/prisma/(.*)\\.js$": "<rootDir>/../generated/prisma/$1.ts",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "prisma:generate": "npx prisma generate"
   },
   "dependencies": {
+    "@cmc/types": "workspace:*",
     "@google/generative-ai": "^0.24.1",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",

--- a/backend/src/battles/adapters/in/battles.gateway.ts
+++ b/backend/src/battles/adapters/in/battles.gateway.ts
@@ -17,6 +17,7 @@ import { AttackRequestDto, DefenseRequestDto, AttackVoteRequestDto, DefenseVoteR
 import { BattlePhaseResponseDto, BattleRoundResponseDto } from '../../dto/battleTurnResponse.dto'
 import { BattleChatDto } from '../../dto/battleChat.dto'
 import { BATTLE_CHAT_SCOPE } from '../../domains/models/const/battles.const'
+import { BATTLE_CLIENT_EVENTS, BATTLE_SERVER_EVENTS } from '@cmc/types'
 import { DiscussionVoteResultDto } from '../../dto/discussionVoteResult.dto'
 import { BattleTeamVoteDto } from '../../dto/battleTeamVote.dto'
 import { BattleClosedResponseDto } from '../../dto/battleClosedResponse.dto'
@@ -95,7 +96,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
       try {
         const result = await this.participationUseCase.leave(userId, battleId)
         const battleRoomId = getBattleRoomId(battleId)
-        this.server.to(battleRoomId).emit('battle:leaved', result)
+        this.server.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.LEAVED, result)
       } catch (error) {
         if (!(error instanceof NotFoundException)) {
           this.logger.error(`[소켓 연결 해제 처리 실패] userId: ${userId}, battleId: ${battleId}`, error as Error)
@@ -115,7 +116,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
     client.disconnect()
   }
 
-  @SubscribeMessage('battle:join')
+  @SubscribeMessage(BATTLE_CLIENT_EVENTS.JOIN)
   async joinBattle(@MessageBody() battleJoinRequestDto: BattleJoinRequestDto, @ConnectedSocket() client: SocketWithUserId) {
     const stopTimer = this.metricsService.startSocketTimer('battle:join')
     try {
@@ -143,19 +144,19 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
       await client.join(battleRoomId)
       await client.join(battleTeamRoom)
 
-      client.emit('battle:joined', { ...res })
+      client.emit(BATTLE_SERVER_EVENTS.JOINED, { ...res })
       stopTimer('success')
     } catch (error) {
       stopTimer('error')
       if (error instanceof Error) {
-        client.emit('battle:join:error', {
+        client.emit(BATTLE_SERVER_EVENTS.JOIN_ERROR, {
           message: error.message,
         })
       }
     }
   }
 
-  @SubscribeMessage('battle:leave')
+  @SubscribeMessage(BATTLE_CLIENT_EVENTS.LEAVE)
   async handleLeave(@MessageBody() dto: { battleId: string }, @ConnectedSocket() client: SocketWithUserId) {
     const { battleId } = dto
     const userId = this.getUserIdFromSocket(client)
@@ -164,10 +165,10 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
     const result = await this.participationUseCase.leave(userId, battleId)
     client.data.battleId = undefined
 
-    this.server.to(battleRoomId).emit('battle:leaved', result)
+    this.server.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.LEAVED, result)
   }
 
-  @SubscribeMessage('battle:start')
+  @SubscribeMessage(BATTLE_CLIENT_EVENTS.START)
   async handleStart(@MessageBody() dto: BattleStartDto) {
     const stopTimer = this.metricsService.startSocketTimer('battle:start')
     try {
@@ -176,7 +177,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
 
       const battleRoomId = getBattleRoomId(battleId)
 
-      this.server.to(battleRoomId).emit('battle:started')
+      this.server.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.STARTED)
       stopTimer('success')
     } catch (error) {
       stopTimer('error')
@@ -184,7 +185,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
     }
   }
 
-  @SubscribeMessage('battle:attack')
+  @SubscribeMessage(BATTLE_CLIENT_EVENTS.ATTACK)
   async handleAttack(@MessageBody() dto: AttackRequestDto, @ConnectedSocket() client: SocketWithUserId) {
     const stopTimer = this.metricsService.startSocketTimer('battle:attack')
     try {
@@ -195,19 +196,19 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
       const attack = await this.interactionUseCase.submitDiscussion(battleId, userId, content, team, 'attack')
       const teamRoom = getBattleRoomId(battleId, team)
 
-      this.server.to(teamRoom).emit('battle:attack:created', attack)
+      this.server.to(teamRoom).emit(BATTLE_SERVER_EVENTS.ATTACK_CREATED, attack)
       stopTimer('success')
     } catch (error) {
       stopTimer('error')
       if (error instanceof Error) {
-        client.emit('battle:attack:error', {
+        client.emit(BATTLE_SERVER_EVENTS.ATTACK_ERROR, {
           message: error.message,
         })
       }
     }
   }
 
-  @SubscribeMessage('battle:defense')
+  @SubscribeMessage(BATTLE_CLIENT_EVENTS.DEFENSE)
   async handleDefense(@MessageBody() dto: DefenseRequestDto, @ConnectedSocket() client: SocketWithUserId) {
     const stopTimer = this.metricsService.startSocketTimer('battle:defense')
     try {
@@ -218,19 +219,19 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
       const defense = await this.interactionUseCase.submitDiscussion(battleId, userId, content, team, 'defense')
       const teamRoom = getBattleRoomId(battleId, team)
 
-      this.server.to(teamRoom).emit('battle:defense:created', defense)
+      this.server.to(teamRoom).emit(BATTLE_SERVER_EVENTS.DEFENSE_CREATED, defense)
       stopTimer('success')
     } catch (error) {
       stopTimer('error')
       if (error instanceof Error) {
-        client.emit('battle:defense:error', {
+        client.emit(BATTLE_SERVER_EVENTS.DEFENSE_ERROR, {
           message: error.message,
         })
       }
     }
   }
 
-  @SubscribeMessage('battle:attack:vote')
+  @SubscribeMessage(BATTLE_CLIENT_EVENTS.ATTACK_VOTE)
   async handleAttackVote(@MessageBody() dto: AttackVoteRequestDto, @ConnectedSocket() client: SocketWithUserId) {
     const stopTimer = this.metricsService.startSocketTimer('battle:attack:vote')
     try {
@@ -243,20 +244,20 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
 
       // 모든 변경된 항목(기존 투표 취소 + 새 투표)을 전송
       updates.forEach(update => {
-        this.server.to(teamRoom).emit('battle:attack:voted', update)
+        this.server.to(teamRoom).emit(BATTLE_SERVER_EVENTS.ATTACK_VOTED, update)
       })
       stopTimer('success')
     } catch (error) {
       stopTimer('error')
       if (error instanceof Error) {
-        client.emit('battle:attack:vote:error', {
+        client.emit(BATTLE_SERVER_EVENTS.ATTACK_VOTE_ERROR, {
           message: error.message,
         })
       }
     }
   }
 
-  @SubscribeMessage('battle:defense:vote')
+  @SubscribeMessage(BATTLE_CLIENT_EVENTS.DEFENSE_VOTE)
   async handleDefenseVote(@MessageBody() dto: DefenseVoteRequestDto, @ConnectedSocket() client: SocketWithUserId) {
     const stopTimer = this.metricsService.startSocketTimer('battle:defense:vote')
     try {
@@ -269,20 +270,20 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
 
       // 모든 변경된 항목(기존 투표 취소 + 새 투표)을 전송
       updates.forEach(update => {
-        this.server.to(teamRoom).emit('battle:defense:voted', update)
+        this.server.to(teamRoom).emit(BATTLE_SERVER_EVENTS.DEFENSE_VOTED, update)
       })
       stopTimer('success')
     } catch (error) {
       stopTimer('error')
       if (error instanceof Error) {
-        client.emit('battle:defense:vote:error', {
+        client.emit(BATTLE_SERVER_EVENTS.DEFENSE_VOTE_ERROR, {
           message: error.message,
         })
       }
     }
   }
 
-  @SubscribeMessage('battle:user:skip')
+  @SubscribeMessage(BATTLE_CLIENT_EVENTS.USER_SKIP)
   async handlePhaseSkip(@MessageBody() dto: { skip: boolean; battleId: string }, @ConnectedSocket() client: SocketWithUserId) {
     const stopTimer = this.metricsService.startSocketTimer('battle:user:skip')
     const userId = this.getUserIdFromSocket(client)
@@ -291,13 +292,13 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
       const totalSkips = await this.phaseTransitionUseCase.handlePhaseSkip(battleId, userId, skip)
       const battleRoomId = getBattleRoomId(battleId)
 
-      this.server.to(battleRoomId).emit('battle:user:skipped', { totalSkips })
+      this.server.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.USER_SKIPPED, { totalSkips })
 
       stopTimer('success')
     } catch (error) {
       stopTimer('error')
       if (error instanceof Error) {
-        client.emit('battle:user:skip:error', {
+        client.emit(BATTLE_SERVER_EVENTS.USER_SKIP_ERROR, {
           message: error.message,
         })
       }
@@ -308,28 +309,28 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
     const { battleId } = payload
     const battleRoomId = getBattleRoomId(battleId)
 
-    this.server.to(battleRoomId).emit('battle:phase:updated', payload)
+    this.server.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.PHASE_UPDATED, payload)
   }
 
   roundUpdate(payload: BattleRoundResponseDto) {
     const { battleId } = payload
     const battleRoomId = getBattleRoomId(battleId)
 
-    this.server.to(battleRoomId).emit('battle:round:updated', payload)
+    this.server.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.ROUND_UPDATED, payload)
   }
 
   onAttacked(payload: DiscussionVoteResultDto) {
     const { battleId } = payload
     const battleRoomId = getBattleRoomId(battleId)
 
-    this.server.to(battleRoomId).emit('battle:attacked', payload)
+    this.server.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.ATTACKED, payload)
   }
 
   onDefensed(payload: DiscussionVoteResultDto) {
     const { battleId } = payload
     const battleRoomId = getBattleRoomId(battleId)
 
-    this.server.to(battleRoomId).emit('battle:defensed', payload)
+    this.server.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.DEFENSED, payload)
   }
 
   closeBattle(payload: BattleClosedResponseDto) {
@@ -338,7 +339,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
     const battleARoomId = getBattleRoomId(battleId, 'A')
     const battleBRoomId = getBattleRoomId(battleId, 'B')
 
-    this.server.to(battleRoomId).emit('battle:closed', payload)
+    this.server.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.CLOSED, payload)
 
     const rooms = [battleRoomId, battleARoomId, battleBRoomId]
 
@@ -349,17 +350,17 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
     const { battleId } = payload
     const battleRoomId = getBattleRoomId(battleId)
 
-    this.server.to(battleRoomId).emit('battle:user:updated', payload)
+    this.server.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.USER_UPDATED, payload)
   }
 
   skipPhase(payload: { battleId: string }) {
     const { battleId } = payload
     const battleRoomId = getBattleRoomId(battleId)
 
-    this.server.to(battleRoomId).emit('battle:phase:skipped')
+    this.server.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.PHASE_SKIPPED)
   }
 
-  @SubscribeMessage('battle:chat')
+  @SubscribeMessage(BATTLE_CLIENT_EVENTS.CHAT)
   async handleChat(@MessageBody() battleChatDto: BattleChatDto, @ConnectedSocket() client: SocketWithUserId) {
     const stopTimer = this.metricsService.startSocketTimer('battle:chat')
     try {
@@ -371,18 +372,18 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
       const team: BattleTeam = battleChatDto.team
       const roomId = scope === BATTLE_CHAT_SCOPE.ALL ? getBattleRoomId(battleId) : getBattleRoomId(battleId, team)
 
-      // this.server.to(roomId).emit('battle:chatted', saved)
-      this.server.to(roomId).except(client.id).emit('battle:chatted', saved)
+      // this.server.to(roomId).emit(BATTLE_SERVER_EVENTS.CHATTED, saved)
+      this.server.to(roomId).except(client.id).emit(BATTLE_SERVER_EVENTS.CHATTED, saved)
       stopTimer('success')
     } catch (error) {
       stopTimer('error')
       if (error instanceof Error) {
-        client.emit('battle:chat:error', { message: error.message })
+        client.emit(BATTLE_SERVER_EVENTS.CHAT_ERROR, { message: error.message })
       }
     }
   }
 
-  @SubscribeMessage('battle:team:vote')
+  @SubscribeMessage(BATTLE_CLIENT_EVENTS.TEAM_VOTE)
   async handleTeamVote(@MessageBody() dto: BattleTeamVoteDto, @ConnectedSocket() client: SocketWithUserId) {
     const stopTimer = this.metricsService.startSocketTimer('battle:team:vote')
     try {
@@ -395,7 +396,7 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
     } catch (error) {
       stopTimer('error')
       if (error instanceof Error) {
-        client.emit('battle:team:vote:error', { message: error.message })
+        client.emit(BATTLE_SERVER_EVENTS.TEAM_VOTE_ERROR, { message: error.message })
       }
     }
   }
@@ -416,9 +417,9 @@ export class BattlesGateway implements OnGatewayConnection, OnGatewayDisconnect 
 
       void socket.leave(fromRoom)
       void socket.join(toRoom)
-      socket.emit('battle:team:updated', { battleId, team: toTeam })
+      socket.emit(BATTLE_SERVER_EVENTS.TEAM_UPDATED, { battleId, team: toTeam })
     }
 
-    this.server.to(battleRoomId).emit('battle:all:updated', payload)
+    this.server.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.ALL_UPDATED, payload)
   }
 }

--- a/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.spec.ts
+++ b/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.spec.ts
@@ -5,6 +5,7 @@ import type { BattleUserUpdateResponseDto } from '../../../dto/battleUserUpdateR
 import type { BattleTeamUpdateAllResponseDto } from '../../../dto/battleTeamUpdateAllResponse.dto'
 import type { BattleClosedResponseDto } from '../../../dto/battleClosedResponse.dto'
 import type { DiscussionVoteResultDto } from '../../../dto/discussionVoteResult.dto'
+import { BATTLE_SERVER_EVENTS } from '@cmc/types'
 
 describe('BattleBroadcasterAdapter', () => {
   let adapter: BattleBroadcasterAdapter
@@ -36,7 +37,7 @@ describe('BattleBroadcasterAdapter', () => {
     it('battle room에 phase:updated 이벤트를 전송한다', () => {
       const dto = { battleId: 'battle-1' } as BattlePhaseResponseDto
       const listener = jest.fn()
-      adapter.on('battle:phase:updated', listener)
+      adapter.on(BATTLE_SERVER_EVENTS.PHASE_UPDATED, listener)
 
       adapter.emitPhaseUpdated(dto)
 
@@ -90,7 +91,7 @@ describe('BattleBroadcasterAdapter', () => {
   describe('emitPhaseSkipped', () => {
     it('battle room에 phase:skipped 이벤트를 전송한다', () => {
       const listener = jest.fn()
-      adapter.on('battle:phase:skipped', listener)
+      adapter.on(BATTLE_SERVER_EVENTS.PHASE_SKIPPED, listener)
 
       adapter.emitPhaseSkipped('battle-1')
 

--- a/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.ts
+++ b/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.ts
@@ -7,6 +7,7 @@ import { BattleUserUpdateResponseDto } from '../../../dto/battleUserUpdateRespon
 import { BattleTeamUpdateAllResponseDto } from '../../../dto/battleTeamUpdateAllResponse.dto'
 import { BattleClosedResponseDto } from '../../../dto/battleClosedResponse.dto'
 import { DiscussionVoteResultDto } from '../../../dto/discussionVoteResult.dto'
+import { BATTLE_SERVER_EVENTS } from '@cmc/types'
 
 @Injectable()
 export class BattleBroadcasterAdapter extends EventEmitter implements BattleBroadcasterPort {
@@ -25,26 +26,26 @@ export class BattleBroadcasterAdapter extends EventEmitter implements BattleBroa
 
   emitPhaseUpdated(phaseRes: BattlePhaseResponseDto): void {
     const battleRoomId = `battle:${phaseRes.battleId}`
-    this.io.to(battleRoomId).emit('battle:phase:updated', phaseRes)
-    this.emit('battle:phase:updated', phaseRes)
+    this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.PHASE_UPDATED, phaseRes)
+    this.emit(BATTLE_SERVER_EVENTS.PHASE_UPDATED, phaseRes)
   }
 
   emitRoundUpdated(roundRes: BattleRoundResponseDto): void {
     const battleRoomId = `battle:${roundRes.battleId}`
-    this.io.to(battleRoomId).emit('battle:round:updated', roundRes)
-    this.emit('battle:round:updated', roundRes)
+    this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.ROUND_UPDATED, roundRes)
+    this.emit(BATTLE_SERVER_EVENTS.ROUND_UPDATED, roundRes)
   }
 
   emitUserUpdated(userRes: BattleUserUpdateResponseDto): void {
     const battleRoomId = `battle:${userRes.battleId}`
-    this.io.to(battleRoomId).emit('battle:user:updated', userRes)
-    this.emit('battle:user:updated', userRes)
+    this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.USER_UPDATED, userRes)
+    this.emit(BATTLE_SERVER_EVENTS.USER_UPDATED, userRes)
   }
 
   emitTeamUpdated(teamRes: BattleTeamUpdateAllResponseDto): void {
     const battleRoomId = `battle:${teamRes.battleId}`
-    this.io.to(battleRoomId).emit('battle:team:updated', teamRes)
-    this.emit('battle:team:updated', teamRes)
+    this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.TEAM_UPDATED, teamRes)
+    this.emit(BATTLE_SERVER_EVENTS.TEAM_UPDATED, teamRes)
   }
 
   emitBattleClosed(closedRes: BattleClosedResponseDto): void {
@@ -52,8 +53,8 @@ export class BattleBroadcasterAdapter extends EventEmitter implements BattleBroa
     const battleARoomId = `battle:${closedRes.battleId}:A`
     const battleBRoomId = `battle:${closedRes.battleId}:B`
 
-    this.io.to(battleRoomId).emit('battle:closed', closedRes)
-    this.emit('battle:closed', closedRes)
+    this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.CLOSED, closedRes)
+    this.emit(BATTLE_SERVER_EVENTS.CLOSED, closedRes)
 
     const rooms = [battleRoomId, battleARoomId, battleBRoomId]
     rooms.forEach(room => this.io.in(room).disconnectSockets(true))
@@ -61,19 +62,19 @@ export class BattleBroadcasterAdapter extends EventEmitter implements BattleBroa
 
   emitPhaseSkipped(battleId: string): void {
     const battleRoomId = `battle:${battleId}`
-    this.io.to(battleRoomId).emit('battle:phase:skipped')
-    this.emit('battle:phase:skipped', { battleId })
+    this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.PHASE_SKIPPED)
+    this.emit(BATTLE_SERVER_EVENTS.PHASE_SKIPPED, { battleId })
   }
 
   emitAttacked(attackedRes: DiscussionVoteResultDto): void {
     const battleRoomId = `battle:${attackedRes.battleId}`
-    this.io.to(battleRoomId).emit('battle:attacked', attackedRes)
-    this.emit('battle:attacked', attackedRes)
+    this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.ATTACKED, attackedRes)
+    this.emit(BATTLE_SERVER_EVENTS.ATTACKED, attackedRes)
   }
 
   emitDefensed(defensedRes: DiscussionVoteResultDto): void {
     const battleRoomId = `battle:${defensedRes.battleId}`
-    this.io.to(battleRoomId).emit('battle:defensed', defensedRes)
-    this.emit('battle:defensed', defensedRes)
+    this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.DEFENSED, defensedRes)
+    this.emit(BATTLE_SERVER_EVENTS.DEFENSED, defensedRes)
   }
 }

--- a/backend/src/battles/domains/models/types/battle.types.ts
+++ b/backend/src/battles/domains/models/types/battle.types.ts
@@ -1,27 +1,14 @@
-import {
-  BATTLE_CATEGORY,
-  BATTLE_LANGUAGE,
-  BATTLE_PHASE,
-  BATTLE_PLAYTIME,
-  BATTLE_TYPE,
-  BATTLE_STATUS,
-  BATTLE_TEAM,
-  BATTLE_DISCUSSION_TYPE,
-} from '../const/battles.const'
+import { BATTLE_PHASE, BATTLE_PLAYTIME, BATTLE_DISCUSSION_TYPE } from '../const/battles.const'
+import type { BattlePhaseName, BattleTeam, BattleStatus, BattleLanguage, BattleCategory, BattleType, BattleDiscussionStatus } from '@cmc/types'
 
 import { BattleResult, Metrics, VoteTimeline, TimelineItem, Mvp } from './battleResult.types'
 import type { BattleReferenceData } from './ai.types'
-export type BattlePhaseName = (typeof BATTLE_PHASE)[keyof typeof BATTLE_PHASE]['name']
+
+export type { BattlePhaseName, BattleTeam, BattleStatus, BattleLanguage, BattleCategory, BattleType, BattleDiscussionStatus }
 export type BattlePhase = (typeof BATTLE_PHASE)[keyof typeof BATTLE_PHASE]
-export type BattleLanguage = (typeof BATTLE_LANGUAGE)[keyof typeof BATTLE_LANGUAGE]
-export type BattleStatus = (typeof BATTLE_STATUS)[keyof typeof BATTLE_STATUS]
-export type BattleType = (typeof BATTLE_TYPE)[keyof typeof BATTLE_TYPE]
 export type BattleDiscussionType = (typeof BATTLE_DISCUSSION_TYPE)[keyof typeof BATTLE_DISCUSSION_TYPE]
-export type BattleCategory = (typeof BATTLE_CATEGORY)[keyof typeof BATTLE_CATEGORY]
 export type BattlePlayTimeName = (typeof BATTLE_PLAYTIME)[keyof typeof BATTLE_PLAYTIME]['name']
 export type BattlePlayTime = (typeof BATTLE_PLAYTIME)[keyof typeof BATTLE_PLAYTIME]
-export type BattleTeam = (typeof BATTLE_TEAM)[keyof typeof BATTLE_TEAM]
-export type BattleDiscussionStatus = 'PENDING' | 'SELECTED' | 'REJECTED'
 
 export interface Battle {
   id: string

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -16,6 +16,7 @@
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
+    "types": ["jest", "node"],
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false,

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,6 +18,9 @@ RUN pnpm install --frozen-lockfile
 # Copy source
 COPY frontend ./frontend
 
+# Build shared packages
+RUN pnpm -C packages/types build
+
 # Build
 ARG VITE_API_URL
 ENV VITE_API_URL=${VITE_API_URL}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "test:e2e:debug": "playwright test --debug"
   },
   "dependencies": {
+    "@cmc/types": "workspace:*",
     "@sentry/react": "^10.38.0",
     "@tanstack/react-query": "^5.90.20",
     "@wasm-fmt/ruff_fmt": "^0.14.13",

--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -4,7 +4,7 @@ export interface BattleChat {
   scope: 'TEAM' | 'ALL';
   messageId: string;
   sender: { userId: string; nickname: string; tier?: string };
-  team: Team;
+  team: BattleTeam;
   text: string;
   createdAt: Date | string;
   type?: 'chat' | 'attack' | 'defense';
@@ -21,7 +21,7 @@ export interface BattleInfo {
   currentRound: number;
   totalRounds: number;
   topics: string[];
-  currentPhase: BattlePhase;
+  currentPhase: BattlePhaseName;
   phaseCount: number;
   timelines: {
     attacks: BattleDiscussion[];
@@ -31,9 +31,7 @@ export interface BattleInfo {
   inviteCode?: string;
 }
 
-// 공통 타입들
-export type BattlePhase = 'PENDING' | 'OPINION_SHARE' | 'ATTACK' | 'DEFENSE' | 'TEAM_SWITCH';
-export type Team = 'A' | 'B' | 'NONE';
+export type { BattlePhaseName, BattleTeam } from '@cmc/types';
 
 // BattleDiscussion 타입
 export interface BattleDiscussion {
@@ -65,8 +63,8 @@ export interface TeamCounts {
 
 export interface TeamChange {
   clientId: string;
-  from: Team;
-  to: Team;
+  from: BattleTeam;
+  to: BattleTeam;
 }
 
 // BattleJoinResponseDto 타입
@@ -86,7 +84,7 @@ export interface BattleJoinData {
   // 배틀 상태 정보
   round: number;
   topics: string[];
-  phase: BattlePhase;
+  phase: BattlePhaseName;
   phaseCount: number;
   startedAt: number | null;
   expiredAt: number | null;
@@ -95,13 +93,13 @@ export interface BattleJoinData {
 export interface UseBattleSocketProps {
   battleId: string;
   userId: string;
-  team: Team;
+  team: BattleTeam;
   password?: string;
 }
 
 export interface BattleProgressState {
   round: number;
-  phase: BattlePhase;
+  phase: BattlePhaseName;
   phaseCount: number;
   topic: string;
   startedAt: number | null;
@@ -115,7 +113,7 @@ export interface DiscussionVoteResultItem {
   ownerId: string | null;
   nickname: string | null;
   count: number | null;
-  team: Team | null;
+  team: BattleTeam | null;
 }
 
 export interface BattleAttackedResult {
@@ -157,7 +155,7 @@ export interface BattleTeamUpdateAllResponse {
     teamB: number;
     teamNone: number;
   };
-  dominantTeam: Team | null;
+  dominantTeam: BattleTeam | null;
 }
 
 // AI 참고 자료 타입

--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -1,4 +1,5 @@
 import type { BattlePhaseName, BattleTeam, BattleDiscussionStatus, BattleChatScope } from '@cmc/types';
+export type { BattlePhaseName, BattleTeam, BattleDiscussionStatus, BattleChatScope };
 
 // BattleChat 타입
 export interface BattleChat {

--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -1,7 +1,10 @@
+import type { BattlePhaseName, BattleTeam, BattleDiscussionStatus, BattleChatScope } from '@cmc/types';
+export type { BattlePhaseName, BattleTeam, BattleDiscussionStatus, BattleChatScope };
+
 // BattleChat 타입
 export interface BattleChat {
   battleId: string;
-  scope: 'TEAM' | 'ALL';
+  scope: BattleChatScope;
   messageId: string;
   sender: { userId: string; nickname: string; tier?: string };
   team: BattleTeam;
@@ -31,8 +34,6 @@ export interface BattleInfo {
   inviteCode?: string;
 }
 
-export type { BattlePhaseName, BattleTeam } from '@cmc/types';
-
 // BattleDiscussion 타입
 export interface BattleDiscussion {
   discussionId: string;
@@ -44,7 +45,7 @@ export interface BattleDiscussion {
   content: string;
   upvotes: number;
   votes: string[];
-  status: 'PENDING' | 'SELECTED' | 'REJECTED';
+  status: BattleDiscussionStatus;
   selectedAt?: number; // SELECTED로 변경된 시간 (timestamp)
   team: 'A' | 'B'; // 어느 팀의 토론인지 (NONE은 불가)
 }

--- a/frontend/src/commons/types/battle.ts
+++ b/frontend/src/commons/types/battle.ts
@@ -1,5 +1,4 @@
 import type { BattlePhaseName, BattleTeam, BattleDiscussionStatus, BattleChatScope } from '@cmc/types';
-export type { BattlePhaseName, BattleTeam, BattleDiscussionStatus, BattleChatScope };
 
 // BattleChat 타입
 export interface BattleChat {

--- a/frontend/src/commons/utils/codeFormatter.ts
+++ b/frontend/src/commons/utils/codeFormatter.ts
@@ -1,4 +1,4 @@
-export type BattleLanguage = 'javascript' | 'typescript' | 'python';
+export type FormatterLanguage = 'javascript' | 'typescript' | 'python';
 
 interface FormatResult {
   code: string;
@@ -42,7 +42,7 @@ async function formatPython(code: string): Promise<string> {
   return format(code);
 }
 
-export async function formatCode(code: string, language: BattleLanguage): Promise<FormatResult> {
+export async function formatCode(code: string, language: FormatterLanguage): Promise<FormatResult> {
   if (!code.trim()) {
     return { code, formatted: false };
   }

--- a/frontend/src/features/battle/components/header/PhaseSkip.tsx
+++ b/frontend/src/features/battle/components/header/PhaseSkip.tsx
@@ -1,8 +1,8 @@
 import Icon from '@/commons/components/Icon';
-import type { BattlePhase } from '@/commons/types/battle';
+import type { BattlePhaseName } from '@/commons/types/battle';
 
 interface PhaseSkipProps {
-  phase: BattlePhase;
+  phase: BattlePhaseName;
   isSkipEnabled: boolean;
   toggleSkip: () => void;
   totalSkips: number;

--- a/frontend/src/features/battle/components/header/StageIndicator.tsx
+++ b/frontend/src/features/battle/components/header/StageIndicator.tsx
@@ -1,6 +1,6 @@
 import Icon, { type IconName } from '@/commons/components/Icon';
 import { useBattleStore, selectBattleProgress } from '@/features/battle/stores/battleStore';
-import type { BattleInfo, BattlePhase } from '@/commons/types/battle';
+import type { BattleInfo, BattlePhaseName } from '@/commons/types/battle';
 import { useLoaderData } from 'react-router-dom';
 
 interface PhaseStyle {
@@ -11,7 +11,7 @@ interface PhaseStyle {
   iconName: IconName;
 }
 
-const PHASE_CONFIG: Record<BattlePhase, PhaseStyle> = {
+const PHASE_CONFIG: Record<BattlePhaseName, PhaseStyle> = {
   PENDING: {
     category: '대기 중',
     message: '배틀이 시작되기를 기다리고 있습니다.',
@@ -56,7 +56,7 @@ export default function StageIndicator() {
 
   const topics = battleInfo?.topics || [];
   const { round, phaseCount } = battleProgress;
-  const phase = (battleProgress?.phase as BattlePhase) || 'PENDING';
+  const phase = (battleProgress?.phase as BattlePhaseName) || 'PENDING';
   const { iconName, category, message, container, icon } = PHASE_CONFIG[phase] || PHASE_CONFIG.PENDING;
   const phaseName = ['ATTACK', 'DEFENSE'].includes(phase) ? `${phaseCount}차 ${category}` : category;
 

--- a/frontend/src/features/battle/components/header/index.tsx
+++ b/frontend/src/features/battle/components/header/index.tsx
@@ -11,6 +11,7 @@ import {
   selectSelectedTeam
 } from '@/features/battle/stores/battleStore';
 import type { BattlePhaseName } from '@/commons/types/battle';
+import { BATTLE_CLIENT_EVENTS } from '@cmc/types';
 import PhaseSkip from './PhaseSkip';
 
 const PHASE_INSTRUCTIONS: Record<BattlePhaseName, string> = {
@@ -39,7 +40,7 @@ export default function BattleHeader({ isSkipEnabled, toggleSkip, totalSkips }: 
 
   const handleStart = () => {
     if (!socket || !battleId) return;
-    socket.emit('battle:start', { battleId });
+    socket.emit(BATTLE_CLIENT_EVENTS.START, { battleId });
   };
 
   return (

--- a/frontend/src/features/battle/components/header/index.tsx
+++ b/frontend/src/features/battle/components/header/index.tsx
@@ -10,10 +10,10 @@ import {
   selectSocket,
   selectSelectedTeam
 } from '@/features/battle/stores/battleStore';
-import type { BattlePhase } from '@/commons/types/battle';
+import type { BattlePhaseName } from '@/commons/types/battle';
 import PhaseSkip from './PhaseSkip';
 
-const PHASE_INSTRUCTIONS: Record<BattlePhase, string> = {
+const PHASE_INSTRUCTIONS: Record<BattlePhaseName, string> = {
   PENDING: '',
   OPINION_SHARE: '자유롭게 의견을 작성하고 투표에 참여해주세요',
   ATTACK: '주어진 시간 내에 상대 코드의 문제점을 지적해주세요',
@@ -32,7 +32,7 @@ export default function BattleHeader({ isSkipEnabled, toggleSkip, totalSkips }: 
   const team = useBattleStore(selectSelectedTeam);
   const battleId = useBattleStore(selectBattleId);
   const socket = useBattleStore(selectSocket);
-  const phase = (battleProgress?.phase as BattlePhase) || 'PENDING';
+  const phase = (battleProgress?.phase as BattlePhaseName) || 'PENDING';
   const instruction = PHASE_INSTRUCTIONS[phase] || PHASE_INSTRUCTIONS.PENDING;
 
   const isSkipVisible = team !== 'NONE';

--- a/frontend/src/features/battle/components/progressBoard/StageList.tsx
+++ b/frontend/src/features/battle/components/progressBoard/StageList.tsx
@@ -1,6 +1,6 @@
 import { StageIcon } from './StageIcon';
 import Icon from '@/commons/components/Icon';
-import type { BattlePhase } from '@/commons/types/battle';
+import type { BattlePhaseName } from '@/commons/types/battle';
 
 const COLOR_MAP = {
   BASE: { bg: '#0A0A1A', border: '#364153', text: '#99A1AF' },
@@ -64,7 +64,7 @@ const STAGES = [
 
 interface StageListProps {
   round: number;
-  phase: BattlePhase;
+  phase: BattlePhaseName;
   phaseCount: number;
 }
 
@@ -81,7 +81,7 @@ export function StageList({ round, phase, phaseCount }: StageListProps) {
     return getCurrentPhaseStep() === stageStep;
   };
 
-  const getStageColor = (stage: BattlePhase) => COLOR_MAP[stage] || COLOR_MAP.BASE;
+  const getStageColor = (stage: BattlePhaseName) => COLOR_MAP[stage] || COLOR_MAP.BASE;
 
   return (
     <div className="flex items-center gap-4 px-4">
@@ -92,7 +92,7 @@ export function StageList({ round, phase, phaseCount }: StageListProps) {
         <div key={stage.step} className="flex items-center gap-3">
           <StageIcon
             icon={stage.icon as 'message' | 'battle' | 'shield' | 'switch'}
-            {...getStageColor(stage.phase as BattlePhase)}
+            {...getStageColor(stage.phase as BattlePhaseName)}
             active={isActiveStage(stage.step)}
             small={true}
             tooltip={stage.description}

--- a/frontend/src/features/battle/components/sidebar/index.tsx
+++ b/frontend/src/features/battle/components/sidebar/index.tsx
@@ -69,7 +69,7 @@ export default function BattleSidebar({
           <BattleInfoSection
             title={title ?? ''}
             description={description ?? ''}
-            language={language ?? 'javascript'}
+            language={language ?? 'JS'}
             category={category ?? 'ALGORITHM'}
           />
         );

--- a/frontend/src/features/battle/hooks/useBattleChat.ts
+++ b/frontend/src/features/battle/hooks/useBattleChat.ts
@@ -1,5 +1,6 @@
 import { useEffect, useCallback, useMemo } from 'react';
 import type { BattleChat } from '@/commons/types/battle';
+import { BATTLE_CLIENT_EVENTS, BATTLE_SERVER_EVENTS } from '@cmc/types';
 import {
   useBattleStore,
   selectSocket,
@@ -49,9 +50,9 @@ export function useBattleChat() {
     const handleChatUpdate = (message: BattleChat) => {
       addChat(message);
     };
-    socket.on('battle:chatted', handleChatUpdate);
+    socket.on(BATTLE_SERVER_EVENTS.CHATTED, handleChatUpdate);
     return () => {
-      socket.off('battle:chatted', handleChatUpdate);
+      socket.off(BATTLE_SERVER_EVENTS.CHATTED, handleChatUpdate);
     };
   }, [socket, addChat]);
 
@@ -78,7 +79,7 @@ export function useBattleChat() {
         createdAt: new Date().toISOString()
       };
       addChat(optimisticMessage);
-      socket.emit('battle:chat', chatMessage);
+      socket.emit(BATTLE_CLIENT_EVENTS.CHAT, chatMessage);
     },
     [socket, battleId, team, user, addChat]
   );

--- a/frontend/src/features/battle/hooks/usePhaseSkip.ts
+++ b/frontend/src/features/battle/hooks/usePhaseSkip.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { selectBattleId, selectSocket, useBattleStore } from '@/features/battle/stores/battleStore';
+import { BATTLE_CLIENT_EVENTS, BATTLE_SERVER_EVENTS } from '@cmc/types';
 
 export function usePhaseSkip() {
   const socket = useBattleStore(selectSocket);
@@ -13,7 +14,7 @@ export function usePhaseSkip() {
 
     setIsSkipEnabled((prev) => {
       const next = !prev;
-      socket.emit('battle:user:skip', { skip: next, battleId: battleId });
+      socket.emit(BATTLE_CLIENT_EVENTS.USER_SKIP, { skip: next, battleId: battleId });
       return next;
     });
   }, [socket, battleId]);
@@ -37,18 +38,18 @@ export function usePhaseSkip() {
       setIsSkipEnabled(false);
       setTotalSkips(0);
     };
-    socket.on('battle:phase:skipped', handleTeamUpdateAll);
-    socket.on('battle:user:skipped', handleSkipped);
-    socket.on('battle:leaved', handleSkipped);
-    socket.on('battle:joined', handleSkipped);
-    socket.on('battle:phase:updated', handlePhaseUpdated);
+    socket.on(BATTLE_SERVER_EVENTS.PHASE_SKIPPED, handleTeamUpdateAll);
+    socket.on(BATTLE_SERVER_EVENTS.USER_SKIPPED, handleSkipped);
+    socket.on(BATTLE_SERVER_EVENTS.LEAVED, handleSkipped);
+    socket.on(BATTLE_SERVER_EVENTS.JOINED, handleSkipped);
+    socket.on(BATTLE_SERVER_EVENTS.PHASE_UPDATED, handlePhaseUpdated);
 
     return () => {
-      socket.off('battle:phase:skipped', handleTeamUpdateAll);
-      socket.off('battle:user:skipped', handleSkipped);
-      socket.off('battle:leaved', handleSkipped);
-      socket.off('battle:joined', handleSkipped);
-      socket.off('battle:phase:updated', handlePhaseUpdated);
+      socket.off(BATTLE_SERVER_EVENTS.PHASE_SKIPPED, handleTeamUpdateAll);
+      socket.off(BATTLE_SERVER_EVENTS.USER_SKIPPED, handleSkipped);
+      socket.off(BATTLE_SERVER_EVENTS.LEAVED, handleSkipped);
+      socket.off(BATTLE_SERVER_EVENTS.JOINED, handleSkipped);
+      socket.off(BATTLE_SERVER_EVENTS.PHASE_UPDATED, handlePhaseUpdated);
     };
   }, [socket]);
 

--- a/frontend/src/features/battle/hooks/useTeamVoteResult.ts
+++ b/frontend/src/features/battle/hooks/useTeamVoteResult.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useBattleStore, selectSocket, selectBattleId } from '@/features/battle/stores/battleStore';
+import { BATTLE_SERVER_EVENTS } from '@cmc/types';
 import type { BattleTeamUpdateAllResponse } from '@/commons/types/battle';
 import { soundManager } from '@/commons/utils/soundManager';
 
@@ -45,10 +46,10 @@ export function useTeamVoteResult() {
       }
     };
 
-    socket.on('battle:all:updated', handleTeamUpdateAll);
+    socket.on(BATTLE_SERVER_EVENTS.ALL_UPDATED, handleTeamUpdateAll);
 
     return () => {
-      socket.off('battle:all:updated', handleTeamUpdateAll);
+      socket.off(BATTLE_SERVER_EVENTS.ALL_UPDATED, handleTeamUpdateAll);
       if (autoCloseTimerRef.current) {
         clearTimeout(autoCloseTimerRef.current);
       }

--- a/frontend/src/features/battle/stores/battleStore.ts
+++ b/frontend/src/features/battle/stores/battleStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { Socket } from 'socket.io-client';
 import type { BattleProgressState, BattleDiscussion, BattleDefense, BattleChat } from '@/commons/types/battle';
+import { BATTLE_CLIENT_EVENTS } from '@cmc/types';
 
 interface BattleStore {
   userId: string;
@@ -176,7 +177,7 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
   setPendingBattleClosed: (pending) => set({ pendingBattleClosed: pending }),
   leaveBattle: () => {
     const { socket, battleId } = get();
-    socket?.emit('battle:leave', { battleId });
+    socket?.emit(BATTLE_CLIENT_EVENTS.LEAVE, { battleId });
 
     socket?.removeAllListeners();
     socket?.disconnect();

--- a/frontend/src/features/battle/types/teamColors.ts
+++ b/frontend/src/features/battle/types/teamColors.ts
@@ -1,4 +1,4 @@
-export type Team = 'A' | 'B' | 'NONE';
+import type { BattleTeam } from '@cmc/types';
 
 export interface TeamColors {
   primary: string;
@@ -12,7 +12,7 @@ export interface TeamColors {
   codeText: string;
 }
 
-export const TEAM_COLORS: Record<Team, TeamColors> = {
+export const TEAM_COLORS: Record<BattleTeam, TeamColors> = {
   A: {
     primary: 'text-[#6BA3FF]',
     border: 'border-[#3B6FA8]',

--- a/frontend/src/features/battle/utils/battlePhase.ts
+++ b/frontend/src/features/battle/utils/battlePhase.ts
@@ -1,4 +1,4 @@
-import type { BattlePhase, BattleProgressState, Team } from '@/commons/types/battle';
+import type { BattlePhaseName, BattleProgressState, BattleTeam } from '@/commons/types/battle';
 
 export const isBattleActive = (battleProgress: BattleProgressState | null): battleProgress is BattleProgressState => {
   if (!battleProgress) return false;
@@ -9,12 +9,12 @@ export const isBattleActive = (battleProgress: BattleProgressState | null): batt
   );
 };
 
-export const isMyTeamAttacking = (team: Team, phase?: BattlePhase): boolean => {
+export const isMyTeamAttacking = (team: BattleTeam, phase?: BattlePhaseName): boolean => {
   if (!phase) return false;
   return phase === 'ATTACK' && team !== 'NONE';
 };
 
-export const isInputDisabled = (team: Team, phase?: BattlePhase, disabled = false): boolean => {
+export const isInputDisabled = (team: BattleTeam, phase?: BattlePhaseName, disabled = false): boolean => {
   if (disabled) return true;
   if (!phase) return true;
 
@@ -24,7 +24,7 @@ export const isInputDisabled = (team: Team, phase?: BattlePhase, disabled = fals
   return false;
 };
 
-export const getDiscussionConfig = (phase?: BattlePhase) => {
+export const getDiscussionConfig = (phase?: BattlePhaseName) => {
   if (phase === 'ATTACK') {
     return {
       label: '이의제기',

--- a/frontend/src/features/battle/utils/convertChatMessage.ts
+++ b/frontend/src/features/battle/utils/convertChatMessage.ts
@@ -1,9 +1,9 @@
-import type { BattleChat, Team } from '@/commons/types/battle';
+import type { BattleChat, BattleTeam } from '@/commons/types/battle';
 
 export interface Message {
   id: string;
   user: string;
-  team: Team;
+  team: BattleTeam;
   content: string;
   timestamp: string;
   tier?: string;

--- a/frontend/src/pages/battleCreatePage/api/types.ts
+++ b/frontend/src/pages/battleCreatePage/api/types.ts
@@ -1,5 +1,5 @@
 export type BattleType = 'PUBLIC' | 'PRIVATE';
-export type BattleLanguage = 'javascript' | 'typescript' | 'python';
+export type BattleLanguage = 'TS' | 'JS' | 'PYTHON';
 export type BattlePlayTime = 'FIFTEEN_MIN' | 'THIRTY_MIN';
 
 export interface CreateBattleRequest {

--- a/frontend/src/pages/battleCreatePage/api/types.ts
+++ b/frontend/src/pages/battleCreatePage/api/types.ts
@@ -1,4 +1,5 @@
-export type { BattleType, BattleLanguage } from '@cmc/types';
+import type { BattleType, BattleLanguage } from '@cmc/types';
+export type { BattleType, BattleLanguage };
 export type BattlePlayTime = 'FIFTEEN_MIN' | 'THIRTY_MIN';
 
 export interface CreateBattleRequest {

--- a/frontend/src/pages/battleCreatePage/api/types.ts
+++ b/frontend/src/pages/battleCreatePage/api/types.ts
@@ -1,5 +1,4 @@
-export type BattleType = 'PUBLIC' | 'PRIVATE';
-export type BattleLanguage = 'TS' | 'JS' | 'PYTHON';
+export type { BattleType, BattleLanguage } from '@cmc/types';
 export type BattlePlayTime = 'FIFTEEN_MIN' | 'THIRTY_MIN';
 
 export interface CreateBattleRequest {

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { BATTLE_CATEGORY_CONFIG } from '../mainPage/types/battle';
 import BattleTopicInput from './components/BattleTopicInput';
-import { formatCode } from '@/commons/utils/codeFormatter';
+import { formatCode, type FormatterLanguage } from '@/commons/utils/codeFormatter';
 import { languageMapper } from '@/commons/utils/languageMapper';
 import { selectUser, useAuthStore } from '@/commons/stores/authStore';
 import { useToastStore, selectAddToast } from '@/commons/stores/toastStore';
@@ -67,7 +67,7 @@ export default function BattleCreatePage() {
   const handleSubmit = async () => {
     if (!canSubmit || isPending) return;
 
-    const formatterLang = languageMapper(language) as Parameters<typeof formatCode>[1];
+    const formatterLang = languageMapper(language) as FormatterLanguage;
     const [formattedA, formattedB] = await Promise.all([
       formatCode(aCode, formatterLang),
       formatCode(bCode, formatterLang)

--- a/frontend/src/pages/battleCreatePage/index.tsx
+++ b/frontend/src/pages/battleCreatePage/index.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { BATTLE_CATEGORY_CONFIG } from '../mainPage/types/battle';
 import BattleTopicInput from './components/BattleTopicInput';
 import { formatCode } from '@/commons/utils/codeFormatter';
+import { languageMapper } from '@/commons/utils/languageMapper';
 import { selectUser, useAuthStore } from '@/commons/stores/authStore';
 import { useToastStore, selectAddToast } from '@/commons/stores/toastStore';
 import { useCreateBattle } from './hooks/useCreateBattle';
@@ -10,9 +11,9 @@ import Button from '@/commons/components/Button';
 import type { BattleType, BattleLanguage, BattlePlayTime } from './api/types';
 
 const LANGUAGE_OPTIONS: Array<{ label: string; value: BattleLanguage }> = [
-  { label: 'JavaScript', value: 'javascript' },
-  { label: 'TypeScript', value: 'typescript' },
-  { label: 'Python', value: 'python' }
+  { label: 'JavaScript', value: 'JS' },
+  { label: 'TypeScript', value: 'TS' },
+  { label: 'Python', value: 'PYTHON' }
 ];
 
 const PLAYTIME_OPTIONS: Array<{ label: string; value: BattlePlayTime; rounds: number }> = [
@@ -44,7 +45,7 @@ export default function BattleCreatePage() {
   const [description, setDescription] = useState('');
   const [aCode, setACode] = useState('');
   const [bCode, setBCode] = useState('');
-  const [language, setLanguage] = useState<BattleLanguage>('javascript');
+  const [language, setLanguage] = useState<BattleLanguage>('JS');
   const [category, setCategory] = useState(categoryOptions[0]?.value ?? 'ALGORITHM');
   const [playTime, setPlayTime] = useState<BattlePlayTime>('FIFTEEN_MIN');
   const [topics, setTopics] = useState<string[]>([]);
@@ -66,7 +67,11 @@ export default function BattleCreatePage() {
   const handleSubmit = async () => {
     if (!canSubmit || isPending) return;
 
-    const [formattedA, formattedB] = await Promise.all([formatCode(aCode, language), formatCode(bCode, language)]);
+    const formatterLang = languageMapper(language) as Parameters<typeof formatCode>[1];
+    const [formattedA, formattedB] = await Promise.all([
+      formatCode(aCode, formatterLang),
+      formatCode(bCode, formatterLang)
+    ]);
 
     if (!authorId) {
       addToast({ message: '로그인이 필요합니다.' });

--- a/frontend/src/pages/battlePage/components/BattleMainContent.tsx
+++ b/frontend/src/pages/battlePage/components/BattleMainContent.tsx
@@ -30,7 +30,7 @@ export default function BattleMainContent({ isSidebarOpen, onVote, onDiscussionS
             <CodeSection
               onViewChange={setViewMode}
               currentView={viewMode}
-              language={language ?? 'javascript'}
+              language={language ?? 'JS'}
               codeA={codeA ?? ''}
               codeB={codeB ?? ''}
             />

--- a/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
@@ -10,7 +10,7 @@ import {
 import { getDiscussionConfig, isInputDisabled } from '@/features/battle/utils/battlePhase';
 import { selectUser, useAuthStore } from '@/commons/stores/authStore';
 import { soundManager } from '@/commons/utils/soundManager';
-import { BATTLE_SERVER_EVENTS } from '@cmc/types';
+import { BATTLE_SERVER_EVENTS, BATTLE_CLIENT_EVENTS } from '@cmc/types';
 
 export function useBattleDiscussions() {
   const socket = useBattleStore(selectSocket);
@@ -29,7 +29,7 @@ export function useBattleDiscussions() {
       if (targetDiscussion?.hasVoted) return;
 
       const { isAttacking } = getDiscussionConfig(battleProgress?.phase);
-      const eventName = isAttacking ? 'battle:attack:vote' : 'battle:defense:vote';
+      const eventName = isAttacking ? BATTLE_CLIENT_EVENTS.ATTACK_VOTE : BATTLE_CLIENT_EVENTS.DEFENSE_VOTE;
 
       soundManager.play('click2');
 
@@ -54,7 +54,7 @@ export function useBattleDiscussions() {
         return;
       }
 
-      socket.emit(isAttacking ? 'battle:attack' : 'battle:defense', {
+      socket.emit(isAttacking ? BATTLE_CLIENT_EVENTS.ATTACK : BATTLE_CLIENT_EVENTS.DEFENSE, {
         battleId,
         authorId: user.id,
         content,

--- a/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleDiscussions.ts
@@ -10,6 +10,7 @@ import {
 import { getDiscussionConfig, isInputDisabled } from '@/features/battle/utils/battlePhase';
 import { selectUser, useAuthStore } from '@/commons/stores/authStore';
 import { soundManager } from '@/commons/utils/soundManager';
+import { BATTLE_SERVER_EVENTS } from '@cmc/types';
 
 export function useBattleDiscussions() {
   const socket = useBattleStore(selectSocket);
@@ -95,16 +96,16 @@ export function useBattleDiscussions() {
       soundManager.play('notificationPing');
     };
 
-    socket.on('battle:attack:voted', handleVoteUpdate);
-    socket.on('battle:defense:voted', handleVoteUpdate);
-    socket.on('battle:attack:created', handleNewDiscussion);
-    socket.on('battle:defense:created', handleNewDiscussion);
+    socket.on(BATTLE_SERVER_EVENTS.ATTACK_VOTED, handleVoteUpdate);
+    socket.on(BATTLE_SERVER_EVENTS.DEFENSE_VOTED, handleVoteUpdate);
+    socket.on(BATTLE_SERVER_EVENTS.ATTACK_CREATED, handleNewDiscussion);
+    socket.on(BATTLE_SERVER_EVENTS.DEFENSE_CREATED, handleNewDiscussion);
 
     return () => {
-      socket.off('battle:attack:voted', handleVoteUpdate);
-      socket.off('battle:defense:voted', handleVoteUpdate);
-      socket.off('battle:attack:created', handleNewDiscussion);
-      socket.off('battle:defense:created', handleNewDiscussion);
+      socket.off(BATTLE_SERVER_EVENTS.ATTACK_VOTED, handleVoteUpdate);
+      socket.off(BATTLE_SERVER_EVENTS.DEFENSE_VOTED, handleVoteUpdate);
+      socket.off(BATTLE_SERVER_EVENTS.ATTACK_CREATED, handleNewDiscussion);
+      socket.off(BATTLE_SERVER_EVENTS.DEFENSE_CREATED, handleNewDiscussion);
     };
   }, [socket, user, team, updateDiscussionVote, addDiscussion]);
 

--- a/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleProgress.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
 import type { BattleProgressState } from '@/commons/types/battle';
 import { useBattleStore, selectSocket } from '@/features/battle/stores/battleStore';
+import { BATTLE_SERVER_EVENTS } from '@cmc/types';
 import { useRoundUpdateModal } from './useRoundUpdateModal';
 import { soundManager } from '@/commons/utils/soundManager';
 
@@ -63,8 +64,8 @@ export function useBattleProgress() {
       showEffect(data.round, data.topic);
     };
 
-    socket.on('battle:phase:updated', handlePhaseUpdate);
-    socket.on('battle:round:updated', handleRoundUpdate);
+    socket.on(BATTLE_SERVER_EVENTS.PHASE_UPDATED, handlePhaseUpdate);
+    socket.on(BATTLE_SERVER_EVENTS.ROUND_UPDATED, handleRoundUpdate);
 
     const handleBattleClosed = (data: { battleId: string }) => {
       const { isTeamVoteResultShowing, setPendingBattleClosed } = useBattleStore.getState();
@@ -76,12 +77,12 @@ export function useBattleProgress() {
         navigate(`/battles/${data.battleId}/result`);
       }
     };
-    socket.on('battle:closed', handleBattleClosed);
+    socket.on(BATTLE_SERVER_EVENTS.CLOSED, handleBattleClosed);
 
     return () => {
-      socket.off('battle:phase:updated', handlePhaseUpdate);
-      socket.off('battle:round:updated', handleRoundUpdate);
-      socket.off('battle:closed', handleBattleClosed);
+      socket.off(BATTLE_SERVER_EVENTS.PHASE_UPDATED, handlePhaseUpdate);
+      socket.off(BATTLE_SERVER_EVENTS.ROUND_UPDATED, handleRoundUpdate);
+      socket.off(BATTLE_SERVER_EVENTS.CLOSED, handleBattleClosed);
     };
   }, [socket, setCurrentStage, updateBattleProgress, navigate, showEffect]);
 

--- a/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocket.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { io } from 'socket.io-client';
 import type { BattleJoinData } from '@/commons/types/battle';
+import { BATTLE_CLIENT_EVENTS, BATTLE_SERVER_EVENTS } from '@cmc/types';
 import { useBattleStore } from '@/features/battle/stores/battleStore';
 import { useAuthStore, selectUser } from '@/commons/stores/authStore';
 
@@ -46,7 +47,7 @@ export function useBattleSocket() {
 
     newSocket.on('connect', () => {
       setIsConnected(true);
-      newSocket.emit('battle:join', {
+      newSocket.emit(BATTLE_CLIENT_EVENTS.JOIN, {
         userId,
         battleId,
         team: selectedTeam,
@@ -55,7 +56,7 @@ export function useBattleSocket() {
     });
 
     // 배틀 참여 성공시 데이터 동기화
-    newSocket.on('battle:joined', (data: BattleJoinData) => {
+    newSocket.on(BATTLE_SERVER_EVENTS.JOINED, (data: BattleJoinData) => {
       // 초기 battleState 설정
       setBattleProgress({
         round: data.round,
@@ -132,7 +133,7 @@ export function useBattleSocket() {
       }
     });
 
-    newSocket.on('battle:leaved', (data) => {
+    newSocket.on(BATTLE_SERVER_EVENTS.LEAVED, (data) => {
       setTeamCounts({
         teamACount: data.counts.teamA,
         teamBCount: data.counts.teamB,
@@ -142,15 +143,15 @@ export function useBattleSocket() {
 
     return () => {
       newSocket.off('connect');
-      newSocket.off('battle:joined');
-      newSocket.off('battle:phase:updated');
-      newSocket.off('battle:round:updated');
-      newSocket.off('battle:attacked');
-      newSocket.off('battle:defensed');
-      newSocket.off('battle:attack:voted');
-      newSocket.off('battle:defense:voted');
-      newSocket.off('battle:attack:created');
-      newSocket.off('battle:defense:created');
+      newSocket.off(BATTLE_SERVER_EVENTS.JOINED);
+      newSocket.off(BATTLE_SERVER_EVENTS.PHASE_UPDATED);
+      newSocket.off(BATTLE_SERVER_EVENTS.ROUND_UPDATED);
+      newSocket.off(BATTLE_SERVER_EVENTS.ATTACKED);
+      newSocket.off(BATTLE_SERVER_EVENTS.DEFENSED);
+      newSocket.off(BATTLE_SERVER_EVENTS.ATTACK_VOTED);
+      newSocket.off(BATTLE_SERVER_EVENTS.DEFENSE_VOTED);
+      newSocket.off(BATTLE_SERVER_EVENTS.ATTACK_CREATED);
+      newSocket.off(BATTLE_SERVER_EVENTS.DEFENSE_CREATED);
       newSocket.disconnect();
       setSocket(null);
       setIsConnected(false);

--- a/frontend/src/pages/battlePage/hooks/useBattleSocketErrorHandling.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleSocketErrorHandling.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import * as Sentry from '@sentry/react';
 import { useBattleStore } from '@/features/battle/stores/battleStore';
 import { useToastStore } from '@/commons/stores/toastStore';
+import { BATTLE_SERVER_EVENTS } from '@cmc/types';
 
 interface ErrorPayload {
   message: string;
@@ -141,7 +142,7 @@ export function useBattleSocketErrorHandling() {
     });
 
     // 서버 비즈니스 에러 핸들러
-    socket.on('battle:join:error', (data: ErrorPayload) => {
+    socket.on(BATTLE_SERVER_EVENTS.JOIN_ERROR, (data: ErrorPayload) => {
       addToast({ message: data.message || '배틀 입장에 실패했습니다.' });
 
       Sentry.captureException(new Error('배틀 입장 실패'), {
@@ -156,7 +157,7 @@ export function useBattleSocketErrorHandling() {
       });
     });
 
-    socket.on('battle:attack:error', (data: ErrorPayload) => {
+    socket.on(BATTLE_SERVER_EVENTS.ATTACK_ERROR, (data: ErrorPayload) => {
       addToast({ message: data.message || '공격 제출에 실패했습니다.' });
 
       Sentry.captureException(new Error('공격 제출 실패'), {
@@ -171,7 +172,7 @@ export function useBattleSocketErrorHandling() {
       });
     });
 
-    socket.on('battle:defense:error', (data: ErrorPayload) => {
+    socket.on(BATTLE_SERVER_EVENTS.DEFENSE_ERROR, (data: ErrorPayload) => {
       addToast({ message: data.message || '방어 제출에 실패했습니다.' });
 
       Sentry.captureException(new Error('방어 제출 실패'), {
@@ -186,7 +187,7 @@ export function useBattleSocketErrorHandling() {
       });
     });
 
-    socket.on('battle:attack:vote:error', (data: ErrorPayload) => {
+    socket.on(BATTLE_SERVER_EVENTS.ATTACK_VOTE_ERROR, (data: ErrorPayload) => {
       addToast({ message: data.message || '투표에 실패했습니다.' });
 
       Sentry.captureException(new Error('공격 투표 실패'), {
@@ -201,7 +202,7 @@ export function useBattleSocketErrorHandling() {
       });
     });
 
-    socket.on('battle:defense:vote:error', (data: ErrorPayload) => {
+    socket.on(BATTLE_SERVER_EVENTS.DEFENSE_VOTE_ERROR, (data: ErrorPayload) => {
       addToast({ message: data.message || '투표에 실패했습니다.' });
 
       Sentry.captureException(new Error('방어 투표 실패'), {
@@ -216,7 +217,7 @@ export function useBattleSocketErrorHandling() {
       });
     });
 
-    socket.on('battle:chat:error', (data: ErrorPayload) => {
+    socket.on(BATTLE_SERVER_EVENTS.CHAT_ERROR, (data: ErrorPayload) => {
       addToast({ message: data.message || '메시지 전송에 실패했습니다.' });
 
       Sentry.captureException(new Error('채팅 전송 실패'), {
@@ -231,7 +232,7 @@ export function useBattleSocketErrorHandling() {
       });
     });
 
-    socket.on('battle:team:vote:error', (data: ErrorPayload) => {
+    socket.on(BATTLE_SERVER_EVENTS.TEAM_VOTE_ERROR, (data: ErrorPayload) => {
       addToast({ message: data.message || '팀 투표에 실패했습니다.' });
 
       Sentry.captureException(new Error('팀 투표 실패'), {
@@ -246,7 +247,7 @@ export function useBattleSocketErrorHandling() {
       });
     });
 
-    socket.on('battle:user:skip:error', (data: ErrorPayload) => {
+    socket.on(BATTLE_SERVER_EVENTS.USER_SKIP_ERROR, (data: ErrorPayload) => {
       addToast({ message: data.message || '스킵 요청에 실패했습니다.' });
 
       Sentry.captureException(new Error('스킵 요청 실패'), {
@@ -268,14 +269,14 @@ export function useBattleSocketErrorHandling() {
       socket.io.off('reconnect');
       socket.io.off('reconnect_attempt');
       socket.io.off('reconnect_failed');
-      socket.off('battle:join:error');
-      socket.off('battle:attack:error');
-      socket.off('battle:defense:error');
-      socket.off('battle:attack:vote:error');
-      socket.off('battle:defense:vote:error');
-      socket.off('battle:chat:error');
-      socket.off('battle:team:vote:error');
-      socket.off('battle:user:skip:error');
+      socket.off(BATTLE_SERVER_EVENTS.JOIN_ERROR);
+      socket.off(BATTLE_SERVER_EVENTS.ATTACK_ERROR);
+      socket.off(BATTLE_SERVER_EVENTS.DEFENSE_ERROR);
+      socket.off(BATTLE_SERVER_EVENTS.ATTACK_VOTE_ERROR);
+      socket.off(BATTLE_SERVER_EVENTS.DEFENSE_VOTE_ERROR);
+      socket.off(BATTLE_SERVER_EVENTS.CHAT_ERROR);
+      socket.off(BATTLE_SERVER_EVENTS.TEAM_VOTE_ERROR);
+      socket.off(BATTLE_SERVER_EVENTS.USER_SKIP_ERROR);
     };
   }, [socket, setIsConnected, setConnectionError, addToast]);
 }

--- a/frontend/src/pages/battlePage/hooks/useBattleTeam.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTeam.ts
@@ -10,6 +10,7 @@ import {
 } from '@/features/battle/stores/battleStore';
 import type { BattleUserUpdateResponse } from '@/commons/types/battle';
 import { soundManager } from '@/commons/utils/soundManager';
+import { BATTLE_CLIENT_EVENTS, BATTLE_SERVER_EVENTS } from '@cmc/types';
 
 interface UseBattleTeamProps {
   onOpenTeamChangeModal: () => void;
@@ -56,10 +57,10 @@ export function useBattleTeam({ onOpenTeamChangeModal, onCloseTeamChangeModal }:
       });
     };
 
-    socket.on('battle:team:updated', handleChangedTeam);
+    socket.on(BATTLE_SERVER_EVENTS.TEAM_UPDATED, handleChangedTeam);
 
     return () => {
-      socket.off('battle:team:updated', handleChangedTeam);
+      socket.off(BATTLE_SERVER_EVENTS.TEAM_UPDATED, handleChangedTeam);
     };
   }, [socket, battleId, setSelectedTeam]);
 
@@ -80,10 +81,10 @@ export function useBattleTeam({ onOpenTeamChangeModal, onCloseTeamChangeModal }:
       );
     };
 
-    socket.on('battle:user:updated', handleUserUpdate);
+    socket.on(BATTLE_SERVER_EVENTS.USER_UPDATED, handleUserUpdate);
 
     return () => {
-      socket.off('battle:user:updated', handleUserUpdate);
+      socket.off(BATTLE_SERVER_EVENTS.USER_UPDATED, handleUserUpdate);
     };
   }, [socket, battleId, setTeamCounts]);
 
@@ -109,7 +110,7 @@ export function useBattleTeam({ onOpenTeamChangeModal, onCloseTeamChangeModal }:
       setTeamCounts(newCounts);
 
       // 서버에 전송
-      socket.emit('battle:team:vote', { battleId, team });
+      socket.emit(BATTLE_CLIENT_EVENTS.TEAM_VOTE, { battleId, team });
 
       onCloseTeamChangeModal();
     },

--- a/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
@@ -5,7 +5,7 @@ import type {
   BattleDiscussion,
   BattleDefense,
   BattleChat,
-  Team
+  BattleTeam
 } from '@/commons/types/battle';
 import { useBattleStore, selectSelectedTeam, selectSocket } from '@/features/battle/stores/battleStore';
 import { useEffectModal } from './useEffectModal';
@@ -20,7 +20,7 @@ export function useBattleTimeline() {
 
     const pushTimelineAndChat = (
       battleId: string,
-      team: Team,
+      team: BattleTeam,
       entry: {
         id: string | null;
         text: string | null;

--- a/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
+++ b/frontend/src/pages/battlePage/hooks/useBattleTimeline.ts
@@ -8,6 +8,7 @@ import type {
   BattleTeam
 } from '@/commons/types/battle';
 import { useBattleStore, selectSelectedTeam, selectSocket } from '@/features/battle/stores/battleStore';
+import { BATTLE_SERVER_EVENTS } from '@cmc/types';
 import { useEffectModal } from './useEffectModal';
 
 export function useBattleTimeline() {
@@ -184,12 +185,12 @@ export function useBattleTimeline() {
       }
     };
 
-    socket.on('battle:attacked', handleAttacked);
-    socket.on('battle:defensed', handleDefensed);
+    socket.on(BATTLE_SERVER_EVENTS.ATTACKED, handleAttacked);
+    socket.on(BATTLE_SERVER_EVENTS.DEFENSED, handleDefensed);
 
     return () => {
-      socket.off('battle:attacked', handleAttacked);
-      socket.off('battle:defensed', handleDefensed);
+      socket.off(BATTLE_SERVER_EVENTS.ATTACKED, handleAttacked);
+      socket.off(BATTLE_SERVER_EVENTS.DEFENSED, handleDefensed);
     };
   }, [socket, showEffect, selectedTeam]);
 

--- a/frontend/src/pages/battlePage/hooks/useEffectModal.ts
+++ b/frontend/src/pages/battlePage/hooks/useEffectModal.ts
@@ -1,10 +1,10 @@
 import { useState, useCallback } from 'react';
-import type { Team } from '@/commons/types/battle';
+import type { BattleTeam } from '@/commons/types/battle';
 import { soundManager } from '@/commons/utils/soundManager';
 
 export interface EffectModalState {
   isOpen: boolean;
-  team: Team;
+  team: BattleTeam;
   content: string;
   type: 'attack' | 'defense';
 }
@@ -17,7 +17,7 @@ export function useEffectModal() {
     type: 'attack'
   });
 
-  const showEffect = useCallback((team: Team, content: string, type: 'attack' | 'defense') => {
+  const showEffect = useCallback((team: BattleTeam, content: string, type: 'attack' | 'defense') => {
     setEffectModal({
       isOpen: true,
       team,

--- a/frontend/src/pages/battlePage/utils/getTurnInfo.ts
+++ b/frontend/src/pages/battlePage/utils/getTurnInfo.ts
@@ -1,4 +1,4 @@
-import type { BattlePhase } from '@/commons/types/battle';
+import type { BattlePhaseName } from '@/commons/types/battle';
 
 interface PhaseInfo {
   title: string;
@@ -13,7 +13,7 @@ export const getPhaseInfo = (phase: string | null): PhaseInfo => {
     };
   }
 
-  const PHASE_MAP: Record<BattlePhase, PhaseInfo> = {
+  const PHASE_MAP: Record<BattlePhaseName, PhaseInfo> = {
     PENDING: {
       title: '대기 중',
       description: '배틀이 곧 시작됩니다.'
@@ -37,7 +37,7 @@ export const getPhaseInfo = (phase: string | null): PhaseInfo => {
   };
 
   if (phase in PHASE_MAP) {
-    return PHASE_MAP[phase as BattlePhase];
+    return PHASE_MAP[phase as BattlePhaseName];
   }
 
   return {

--- a/frontend/src/pages/battlePage/utils/test/getDiscussionConfig.test.ts
+++ b/frontend/src/pages/battlePage/utils/test/getDiscussionConfig.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { getDiscussionConfig } from '@/features/battle/utils/battlePhase';
-import type { BattlePhase } from '@/commons/types/battle';
+import type { BattlePhaseName } from '@/commons/types/battle';
 
 describe('getDiscussionConfig', () => {
   it('ATTACK 페이즈에는 이의제기 설정 반환', () => {
-    const config = getDiscussionConfig('ATTACK' as BattlePhase);
+    const config = getDiscussionConfig('ATTACK' as BattlePhaseName);
 
     expect(config.label).toBe('이의제기');
     expect(config.placeholderText).toBe('상대 코드의 허점을 찾아 이의 제기하세요');
@@ -17,7 +17,7 @@ describe('getDiscussionConfig', () => {
   });
 
   it('DEFENSE 페이즈에는 반박 설정 반환', () => {
-    const config = getDiscussionConfig('DEFENSE' as BattlePhase);
+    const config = getDiscussionConfig('DEFENSE' as BattlePhaseName);
 
     expect(config.label).toBe('반론');
     expect(config.placeholderText).toBe('상대 주장에 논리적으로 반박해 보세요');
@@ -30,7 +30,7 @@ describe('getDiscussionConfig', () => {
   });
 
   it('ATTACK/DEFENSE 외 페이즈에는 비활성 설정 반환', () => {
-    const config = getDiscussionConfig('OPINION_SHARE' as BattlePhase);
+    const config = getDiscussionConfig('OPINION_SHARE' as BattlePhaseName);
 
     expect(config.label).toBe('');
     expect(config.placeholderText).toBe('');

--- a/frontend/src/pages/battleResultPage/apis/types.ts
+++ b/frontend/src/pages/battleResultPage/apis/types.ts
@@ -1,4 +1,4 @@
-import type { Team } from '@/commons/types/battle';
+import type { BattleTeam } from '@/commons/types/battle';
 
 export interface VoteResult {
   votes: number;
@@ -6,7 +6,7 @@ export interface VoteResult {
 }
 
 export interface BattleResult {
-  winner: Exclude<Team, 'NONE'> | 'DRAW';
+  winner: Exclude<BattleTeam, 'NONE'> | 'DRAW';
   teamA: VoteResult;
   teamB: VoteResult;
   neutral: VoteResult;
@@ -37,7 +37,7 @@ export interface TimelineItem {
   id: string;
   type: DiscussionType;
   author: TimelineAuthor;
-  team: Exclude<Team, 'NONE'>;
+  team: Exclude<BattleTeam, 'NONE'>;
   content: string;
   turn: number;
   upvotes: number;
@@ -47,7 +47,7 @@ export interface TimelineItem {
 export interface Mvp {
   userId: string;
   nickname: string;
-  team: Exclude<Team, 'NONE'>;
+  team: Exclude<BattleTeam, 'NONE'>;
   score: number;
   totalVotes: number;
   opinionCount: number;

--- a/frontend/src/pages/battleResultPage/types/index.ts
+++ b/frontend/src/pages/battleResultPage/types/index.ts
@@ -1,4 +1,4 @@
-import type { Team } from '@/commons/types/battle';
+import type { BattleTeam } from '@/commons/types/battle';
 
 export interface VoteResult {
   votes: number;
@@ -6,7 +6,7 @@ export interface VoteResult {
 }
 
 export interface BattleResult {
-  winner: Exclude<Team, 'NONE'> | 'DRAW';
+  winner: Exclude<BattleTeam, 'NONE'> | 'DRAW';
   teamA: VoteResult;
   teamB: VoteResult;
   neutral: VoteResult;
@@ -37,7 +37,7 @@ export interface TimelineItem {
   id: string;
   type: DiscussionType;
   author: TimelineAuthor;
-  team: Exclude<Team, 'NONE'>;
+  team: Exclude<BattleTeam, 'NONE'>;
   content: string;
   turn: number;
   upvotes: number;
@@ -47,7 +47,7 @@ export interface TimelineItem {
 export interface Mvp {
   userId: string;
   nickname: string;
-  team: Team;
+  team: BattleTeam;
   score: number;
   totalVotes: number;
   opinionCount: number;

--- a/frontend/src/pages/mainPage/types/battle.ts
+++ b/frontend/src/pages/mainPage/types/battle.ts
@@ -1,8 +1,7 @@
 import type { IconName } from '@/commons/components/Icon';
+import type { BattleCategory, BattleStatus } from '@cmc/types';
 
-export type BattleCategory = 'ALGORITHM' | 'REFACTORING' | 'IMPLEMENT' | 'ETC';
-
-export type BattleStatus = 'OPEN' | 'CLOSED' | 'PENDING';
+export type { BattleCategory, BattleStatus } from '@cmc/types';
 export type WinnerTeam = 'A' | 'B' | 'DRAW';
 
 export const BATTLE_CATEGORY_CONFIG: Record<

--- a/frontend/src/pages/mainPage/types/battle.ts
+++ b/frontend/src/pages/mainPage/types/battle.ts
@@ -1,6 +1,6 @@
 import type { IconName } from '@/commons/components/Icon';
 
-export type BattleCategory = 'ALGORITHM' | 'REFACTORING' | 'IMPLEMENTATION' | 'ETC';
+export type BattleCategory = 'ALGORITHM' | 'REFACTORING' | 'IMPLEMENT' | 'ETC';
 
 export type BattleStatus = 'OPEN' | 'CLOSED' | 'PENDING';
 export type WinnerTeam = 'A' | 'B' | 'DRAW';
@@ -37,8 +37,8 @@ export const BATTLE_CATEGORY_CONFIG: Record<
     icon: 'battle'
   },
 
-  IMPLEMENTATION: {
-    key: 'IMPLEMENTATION',
+  IMPLEMENT: {
+    key: 'IMPLEMENT',
     title: '💡 구현 배틀',
     description: '같은 기능, 다른 접근법의 대결',
     text: 'text-orange-400',

--- a/frontend/src/pages/teamSelectPage/components/TeamCard.tsx
+++ b/frontend/src/pages/teamSelectPage/components/TeamCard.tsx
@@ -1,9 +1,9 @@
-import type { Team } from '@/commons/types/battle';
+import type { BattleTeam } from '@/commons/types/battle';
 import Icon from '@/commons/components/Icon';
 import type { IconName } from '@/commons/components/Icon';
 
 interface TeamCardProps {
-  team: Team;
+  team: BattleTeam;
   label: string;
   description: string;
   isSelected: boolean;

--- a/frontend/src/pages/teamSelectPage/components/steps/BattleInfo/RoundProgressCard.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/BattleInfo/RoundProgressCard.tsx
@@ -1,12 +1,12 @@
 import Icon from '@/commons/components/Icon';
-import type { BattlePhase } from '@/commons/types/battle';
+import type { BattlePhaseName } from '@/commons/types/battle';
 import { PHASE_CONFIG } from './phaseConfig';
 
 interface RoundProgressCardProps {
   currentRound: number;
   totalRounds: number;
   topics: string[];
-  currentPhase: BattlePhase | null;
+  currentPhase: BattlePhaseName | null;
   phaseCount: number | null;
 }
 

--- a/frontend/src/pages/teamSelectPage/components/steps/BattleInfo/phaseConfig.ts
+++ b/frontend/src/pages/teamSelectPage/components/steps/BattleInfo/phaseConfig.ts
@@ -1,5 +1,5 @@
 import type { IconName } from '@/commons/components/Icon';
-import type { BattlePhase } from '@/commons/types/battle';
+import type { BattlePhaseName } from '@/commons/types/battle';
 
 export interface PhaseConfig {
   label: string;
@@ -9,7 +9,7 @@ export interface PhaseConfig {
   icon: IconName;
 }
 
-export const PHASE_CONFIG: Record<BattlePhase, PhaseConfig> = {
+export const PHASE_CONFIG: Record<BattlePhaseName, PhaseConfig> = {
   PENDING: {
     label: '대기 중',
     color: 'text-gray-400',

--- a/frontend/src/pages/teamSelectPage/components/steps/TeamSelect.tsx
+++ b/frontend/src/pages/teamSelectPage/components/steps/TeamSelect.tsx
@@ -1,10 +1,10 @@
 import Icon from '@/commons/components/Icon';
 import TeamCard from '../TeamCard';
-import type { Team } from '@/commons/types/battle';
+import type { BattleTeam } from '@/commons/types/battle';
 
 interface TeamSelectProps {
-  onSelect: (team: Team) => void;
-  selectedTeam?: Team;
+  onSelect: (team: BattleTeam) => void;
+  selectedTeam?: BattleTeam;
 }
 
 export default function TeamSelect({ onSelect, selectedTeam }: TeamSelectProps) {

--- a/frontend/src/pages/teamSelectPage/hooks/useTeamSelectSubmit.ts
+++ b/frontend/src/pages/teamSelectPage/hooks/useTeamSelectSubmit.ts
@@ -1,11 +1,11 @@
 import { useNavigate } from 'react-router-dom';
 import { selectIsOAuth, selectUser, useAuthStore } from '@/commons/stores/authStore';
 import { useBattleStore } from '@/features/battle/stores/battleStore';
-import type { Team } from '@/commons/types/battle';
+import type { BattleTeam } from '@/commons/types/battle';
 
 interface UseTeamSelectSubmitOptions {
   battleId: string;
-  selectedTeam: Team | null;
+  selectedTeam: BattleTeam | null;
 }
 
 export function useTeamSelectSubmit({ battleId, selectedTeam }: UseTeamSelectSubmitOptions) {

--- a/frontend/src/pages/teamSelectPage/index.tsx
+++ b/frontend/src/pages/teamSelectPage/index.tsx
@@ -13,7 +13,7 @@ import CodeCompare from './components/steps/CodeCompare';
 import ReferenceData from './components/steps/ReferenceData';
 import Timeline from './components/steps/Timeline';
 import TeamSelect from './components/steps/TeamSelect';
-import type { Team } from '@/commons/types/battle';
+import type { BattleTeam } from '@/commons/types/battle';
 
 export default function TeamSelectPage() {
   const { id } = useParams<{ id: string }>();
@@ -21,7 +21,7 @@ export default function TeamSelectPage() {
   const hasReferenceData = !!battleInfo?.referenceData;
   const totalSteps = hasReferenceData ? 5 : 4;
   const { currentStep, goToNext, goToPrev, isLastStep } = useStepFlow({ totalSteps });
-  const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
+  const [selectedTeam, setSelectedTeam] = useState<BattleTeam | null>(null);
   const isLoggingIn = useAuthStore(selectIsLoggingIn);
   const { handleSubmit } = useTeamSelectSubmit({ battleId: id!, selectedTeam });
 

--- a/frontend/src/pages/tutorialPage/battle/hooks/usePracticeFlow.ts
+++ b/frontend/src/pages/tutorialPage/battle/hooks/usePracticeFlow.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { BattlePhase } from '@/commons/types/battle';
+import type { BattlePhaseName } from '@/commons/types/battle';
 import { useBattleStore, selectBattleProgress } from '@/features/battle/stores/battleStore';
 import { useAuthStore } from '@/commons/stores/authStore';
 import { soundManager } from '@/commons/utils/soundManager';
@@ -99,7 +99,7 @@ export function usePracticeFlow({ currentStep, onOpenTeamChangeModal }: Practice
   }, [introOverride, practicePhase]);
 
   const updatePhase = useCallback(
-    (phase: BattlePhase) => {
+    (phase: BattlePhaseName) => {
       const now = Date.now();
       const expiresInMs = 3 * 60 * 1000;
       useBattleStore.getState().updateBattleProgress({

--- a/frontend/src/pages/tutorialPage/battle/index.tsx
+++ b/frontend/src/pages/tutorialPage/battle/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import Button from '@/commons/components/Button';
 import { useLocation, useNavigate, useLoaderData } from 'react-router-dom';
-import type { BattleInfo, Team } from '@/commons/types/battle';
+import type { BattleInfo, BattleTeam } from '@/commons/types/battle';
 import useModal from '@/commons/hooks/useModal';
 import { useBattleStore, selectBattleProgress, selectSelectedTeam } from '@/features/battle/stores/battleStore';
 import { isInputDisabled } from '@/features/battle/utils/battlePhase';
@@ -41,7 +41,7 @@ export default function TutorialBattlePage() {
   const battleProgress = useBattleStore(selectBattleProgress);
   const selectedTeam = useBattleStore(selectSelectedTeam);
 
-  const selectedTeamFromState = (location.state as { selectedTeam?: Team })?.selectedTeam;
+  const selectedTeamFromState = (location.state as { selectedTeam?: BattleTeam })?.selectedTeam;
 
   useTutorialBattleSetup({ battleInfo, selectedTeamFromState });
 

--- a/frontend/src/pages/tutorialPage/const/tutorialBattle.ts
+++ b/frontend/src/pages/tutorialPage/const/tutorialBattle.ts
@@ -131,7 +131,7 @@ export const TUTORIAL_BATTLE_INFO: BattleInfo = {
 }`,
   bCode: `if (!user) return null;`,
   language: 'TS',
-  category: 'IMPLEMENTATION',
+  category: 'IMPLEMENT',
   participantCount: 30,
   currentRound: 1,
   totalRounds: topics.length,

--- a/frontend/src/pages/tutorialPage/teamSelect/index.tsx
+++ b/frontend/src/pages/tutorialPage/teamSelect/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from '@/commons/components/Button';
-import type { Team } from '@/commons/types/battle';
+import type { BattleTeam } from '@/commons/types/battle';
 import { useStepFlow } from '@/pages/teamSelectPage/hooks/useStepFlow';
 import StepIndicator from '@/pages/teamSelectPage/components/StepIndicator';
 import StepNavigation from '@/pages/teamSelectPage/components/StepNavigation';
@@ -21,7 +21,7 @@ export default function TutorialTeamSelectPage() {
   const hasReferenceData = !!battleInfo.referenceData;
   const totalSteps = hasReferenceData ? 5 : 4;
   const { currentStep, goToNext, goToPrev, isLastStep } = useStepFlow({ totalSteps });
-  const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
+  const [selectedTeam, setSelectedTeam] = useState<BattleTeam | null>(null);
   const [introStep, setIntroStep] = useState<0 | 1>(0);
   const [showIntro, setShowIntro] = useState(true);
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,13 +10,13 @@ import path from 'path';
 export default defineConfig({
   plugins: [react(), tailwindcss(), svgr(), wasm(), topLevelAwait()],
   optimizeDeps: {
-    exclude: ['@wasm-fmt/ruff_fmt'],
-    include: ['@cmc/types']
+    exclude: ['@wasm-fmt/ruff_fmt']
   },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
-      '@public': path.resolve(__dirname, './public')
+      '@public': path.resolve(__dirname, './public'),
+      '@cmc/types': path.resolve(__dirname, '../packages/types/src/index.ts')
     }
   },
   server: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,7 +10,8 @@ import path from 'path';
 export default defineConfig({
   plugins: [react(), tailwindcss(), svgr(), wasm(), topLevelAwait()],
   optimizeDeps: {
-    exclude: ['@wasm-fmt/ruff_fmt']
+    exclude: ['@wasm-fmt/ruff_fmt'],
+    include: ['@cmc/types']
   },
   resolve: {
     alias: {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,11 +2,12 @@
   "name": "@cmc/types",
   "version": "0.0.1",
   "private": true,
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@cmc/types",
+  "version": "0.0.1",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "~5.9.3"
+  }
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,12 +2,12 @@
   "name": "@cmc/types",
   "version": "0.0.1",
   "private": true,
-  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
   },

--- a/packages/types/src/battle.ts
+++ b/packages/types/src/battle.ts
@@ -1,0 +1,8 @@
+export type BattlePhaseName = 'PENDING' | 'OPINION_SHARE' | 'ATTACK' | 'DEFENSE' | 'TEAM_SWITCH'
+export type BattleTeam = 'A' | 'B' | 'NONE'
+export type BattleStatus = 'PENDING' | 'OPEN' | 'CLOSED'
+export type BattleDiscussionStatus = 'PENDING' | 'SELECTED' | 'REJECTED'
+export type BattleLanguage = 'TS' | 'JS' | 'PYTHON'
+export type BattleCategory = 'ALGORITHM' | 'REFACTORING' | 'IMPLEMENT' | 'ETC'
+export type BattleType = 'PUBLIC' | 'PRIVATE'
+export type BattleChatScope = 'ALL' | 'TEAM'

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,2 +1,2 @@
-export * from './battle'
-export * from './socket-events'
+export * from './battle.js'
+export * from './socket-events.js'

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,2 @@
+export * from './battle'
+export * from './socket-events'

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,2 +1,2 @@
-export * from './battle.js'
-export * from './socket-events.js'
+export * from './battle'
+export * from './socket-events'

--- a/packages/types/src/socket-events.ts
+++ b/packages/types/src/socket-events.ts
@@ -1,0 +1,42 @@
+/** 클라이언트 → 서버 이벤트 */
+export const BATTLE_CLIENT_EVENTS = {
+  JOIN: 'battle:join',
+  LEAVE: 'battle:leave',
+  START: 'battle:start',
+  ATTACK: 'battle:attack',
+  DEFENSE: 'battle:defense',
+  ATTACK_VOTE: 'battle:attack:vote',
+  DEFENSE_VOTE: 'battle:defense:vote',
+  CHAT: 'battle:chat',
+  USER_SKIP: 'battle:user:skip',
+} as const
+
+/** 서버 → 클라이언트 이벤트 */
+export const BATTLE_SERVER_EVENTS = {
+  JOINED: 'battle:joined',
+  JOIN_ERROR: 'battle:join:error',
+  LEAVED: 'battle:leaved',
+  STARTED: 'battle:started',
+  ATTACK_CREATED: 'battle:attack:created',
+  ATTACK_ERROR: 'battle:attack:error',
+  DEFENSE_CREATED: 'battle:defense:created',
+  DEFENSE_ERROR: 'battle:defense:error',
+  ATTACK_VOTED: 'battle:attack:voted',
+  DEFENSE_VOTED: 'battle:defense:voted',
+  ATTACK_VOTE_ERROR: 'battle:attack:vote:error',
+  DEFENSE_VOTE_ERROR: 'battle:defense:vote:error',
+  PHASE_UPDATED: 'battle:phase:updated',
+  PHASE_SKIPPED: 'battle:phase:skipped',
+  ROUND_UPDATED: 'battle:round:updated',
+  ATTACKED: 'battle:attacked',
+  DEFENSED: 'battle:defensed',
+  CLOSED: 'battle:closed',
+  CHATTED: 'battle:chatted',
+  ALL_UPDATED: 'battle:all:updated',
+  TEAM_UPDATED: 'battle:team:updated',
+  USER_UPDATED: 'battle:user:updated',
+  USER_SKIPPED: 'battle:user:skipped',
+} as const
+
+export type BattleClientEvent = (typeof BATTLE_CLIENT_EVENTS)[keyof typeof BATTLE_CLIENT_EVENTS]
+export type BattleServerEvent = (typeof BATTLE_SERVER_EVENTS)[keyof typeof BATTLE_SERVER_EVENTS]

--- a/packages/types/src/socket-events.ts
+++ b/packages/types/src/socket-events.ts
@@ -36,6 +36,9 @@ export const BATTLE_SERVER_EVENTS = {
   TEAM_UPDATED: 'battle:team:updated',
   USER_UPDATED: 'battle:user:updated',
   USER_SKIPPED: 'battle:user:skipped',
+  CHAT_ERROR: 'battle:chat:error',
+  TEAM_VOTE_ERROR: 'battle:team:vote:error',
+  USER_SKIP_ERROR: 'battle:user:skip:error',
 } as const
 
 export type BattleClientEvent = (typeof BATTLE_CLIENT_EVENTS)[keyof typeof BATTLE_CLIENT_EVENTS]

--- a/packages/types/src/socket-events.ts
+++ b/packages/types/src/socket-events.ts
@@ -9,6 +9,7 @@ export const BATTLE_CLIENT_EVENTS = {
   DEFENSE_VOTE: 'battle:defense:vote',
   CHAT: 'battle:chat',
   USER_SKIP: 'battle:user:skip',
+  TEAM_VOTE: 'battle:team:vote',
 } as const
 
 /** 서버 → 클라이언트 이벤트 */

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "Node10",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist",

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "CommonJS",
+    "moduleResolution": "Node10",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist",

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node10",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   backend:
     dependencies:
+      '@cmc/types':
+        specifier: workspace:*
+        version: link:../packages/types
       '@google/generative-ai':
         specifier: ^0.24.1
         version: 0.24.1
@@ -195,6 +198,9 @@ importers:
 
   frontend:
     dependencies:
+      '@cmc/types':
+        specifier: workspace:*
+        version: link:../packages/types
       '@sentry/react':
         specifier: ^10.38.0
         version: 10.38.0(react@19.2.3)
@@ -319,6 +325,12 @@ importers:
       vitest:
         specifier: ^4.0.16
         version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+
+  packages/types:
+    devDependencies:
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
 
 packages:
 


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #209


## ✅ 작업 내용

### 배경

현재 저희 프로젝트는 모노레포 구조로 프로젝트를 관리하고 있었지만, 프론트엔드와 백엔드 간 공유 할 수 있는 환경임에도 불구하고 타입과 소켓 이벤트 정의가 각각 분리되어 있어 그 이점을 충분히 활용하지 못하고 있다고 생각했습니다.

그래소 생긴 문제로는...

* 프론트엔드와 백엔드에서 타입을 각각 별도로 정의하기에 중복 선언으로 인해 불필요한 코드량 증가.
* 한쪽에서 값이나 이름이 변경될 경우 다른 쪽도 수동으로 수정해야 했기 때문에, 불일치로 인한 실수가 발생하기 쉬운 구조라는점
* 실제로도 프론트엔드에서 사용하던 몇몇 타입이 백엔드 스펙과 달라 버그가 불필요한 변환 로직을 사용하고 있었습니다.

그래서 이러한 문제를 해결하고 타입과 이벤트 정의를 일관되게 관리하기 위해, 공통 타입과 소켓 이벤트를 하나의 모듈로 분리하여 공유하도록 개선했습니다.

<br/>

### 1. `packages/types` — `@cmc/types` 공유 패키지 생성

pnpm workspace에 `@cmc/types` 패키지를 생성하고, 프론트엔드와 백엔드가 공통으로 사용하는 타입과 소켓 이벤트 상수를 한 곳에서 관리하도록 구성했습니다.

```ts
// packages/types/src/battle.ts
export type BattleTeam = 'A' | 'B' | 'NONE'
export type BattlePhaseName = 'PENDING' | 'OPINION_SHARE' | 'ATTACK' | 'DEFENSE' | 'TEAM_SWITCH'
export type BattleCategory = 'ALGORITHM' | 'REFACTORING' | 'IMPLEMENT' | 'ETC'
export type BattleLanguage = 'TS' | 'JS' | 'PYTHON'

// packages/types/src/socket-events.ts
export const BATTLE_CLIENT_EVENTS = {
  JOIN: 'battle:join',
  ATTACK: 'battle:attack',
  ATTACK_VOTE: 'battle:attack:vote',
} as const

export const BATTLE_SERVER_EVENTS = {
  JOINED: 'battle:joined',
  ATTACKED: 'battle:attacked',
} as const
```

<br/>

### 2. 프론트·백엔드 중복 타입 제거 및 `@cmc/types`로 통합

기존에 각각 선언되어 있던 타입을 제거하고, `@cmc/types`에서 import하도록 변경했습니다.

* 프론트: `commons/types/battle.ts` — 인라인 유니온 타입 제거
* 백엔드: `battle.types.ts` — 로컬 타입 정의 제거 후 `@cmc/types` re-export로 대체

<br/>

### 3. 소켓 이벤트 문자열 하드코딩 제거

프론트엔드와 백엔드 전반에서 `'battle:join'`, `'battle:attack:vote'` 등의 문자열을 직접 사용하던 부분을 모두 상수로 교체했습니다.

```ts
// Before
socket.emit('battle:attack:vote', { ... })
socket.on('battle:attacked', handler)

// After
socket.emit(BATTLE_CLIENT_EVENTS.ATTACK_VOTE, { ... })
socket.on(BATTLE_SERVER_EVENTS.ATTACKED, handler)
```

<br/>

### 4. 프론트–백엔드 스펙 불일치 수정

타입을 통합하는 과정에서 드러난 값 불일치도 함께 수정했습니다.

* `BattleCategory`: `'IMPLEMENTATION'` → `'IMPLEMENT'`
* `BattleLanguage`: `'javascript'` / `'typescript'` / `'python'`
  → `'JS'` / `'TS'` / `'PYTHON'`

또한, API 응답 값(`'TS'`)을 코드 포매터용 값(`'typescript'`)으로 변환하기 위한 `languageMapper` 유틸을 추가했습니다.

---

## 💬 고민했던 부분

### API 응답 타입은 `@cmc/types`에 포함하지 않았습니다

`BattleReferenceData`, `BattleResult` 등의 API 응답 타입도 공유 패키지에 포함해야하나 고민했었지만..

이 타입들은 백엔드 -> 프론트 방향으로만 사용되며,  NestJS DTO는 데코레이터가 포함된 클래스 형태이기 때문에 순수 타입으로 분리해 공유하기가 어렵다고 생각했습니다.

따라서 `@cmc/types`에는 **소켓처럼 양방향에서 동일하게 사용해야 하는 타입과 값만 포함**하도록 범위를 제한했습니다.

### `@cmc/types` 빌드 포맷 (CJS vs ESM)

프론트엔드(Vite)는 ESM을, 백엔드(NestJS)는 CJS를 사용하고 있어 빌드 포맷에서 충돌이 있었습니다.

초기에는 ESM으로 전환했지만, 백엔드에서 패키지를 정상적으로 import하지 못하는 문제가 발생했습니다.

최종적으로는 CJS 빌드를 유지하고, 프론트엔드에서는 Vite의 `optimizeDeps.include`에 등록하여 CJS를 ESM으로 pre-bundling하도록 처리했습니다.
