### PR TITLE
[Feature] Nginx에 rate limit을 설정한다.

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,6 @@
+# Rate Limit 설정 - 클라이언트 IP 이진을 Key로 3rps를 허용하며 최대 1M 용량으로 저장
+limit_req_zone $binary_remote_addr zone=cmc_api_limit:1m rate=3r/s;
+
 # HTTP → HTTPS 리다이렉트
 server {
     listen 80;
@@ -35,6 +38,9 @@ server {
 
     # 백엔드 API
     location /api/ {
+        limit_req zone=cmc_api_limit burst=5 delay=3;
+        limit_req_status 429;
+        
         proxy_pass http://backend:3000/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,21 @@
-# Rate Limit 설정 - 클라이언트 IP 이진을 Key로 3rps를 허용하며 최대 1M 용량으로 저장
-limit_req_zone $binary_remote_addr zone=cmc_api_limit:1m rate=3r/s;
+# Request Method에 따라 Rate Limit Zone을 분리
+map $request_method $cmc_api_read_key {
+    GET $binary_remote_addr;
+    HEAD $binary_remote_addr;
+    default "";
+}
+
+map $request_method $cmc_api_write_key {
+    POST $binary_remote_addr;
+    PUT $binary_remote_addr;
+    PATCH $binary_remote_addr;
+    DELETE $binary_remote_addr;
+    default "";
+}
+
+# Rate Limit 설정
+limit_req_zone $cmc_api_read_key zone=cmc_api_read_limit:8m rate=24r/s;
+limit_req_zone $cmc_api_write_key zone=cmc_api_write_limit:1m rate=3r/s;
 
 # HTTP → HTTPS 리다이렉트
 server {
@@ -38,7 +54,8 @@ server {
 
     # 백엔드 API
     location /api/ {
-        limit_req zone=cmc_api_limit burst=5 delay=3;
+        limit_req zone=cmc_api_read_limit burst=40 delay=24;
+        limit_req zone=cmc_api_write_limit burst=5 delay=3;
         limit_req_status 429;
         
         proxy_pass http://backend:3000/;


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Closes #431 

## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

- `/api/` 경로에 IP 기반 Nginx rate limit을 적용했습니다.
- 클라이언트 IP 기준으로 평균 `3r/s`를 허용하도록 설정했습니다.
- Burst 요청을 흡수하기 위해 `burst=5`, `delay=3`을 설정했습니다.
- 제한을 초과한 요청은 `429 Too Many Requests`로 응답하도록 설정했습니다.

####  🔷  Rate Limit 임계값 설정 근거

1️⃣ 서버 한계 RPS 측정

K6 부하테스트를 통해 각 RPS 단위 별로 요청을 보냈을 때, 다음과 같은 결과가 나왔습니다. 

```
   RPS | actual RPS |    failed |      slow |          p95 |          p99 |  dropped | stable
-------|------------|-----------|-----------|--------------|--------------|----------|--------
    25 |      25.01 |     0.00% |     0.00% |      25.42ms |      31.48ms |        0 | yes
    50 |      50.01 |     0.00% |     0.00% |      25.82ms |      33.20ms |        0 | yes
    75 |      75.01 |     0.00% |     0.00% |      27.71ms |      34.70ms |        0 | yes
   100 |     100.01 |     0.00% |     0.00% |      37.70ms |      55.45ms |        0 | yes
   125 |     125.01 |     0.00% |     0.00% |      57.85ms |     111.55ms |        0 | yes
   150 |     149.63 |     0.00% |    14.54% |    1041.34ms |    1313.88ms |       45 | no
```
RPS 150 단계에서 p95와 p99는 1000ms를 초과하였고 서버가 요청이 지연되어 테스트가 drop되는 현상도 45회 발생하였습니다. 이에 대해 서버의 한계 RPS 는 150으로 잡고 Rate Limit 임계값을 산출하였습니다.

2️⃣ 서비스 일 사용자 및 최대 동시접속자 가정

현재 실 서비스 이용자는 존재하지 않기 때문에 🥲 일 사용자 100명으로 가정하였습니다. 일 사용자가 100명이더라도 1시간에 10명씩 들어오는 것과 1초에 100명이 한 번에 접속하는 것은 명백히 다르기 때문에, 최대 동시접속자 수를 가정할 필요가 있었고 이에 대해서도 일 사용자 수의 40%인 40명으로 가정하였습니다.

- 일 접속자 수: 100 명
- 최대 동시 접속자 수: 40 명

이에 대해서도 모니터링을 통해 조정이 필요할 것 같습니다.   

3️⃣ rate limit RPS, burst, delay 설정

서버의 한계 RPS는 150으로 확인하였지만 조금 더 안정적으로 최대 요청을 수용하기 위해 125 RPS를 기준으로 잡았습니다.

```
// 동일 접속자 40명이 낼 수 있는 최대 RPS
125 / 40 = 3.1...
```

이에 대해, Nginx 설정에서 `3 r/s` 로 요청을 제한하도록 설정하였습니다. 

하지만 사용자가 의도적으로 요청하는 것이 아닌 페이지 로딩에서 자연스럽게 발생하는 API가 3개 이상일 경우,  요청이 제한될 수도 있으니  이런 Burst한 요청에 대해서도 요청을 허용하여 유연하게 처리할 수 있도록 값을 설정해주었습니다. 

현재 메인 페이지에서 가장 많은 동시 API가 발생(3개)하기에, 이 기준에 맞춰서 넉넉하게 `burst` 값은 5로 설정해주었고 그 절반을 반올림하여 `delay` 는 3으로 설정하여 유연하게 요청을 수용하며 안정적으로 요청을 서버가 처리하게 끔 설정해주었습니다.

#### 🔷 Nginx Rate Limit 설정 후 부하테스트 결과

`3 r/s` / `burst=5` / `delay=3` 인 상태에서 단일 IP와 다중 IP로 부하 테스트를 진행하였습니다.

1️⃣ **단일 IP**

- **하나의 IP가 7개의 요청을 동시에 보낼 때 (정책이 올바르게 작동하는지)**

```
nginx-1  | 2026/05/03 06:16:42 [warn] 10#10: *86 delaying request, excess: 3.982, by zone "cmc_api_limit", client: 210.105.199.180, server: cmctv.kro.kr, request: "GET /api/battles/closed HTTP/1.1", host: "cmctv.kro.kr"
nginx-1  | 2026/05/03 06:16:42 [warn] 10#10: *85 delaying request, excess: 4.979, by zone "cmc_api_limit", client: 210.105.199.180, server: cmctv.kro.kr, request: "GET /api/battles/closed HTTP/1.1", host: "cmctv.kro.kr"
nginx-1  | 210.105.199.180 - - [03/May/2026:06:16:42 +0000] "GET /api/battles/closed HTTP/1.1" 200 3742 "-" "Grafana k6/1.6.1" "-"
nginx-1  | 210.105.199.180 - - [03/May/2026:06:16:42 +0000] "GET /api/battles/closed HTTP/1.1" 200 3742 "-" "Grafana k6/1.6.1" "-"
nginx-1  | 2026/05/03 06:16:42 [error] 10#10: *84 limiting requests, excess: 5.919 by zone "cmc_api_limit", client: 210.105.199.180, server: cmctv.kro.kr, request: "GET /api/battles/closed HTTP/1.1", host: "cmctv.kro.kr"
nginx-1  | 210.105.199.180 - - [03/May/2026:06:16:42 +0000] "GET /api/battles/closed HTTP/1.1" 429 169 "-" "Grafana k6/1.6.1" "-"
nginx-1  | 210.105.199.180 - - [03/May/2026:06:16:42 +0000] "GET /api/battles/closed HTTP/1.1" 200 3742 "-" "Grafana k6/1.6.1" "-"
nginx-1  | 210.105.199.180 - - [03/May/2026:06:16:42 +0000] "GET /api/battles/closed HTTP/1.1" 200 3742 "-" "Grafana k6/1.6.1" "-"
nginx-1  | 210.105.199.180 - - [03/May/2026:06:16:43 +0000] "GET /api/battles/closed HTTP/1.1" 200 3742 "-" "Grafana k6/1.6.1" "-"
nginx-1  | 210.105.199.180 - - [03/May/2026:06:16:43 +0000] "GET /api/battles/closed HTTP/1.1" 200 3742 "-" "Grafana k6/1.6.1" "-"
```

`excess` 값이 5이하일 경우에는 `delay`에 의해 요청을 지연하며 허용하지만 `burst` 5를 초과하면 `limiting requests`로 지정하여 429 에러와 함께 요청을 거절합니다.

  
- **하나의 IP가 RPS 150을 초과할 때 (악의적인 공격에 대해 방어를 하는지)** 

```
Total requests   : 18001
2xx/3xx          : 2.03% (365건)
429              : 97.97% (17636건)
Unexpected       : 0.00% (0건)
Slow responses   : 2.00% (360건)
Dropped          : 0

All responses p95: 10.67ms
All responses p99: 682.45ms
429 p95          : 9.86ms
429 p99          : 12.07ms
```

RPS 150으로 2분간 총 18001 요청을 발생시켰을 때, 365 건의 요청만 허용하였으며 그 외의 요청은 429 에러를 발생시켰습니다. 
120초간 3RPS 이기 때문에 360개의 요청을 허용하는 설정값에 가깝게 요청을 허용하였으며 p95는 10ms 로 안정적인 응답을 받을 수 있었습니다.

2️⃣ **다중 IP**

- 40개의 IP로 3 RPS 요청을 보낼 때 (120RPS)
```
All responses p95: 73.19ms
All responses p99: 150.05ms
2xx/3xx p95      : 73.19ms
2xx/3xx p99      : 150.05ms
```

- 60개의 IP로 4 RPS로 요청을 보낼 때 (160RPS)
```
Total requests   : 24000
2xx/3xx          : 75.83% (18200건)
429              : 24.17% (5800건)
Unexpected       : 0.00% (0건)
Slow responses   : 53.19% (12766건)
Dropped          : 0

All responses p95: 665.34ms
All responses p99: 680.28ms
2xx/3xx p95      : 668.58ms
2xx/3xx p99      : 682.25ms
```
- 50개의 IP로 3RPS로 요청을 보낼 때 (150RPS) 
```
All responses p95: 1465.52ms
All responses p99: 1791.03ms
2xx/3xx p95      : 1465.52ms
2xx/3xx p99      : 1791.03ms
```

목표 한계치 이하의 RPS는 안정적으로 수용하지만 160RPS와 150RPS는 p95, p99가 500ms를 초과합니다.
하지만 두 테스트의 차이점은 "3 RPS로 요청하였는가"에 있습니다. 160RPS는 40개의 IP가 4RPS로 요청을 보냈기 때문에, 1개의 초과 요청을 거절하며 처리하였기 때문에 600ms의 응답 속도를 가졌지만 150RPS는 50개의 IP가 3RPS 로 요청을 보냈기 때문에 Rate Limit 제한에 걸리지 않아 1000ms가 넘는 응답 속도를 가졌습니다.

#### 🔷 결론

Rate Limit은 서버로 들어오는 전체 RPS를 막기보다는 **1인이 보낼 수 있는 최대 RPS를 제한하여 서버의 안정성을 높이는 방식**이라고 판단하였습니다.

이번 설정은 일 사용자 100명, 최대 동시 접속자 40명이라는 가정 하에 산출된 값으로, 단일 IP의 악의적인 대량 요청에 대해서는 효과적으로 방어할 수 있음을 테스트를 통해 확인하였습니다. 하지만 부하테스트 결과에서 확인할 수 있듯, Rate Limit에서 중요한 점은 **어느 정도의 사용자가 어느 정도의 요청을 보내는 가를 파악하는 것**이라는 것은 느꼈습니다.  

동일한 150RPS라도 50명이 각각 3r/s로 요청하면 제한이 전혀 걸리지 않아 서버가 한계치에 도달하는 반면, 40명이 4r/s로 요청하면 초과분이 차단되어 150RPS보다 더 안정적인 응답속도를 받을 수 있었습니다. 이처럼 Rate Limit 값은 고정된 값이 아닌 모니터링을 통해 지속적으로 임계값이 산출되어야 함을 느낄 수 있었습니다.

- 추가로 값을 설정하면 이벤트를 발행해서 자동으로 서버 rate limit이 바뀌도록 하는 그런 설정까지...? (Nginx를 안쓴다면..)

<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

Why 문서: https://lovely-sunstone-c80.notion.site/Rate-Limiter-34cd7ffb4ba48031b099ee88690c8002?source=copy_link

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->

- Global Edge를 통해 서버로 요청을 보내게 되는데 그러면 프록시를 통해 동일한 IP로 Nginx에서 파악하는 지 여부를 확인하지 못하였습니다..
    - 와이파이로 접속할 때와 데이터로 접속할 때, nginx에서는 다른 IP로 잡히긴 했는데, 스크럼 때 한 번 테스트해보면 좋을 것 같습니다.