### PR TITLE
[hotifx] 타입 빌드 과정 추가

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -89,9 +89,9 @@ jobs:
           push: true
           build-args: |
             VITE_API_URL=${{ secrets.VITE_API_URL }}
-            VITE_SOCKET_URL: ${{ secrets.VITE_SOCKET_URL }}
-            VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
-            VITE_ENABLE_SENTRY: ${{ secrets.VITE_ENABLE_SENTRY }}
+            VITE_SOCKET_URL=${{ secrets.VITE_SOCKET_URL }}
+            VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
+            VITE_ENABLE_SENTRY=${{ secrets.VITE_ENABLE_SENTRY }}
           tags: |
             ${{ env.REGISTRY }}/${{ steps.image_names.outputs.frontend_image }}:latest
             ${{ env.REGISTRY }}/${{ steps.image_names.outputs.frontend_image }}:${{ steps.set_version.outputs.version_tag }}
@@ -167,6 +167,9 @@ jobs:
         env:
           HUSKY: 0
         run: pnpm install --frozen-lockfile
+
+      - name: Build shared types
+        run: pnpm -C packages/types build
 
       - name: Build frontend
         env:


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #435

## ✅ 작업 내용

- [x] CD 과정에서 Frontend Build 이전 `packages/types` build 과정을 추가해주었습니다.
- [x] `@cmc/types` 패키지의 타입 선언 파일이 생성된 이후 frontend build가 실행되도록 순서를 보장했습니다.

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

- CI/CD 과정에서 Frontend Build 시, `@cmc/types`의 `dist/index.d.ts`를 정상적으로 참조할 수 있도록 개선했습니다.

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

- `frontend/Dockerfile`에는 이미 `pnpm -C packages/types build` 단계가 있었지만, prod의 `cd-frontend` job은 Docker build가 아닌 별도 frontend build를 수행하고 있어 동일한 선행 build가 필요했습니다.

- 확인 명령:
  - `pnpm -C packages/types build`
  - `pnpm -C frontend build`

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
