### PR TITLE
Hotfix/#437 cd backend types

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -89,9 +89,9 @@ jobs:
           push: true
           build-args: |
             VITE_API_URL=${{ secrets.VITE_API_URL }}
-            VITE_SOCKET_URL: ${{ secrets.VITE_SOCKET_URL }}
-            VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
-            VITE_ENABLE_SENTRY: ${{ secrets.VITE_ENABLE_SENTRY }}
+            VITE_SOCKET_URL=${{ secrets.VITE_SOCKET_URL }}
+            VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
+            VITE_ENABLE_SENTRY=${{ secrets.VITE_ENABLE_SENTRY }}
           tags: |
             ${{ env.REGISTRY }}/${{ steps.image_names.outputs.frontend_image }}:latest
             ${{ env.REGISTRY }}/${{ steps.image_names.outputs.frontend_image }}:${{ steps.set_version.outputs.version_tag }}
@@ -167,6 +167,9 @@ jobs:
         env:
           HUSKY: 0
         run: pnpm install --frozen-lockfile
+
+      - name: Build shared types
+        run: pnpm -C packages/types build
 
       - name: Build frontend
         env:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,6 +50,7 @@ RUN HUSKY=0 pnpm install --filter backend --prod --frozen-lockfile --ignore-scri
 # Copy built artifacts
 COPY --from=builder /app/backend/dist ./backend/dist
 COPY --from=builder /app/backend/prisma ./backend/prisma
+COPY --from=builder /app/packages/types/dist ./packages/types/dist
 
 COPY backend/prisma.config.ts ./backend/prisma.config.ts
 


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #437

## ✅ 작업 내용

`@cmc/types`는 backend의 workspace dependency이며, 런타임에서 `backend/node_modules/@cmc/types`가 `packages/types`를 참조합니다.

하지만 Backend Dockerfile에서 `RUN pnpm -C packages/types build`를 통해 `@cmc/types`를 빌드하더라도, 실제 빌드 산출물인 `packages/types/dist`가 복사되지 않아 런타임 환경에서 참조할 수 없는 문제가 발생했습니다.

```text
Error: Cannot find module '/app/backend/node_modules/@cmc/types/dist/index.js'
```

이에 대해 `packages/types/dist`를 복사하여, 컨테이너 내부 런타임 환경에서도 타입을 정상적으로 참조할 수 있도록 수정했습니다.


### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

- backen 이미지에 `@cmc/types` 빌드 산출물이 포함되도록 개선했습니다.

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
