### PR TITLE
fix: 백엔드 Dockerfile에 타입 패키지 빌드 아티팩트 복사 추가

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,6 +50,7 @@ RUN HUSKY=0 pnpm install --filter backend --prod --frozen-lockfile --ignore-scri
 # Copy built artifacts
 COPY --from=builder /app/backend/dist ./backend/dist
 COPY --from=builder /app/backend/prisma ./backend/prisma
+COPY --from=builder /app/packages/types/dist ./packages/types/dist
 
 COPY backend/prisma.config.ts ./backend/prisma.config.ts
 


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #437

## ✅ 작업 내용

`@cmc/types`는 backend의 workspace dependency이며, 런타임에서 `backend/node_modules/@cmc/types`가 `packages/types`를 참조합니다.

하지만 Backend Dockerfile에서 `RUN pnpm -C packages/types build`를 통해 `@cmc/types`를 빌드하더라도, 실제 빌드 산출물인 `packages/types/dist`가 복사되지 않아 런타임 환경에서 참조할 수 없는 문제가 발생했습니다.

```text
Error: Cannot find module '/app/backend/node_modules/@cmc/types/dist/index.js'
```

이에 대해 `packages/types/dist`를 복사하여, 컨테이너 내부 런타임 환경에서도 타입을 정상적으로 참조할 수 있도록 수정했습니다.


### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

- backen 이미지에 `@cmc/types` 빌드 산출물이 포함되도록 개선했습니다.

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
