### PR TITLE
[Feature] 배틀 액션 6개(chat/skip/vote/leave/start/reset) dev API 및 dev-mcp 툴 추가

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "dev-mcp": {
+      "command": "node",
+      "args": ["./dev-mcp/dist/index.js"]
+    }
+  }
+}

--- a/backend/src/battles/adapters/in/dev.controller.ts
+++ b/backend/src/battles/adapters/in/dev.controller.ts
@@ -7,8 +7,17 @@ import { BATTLE_STATE_PORT, BATTLE_BROADCASTER_PORT, BATTLE_TIMER_PORT } from '.
 import type { BattleStatePort } from '../../application/ports/out/battleState.port'
 import type { BattleBroadcasterPort } from '../../application/ports/out/battleBroadcaster.port'
 import type { BattleTimerPort } from '../../application/ports/out/battleTimer.port'
-import { DevForcePhaseDto, DevForceTimerDto, DevAddParticipantDto, DevInjectDiscussionDto, DevInjectVoteDto } from '../../dto/devForcePhase.dto'
+import {
+  DevForcePhaseDto,
+  DevForceTimerDto,
+  DevAddParticipantDto,
+  DevInjectDiscussionDto,
+  DevInjectVoteDto,
+  DevChatDto,
+} from '../../dto/devForcePhase.dto'
 import { BattleUserUpdateResponseDto } from '../../dto/battleUserUpdateResponse.dto'
+import { BATTLE_CHAT_SCOPE, BATTLE_TEAM } from '../../domains/models/const/battles.const'
+import type { BattleChatDto } from '../../dto/battleChat.dto'
 
 @Controller('dev/battles')
 export class DevController implements OnModuleInit {
@@ -152,6 +161,31 @@ export class DevController implements OnModuleInit {
       voterId,
       updatedCount: updates.length,
     }
+  }
+
+  @Post(':id/chat')
+  @HttpCode(200)
+  async chat(
+    @Param('id') battleId: string,
+    @Body() body: DevChatDto,
+  ): Promise<{ battleId: string; messageId: string; scope: string; team: string; userId: string; nickname: string }> {
+    this.assertNotProduction()
+
+    const { state } = await this.stateRepo.loadBattleState(battleId)
+    const team = state.participants.get(body.userId)
+    if (!team) {
+      throw new BadRequestException(`userId=${body.userId}는 배틀에 참가하지 않았습니다. 먼저 addParticipant로 추가하세요.`)
+    }
+    if (body.scope === BATTLE_CHAT_SCOPE.TEAM && team === BATTLE_TEAM.NONE) {
+      throw new BadRequestException('NONE 진영은 TEAM scope 채팅을 보낼 수 없습니다.')
+    }
+
+    const dto: BattleChatDto = { battleId, scope: body.scope, team, text: body.text }
+    const saved = await this.interactionUseCase.sendChat(dto, body.userId)
+
+    this.broadcaster.emitChatted(saved)
+
+    return { battleId, messageId: saved.messageId, scope: saved.scope, team: saved.team, userId: body.userId, nickname: saved.sender.nickname }
   }
 
   @Get(':id/inspect')

--- a/backend/src/battles/adapters/in/dev.controller.ts
+++ b/backend/src/battles/adapters/in/dev.controller.ts
@@ -15,7 +15,9 @@ import {
   DevInjectVoteDto,
   DevChatDto,
   DevTeamVoteDto,
+  DevLeaveDto,
 } from '../../dto/devForcePhase.dto'
+import { BattleParticipationUseCase } from '../../application/usecases/battleParticipation.usecase'
 import { BattleUserUpdateResponseDto } from '../../dto/battleUserUpdateResponse.dto'
 import { BATTLE_CHAT_SCOPE, BATTLE_TEAM } from '../../domains/models/const/battles.const'
 import type { BattleChatDto } from '../../dto/battleChat.dto'
@@ -25,6 +27,7 @@ export class DevController implements OnModuleInit {
   constructor(
     private readonly phaseTransitionUseCase: BattlePhaseTransitionUseCase,
     private readonly interactionUseCase: BattleInteractionUseCase,
+    private readonly participationUseCase: BattleParticipationUseCase,
     @Inject(BATTLE_STATE_PORT) private readonly stateRepo: BattleStatePort,
     @Inject(BATTLE_BROADCASTER_PORT) private readonly broadcaster: BattleBroadcasterPort,
     @Inject(BATTLE_TIMER_PORT) private readonly timer: BattleTimerPort,
@@ -211,6 +214,21 @@ export class DevController implements OnModuleInit {
     })
 
     return { battleId, userId: body.userId, team: body.team, counts }
+  }
+
+  @Post(':id/leave')
+  @HttpCode(200)
+  async leave(
+    @Param('id') battleId: string,
+    @Body() body: DevLeaveDto,
+  ): Promise<{ battleId: string; userId: string; counts: { teamA: number; teamB: number; teamNone: number }; totalSkips: number }> {
+    this.assertNotProduction()
+
+    const result = await this.participationUseCase.leave(body.userId, battleId)
+
+    this.broadcaster.emitLeaved(result)
+
+    return { battleId, userId: body.userId, counts: result.counts, totalSkips: result.totalSkips }
   }
 
   @Get(':id/inspect')

--- a/backend/src/battles/adapters/in/dev.controller.ts
+++ b/backend/src/battles/adapters/in/dev.controller.ts
@@ -14,6 +14,7 @@ import {
   DevInjectDiscussionDto,
   DevInjectVoteDto,
   DevChatDto,
+  DevSkipDto,
 } from '../../dto/devForcePhase.dto'
 import { BattleUserUpdateResponseDto } from '../../dto/battleUserUpdateResponse.dto'
 import { BATTLE_CHAT_SCOPE, BATTLE_TEAM } from '../../domains/models/const/battles.const'
@@ -186,6 +187,22 @@ export class DevController implements OnModuleInit {
     this.broadcaster.emitChatted(saved)
 
     return { battleId, messageId: saved.messageId, scope: saved.scope, team: saved.team, userId: body.userId, nickname: saved.sender.nickname }
+  }
+
+  @Post(':id/skip')
+  @HttpCode(200)
+  async skip(
+    @Param('id') battleId: string,
+    @Body() body: DevSkipDto,
+  ): Promise<{ battleId: string; userId: string; skip: boolean; totalSkips: number }> {
+    this.assertNotProduction()
+
+    const skip = body.skip ?? true
+    const totalSkips = await this.phaseTransitionUseCase.handlePhaseSkip(battleId, body.userId, skip)
+
+    this.broadcaster.emitUserSkipped(battleId, totalSkips)
+
+    return { battleId, userId: body.userId, skip, totalSkips }
   }
 
   @Get(':id/inspect')

--- a/backend/src/battles/adapters/in/dev.controller.ts
+++ b/backend/src/battles/adapters/in/dev.controller.ts
@@ -18,6 +18,7 @@ import {
   DevLeaveDto,
 } from '../../dto/devForcePhase.dto'
 import { BattleParticipationUseCase } from '../../application/usecases/battleParticipation.usecase'
+import { BattleCreationUseCase } from '../../application/usecases/battleCreation.usecase'
 import { BattleUserUpdateResponseDto } from '../../dto/battleUserUpdateResponse.dto'
 import { BATTLE_CHAT_SCOPE, BATTLE_TEAM } from '../../domains/models/const/battles.const'
 import type { BattleChatDto } from '../../dto/battleChat.dto'
@@ -28,6 +29,7 @@ export class DevController implements OnModuleInit {
     private readonly phaseTransitionUseCase: BattlePhaseTransitionUseCase,
     private readonly interactionUseCase: BattleInteractionUseCase,
     private readonly participationUseCase: BattleParticipationUseCase,
+    private readonly creationUseCase: BattleCreationUseCase,
     @Inject(BATTLE_STATE_PORT) private readonly stateRepo: BattleStatePort,
     @Inject(BATTLE_BROADCASTER_PORT) private readonly broadcaster: BattleBroadcasterPort,
     @Inject(BATTLE_TIMER_PORT) private readonly timer: BattleTimerPort,
@@ -229,6 +231,17 @@ export class DevController implements OnModuleInit {
     this.broadcaster.emitLeaved(result)
 
     return { battleId, userId: body.userId, counts: result.counts, totalSkips: result.totalSkips }
+  }
+
+  @Post(':id/start')
+  @HttpCode(200)
+  async start(@Param('id') battleId: string): Promise<{ battleId: string }> {
+    this.assertNotProduction()
+
+    await this.creationUseCase.start(battleId)
+    this.broadcaster.emitStarted(battleId)
+
+    return { battleId }
   }
 
   @Get(':id/inspect')

--- a/backend/src/battles/adapters/in/dev.controller.ts
+++ b/backend/src/battles/adapters/in/dev.controller.ts
@@ -1,12 +1,26 @@
 import { randomUUID } from 'node:crypto'
-import { BadRequestException, Body, Controller, ForbiddenException, Get, HttpCode, Inject, OnModuleInit, Param, Post } from '@nestjs/common'
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  ForbiddenException,
+  Get,
+  HttpCode,
+  Inject,
+  Logger,
+  OnModuleInit,
+  Param,
+  Post,
+} from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { BattlePhaseTransitionUseCase } from '../../application/usecases/battlePhaseTransition.usecase'
 import { BattleInteractionUseCase } from '../../application/usecases/battleInteraction.usecase'
-import { BATTLE_STATE_PORT, BATTLE_BROADCASTER_PORT, BATTLE_TIMER_PORT } from '../../application/ports/tokens'
+import { BATTLE_STATE_PORT, BATTLE_BROADCASTER_PORT, BATTLE_TIMER_PORT, BATTLE_REPO_PORT } from '../../application/ports/tokens'
 import type { BattleStatePort } from '../../application/ports/out/battleState.port'
 import type { BattleBroadcasterPort } from '../../application/ports/out/battleBroadcaster.port'
 import type { BattleTimerPort } from '../../application/ports/out/battleTimer.port'
+import type { BattleRepoPort } from '../../application/ports/out/battleRepository.port'
 import {
   DevForcePhaseDto,
   DevForceTimerDto,
@@ -25,6 +39,8 @@ import type { BattleChatDto } from '../../dto/battleChat.dto'
 
 @Controller('dev/battles')
 export class DevController implements OnModuleInit {
+  private readonly logger = new Logger(DevController.name)
+
   constructor(
     private readonly phaseTransitionUseCase: BattlePhaseTransitionUseCase,
     private readonly interactionUseCase: BattleInteractionUseCase,
@@ -33,6 +49,7 @@ export class DevController implements OnModuleInit {
     @Inject(BATTLE_STATE_PORT) private readonly stateRepo: BattleStatePort,
     @Inject(BATTLE_BROADCASTER_PORT) private readonly broadcaster: BattleBroadcasterPort,
     @Inject(BATTLE_TIMER_PORT) private readonly timer: BattleTimerPort,
+    @Inject(BATTLE_REPO_PORT) private readonly repo: BattleRepoPort,
     private readonly config: ConfigService,
   ) {}
 
@@ -242,6 +259,40 @@ export class DevController implements OnModuleInit {
     this.broadcaster.emitStarted(battleId)
 
     return { battleId }
+  }
+
+  @Delete(':id')
+  @HttpCode(200)
+  async reset(
+    @Param('id') battleId: string,
+  ): Promise<{ battleId: string; deleted: { timer: boolean; redis: boolean; memory: boolean; db: boolean } }> {
+    this.assertNotProduction()
+
+    const result = { timer: false, redis: false, memory: false, db: false }
+
+    try {
+      this.timer.cancel(battleId)
+      result.timer = true
+    } catch (err) {
+      this.logger.error(`[reset] timer.cancel 실패 ${battleId}: ${(err as Error).message}`)
+    }
+
+    try {
+      await this.stateRepo.clearBattleStateFromRedis(battleId)
+      result.redis = true
+      result.memory = true
+    } catch (err) {
+      this.logger.error(`[reset] state clear 실패 ${battleId}: ${(err as Error).message}`)
+    }
+
+    try {
+      await this.repo.delete(battleId)
+      result.db = true
+    } catch (err) {
+      this.logger.error(`[reset] DB delete 실패 ${battleId}: ${(err as Error).message}`)
+    }
+
+    return { battleId, deleted: result }
   }
 
   @Get(':id/inspect')

--- a/backend/src/battles/adapters/in/dev.controller.ts
+++ b/backend/src/battles/adapters/in/dev.controller.ts
@@ -14,7 +14,7 @@ import {
   DevInjectDiscussionDto,
   DevInjectVoteDto,
   DevChatDto,
-  DevSkipDto,
+  DevTeamVoteDto,
 } from '../../dto/devForcePhase.dto'
 import { BattleUserUpdateResponseDto } from '../../dto/battleUserUpdateResponse.dto'
 import { BATTLE_CHAT_SCOPE, BATTLE_TEAM } from '../../domains/models/const/battles.const'
@@ -189,20 +189,28 @@ export class DevController implements OnModuleInit {
     return { battleId, messageId: saved.messageId, scope: saved.scope, team: saved.team, userId: body.userId, nickname: saved.sender.nickname }
   }
 
-  @Post(':id/skip')
+  @Post(':id/team-vote')
   @HttpCode(200)
-  async skip(
+  async teamVote(
     @Param('id') battleId: string,
-    @Body() body: DevSkipDto,
-  ): Promise<{ battleId: string; userId: string; skip: boolean; totalSkips: number }> {
+    @Body() body: DevTeamVoteDto,
+  ): Promise<{ battleId: string; userId: string; team: string; counts: { A: number; B: number; NONE: number } }> {
     this.assertNotProduction()
 
-    const skip = body.skip ?? true
-    const totalSkips = await this.phaseTransitionUseCase.handlePhaseSkip(battleId, body.userId, skip)
+    const { state } = await this.stateRepo.loadBattleState(battleId)
+    if (!state.participants.has(body.userId)) {
+      throw new BadRequestException(`userId=${body.userId}는 배틀에 참가하지 않았습니다.`)
+    }
 
-    this.broadcaster.emitUserSkipped(battleId, totalSkips)
+    await this.interactionUseCase.switchTeam(battleId, body.userId, body.team)
 
-    return { battleId, userId: body.userId, skip, totalSkips }
+    const { state: after } = await this.stateRepo.loadBattleState(battleId)
+    const counts = { A: 0, B: 0, NONE: 0 }
+    after.teamVotes.forEach(team => {
+      counts[team] = (counts[team] ?? 0) + 1
+    })
+
+    return { battleId, userId: body.userId, team: body.team, counts }
   }
 
   @Get(':id/inspect')

--- a/backend/src/battles/adapters/in/dev.controller.ts
+++ b/backend/src/battles/adapters/in/dev.controller.ts
@@ -30,6 +30,7 @@ import {
   DevChatDto,
   DevTeamVoteDto,
   DevLeaveDto,
+  DevSkipDto,
 } from '../../dto/devForcePhase.dto'
 import { BattleParticipationUseCase } from '../../application/usecases/battleParticipation.usecase'
 import { BattleCreationUseCase } from '../../application/usecases/battleCreation.usecase'
@@ -259,6 +260,22 @@ export class DevController implements OnModuleInit {
     this.broadcaster.emitStarted(battleId)
 
     return { battleId }
+  }
+
+  @Post(':id/skip')
+  @HttpCode(200)
+  async skip(
+    @Param('id') battleId: string,
+    @Body() body: DevSkipDto,
+  ): Promise<{ battleId: string; userId: string; skip: boolean; totalSkips: number }> {
+    this.assertNotProduction()
+
+    const skip = body.skip ?? true
+    const totalSkips = await this.phaseTransitionUseCase.handlePhaseSkip(battleId, body.userId, skip)
+
+    this.broadcaster.emitUserSkipped(battleId, totalSkips)
+
+    return { battleId, userId: body.userId, skip, totalSkips }
   }
 
   @Delete(':id')

--- a/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.ts
+++ b/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.ts
@@ -118,4 +118,10 @@ export class BattleBroadcasterAdapter extends EventEmitter implements BattleBroa
     this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.LEAVED, payload)
     this.emit('battle:leaved', payload)
   }
+
+  emitStarted(battleId: string): void {
+    const battleRoomId = getBattleRoomId(battleId)
+    this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.STARTED)
+    this.emit('battle:started', { battleId })
+  }
 }

--- a/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.ts
+++ b/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.ts
@@ -111,4 +111,10 @@ export class BattleBroadcasterAdapter extends EventEmitter implements BattleBroa
     this.io.to(roomId).emit(BATTLE_SERVER_EVENTS.CHATTED, payload)
     this.emit('battle:chatted', payload)
   }
+
+  emitUserSkipped(battleId: string, totalSkips: number): void {
+    const battleRoomId = getBattleRoomId(battleId)
+    this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.USER_SKIPPED, { totalSkips })
+    this.emit('battle:user:skipped', { battleId, totalSkips })
+  }
 }

--- a/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.ts
+++ b/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.ts
@@ -124,4 +124,10 @@ export class BattleBroadcasterAdapter extends EventEmitter implements BattleBroa
     this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.STARTED)
     this.emit('battle:started', { battleId })
   }
+
+  emitUserSkipped(battleId: string, totalSkips: number): void {
+    const battleRoomId = getBattleRoomId(battleId)
+    this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.USER_SKIPPED, { totalSkips })
+    this.emit('battle:user:skipped', { battleId, totalSkips })
+  }
 }

--- a/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.ts
+++ b/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.ts
@@ -3,6 +3,7 @@ import { Server } from 'socket.io'
 import { EventEmitter } from 'node:events'
 import { getBattleRoomId } from '../../../domains/services/utils/battle.util'
 import { BattleBroadcasterPort, BattleChatBroadcastPayload } from '../../../application/ports/out/battleBroadcaster.port'
+import { BattleLeaveResponseDto } from '../../../dto/battleLeaveResponse.dto'
 import { BATTLE_CHAT_SCOPE } from '../../../domains/models/const/battles.const'
 import { BattlePhaseResponseDto, BattleRoundResponseDto } from '../../../dto/battleTurnResponse.dto'
 import { BattleUserUpdateResponseDto } from '../../../dto/battleUserUpdateResponse.dto'
@@ -110,5 +111,11 @@ export class BattleBroadcasterAdapter extends EventEmitter implements BattleBroa
     const roomId = payload.scope === BATTLE_CHAT_SCOPE.ALL ? getBattleRoomId(payload.battleId) : getBattleRoomId(payload.battleId, payload.team)
     this.io.to(roomId).emit(BATTLE_SERVER_EVENTS.CHATTED, payload)
     this.emit('battle:chatted', payload)
+  }
+
+  emitLeaved(payload: BattleLeaveResponseDto): void {
+    const battleRoomId = getBattleRoomId(payload.battleId)
+    this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.LEAVED, payload)
+    this.emit('battle:leaved', payload)
   }
 }

--- a/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.ts
+++ b/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.ts
@@ -2,7 +2,8 @@ import { Injectable } from '@nestjs/common'
 import { Server } from 'socket.io'
 import { EventEmitter } from 'node:events'
 import { getBattleRoomId } from '../../../domains/services/utils/battle.util'
-import { BattleBroadcasterPort } from '../../../application/ports/out/battleBroadcaster.port'
+import { BattleBroadcasterPort, BattleChatBroadcastPayload } from '../../../application/ports/out/battleBroadcaster.port'
+import { BATTLE_CHAT_SCOPE } from '../../../domains/models/const/battles.const'
 import { BattlePhaseResponseDto, BattleRoundResponseDto } from '../../../dto/battleTurnResponse.dto'
 import { BattleUserUpdateResponseDto } from '../../../dto/battleUserUpdateResponse.dto'
 import { BattleTeamUpdateAllResponseDto } from '../../../dto/battleTeamUpdateAllResponse.dto'
@@ -103,5 +104,11 @@ export class BattleBroadcasterAdapter extends EventEmitter implements BattleBroa
     const teamRoom = getBattleRoomId(battleId, team)
     this.io.to(teamRoom).emit(BATTLE_SERVER_EVENTS.DEFENSE_VOTED, voteRes)
     this.emit('battle:defense:voted', { battleId, team, voteRes })
+  }
+
+  emitChatted(payload: BattleChatBroadcastPayload): void {
+    const roomId = payload.scope === BATTLE_CHAT_SCOPE.ALL ? getBattleRoomId(payload.battleId) : getBattleRoomId(payload.battleId, payload.team)
+    this.io.to(roomId).emit(BATTLE_SERVER_EVENTS.CHATTED, payload)
+    this.emit('battle:chatted', payload)
   }
 }

--- a/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.ts
+++ b/backend/src/battles/adapters/out/broadcaster/battleBroadcaster.adapter.ts
@@ -111,10 +111,4 @@ export class BattleBroadcasterAdapter extends EventEmitter implements BattleBroa
     this.io.to(roomId).emit(BATTLE_SERVER_EVENTS.CHATTED, payload)
     this.emit('battle:chatted', payload)
   }
-
-  emitUserSkipped(battleId: string, totalSkips: number): void {
-    const battleRoomId = getBattleRoomId(battleId)
-    this.io.to(battleRoomId).emit(BATTLE_SERVER_EVENTS.USER_SKIPPED, { totalSkips })
-    this.emit('battle:user:skipped', { battleId, totalSkips })
-  }
 }

--- a/backend/src/battles/adapters/out/persistence/battleRepository.adapter.ts
+++ b/backend/src/battles/adapters/out/persistence/battleRepository.adapter.ts
@@ -198,4 +198,8 @@ export class BattleRepositoryAdapter implements BattleRepoPort {
       data: args.data,
     })
   }
+
+  async delete(battleId: string): Promise<void> {
+    await this.prisma.battle.delete({ where: { id: battleId } })
+  }
 }

--- a/backend/src/battles/application/ports/out/battleBroadcaster.port.ts
+++ b/backend/src/battles/application/ports/out/battleBroadcaster.port.ts
@@ -6,6 +6,16 @@ import { DiscussionVoteResultDto } from '../../../dto/discussionVoteResult.dto'
 import type { BattleDiscussion, BattleTeam } from '../../../domains/models/types/battle.types'
 import type { DiscussionVoteResponseDto } from '../../../dto/discussionVoteResponse.dto'
 
+export interface BattleChatBroadcastPayload {
+  battleId: string
+  scope: string
+  messageId: string
+  team: BattleTeam
+  sender: { userId: string; nickname: string; tier?: string }
+  text: string
+  createdAt: Date
+}
+
 export interface BattleBroadcasterPort {
   emitPhaseUpdated(phaseRes: BattlePhaseResponseDto): void
   emitRoundUpdated(roundRes: BattleRoundResponseDto): void
@@ -19,5 +29,6 @@ export interface BattleBroadcasterPort {
   emitDefenseCreated(battleId: string, team: BattleTeam, discussion: BattleDiscussion): void
   emitAttackVoted(battleId: string, team: BattleTeam, voteRes: DiscussionVoteResponseDto): void
   emitDefenseVoted(battleId: string, team: BattleTeam, voteRes: DiscussionVoteResponseDto): void
+  emitChatted(payload: BattleChatBroadcastPayload): void
   on(event: string, listener: (...args: any[]) => void): void
 }

--- a/backend/src/battles/application/ports/out/battleBroadcaster.port.ts
+++ b/backend/src/battles/application/ports/out/battleBroadcaster.port.ts
@@ -33,5 +33,6 @@ export interface BattleBroadcasterPort {
   emitChatted(payload: BattleChatBroadcastPayload): void
   emitLeaved(payload: BattleLeaveResponseDto): void
   emitStarted(battleId: string): void
+  emitUserSkipped(battleId: string, totalSkips: number): void
   on(event: string, listener: (...args: any[]) => void): void
 }

--- a/backend/src/battles/application/ports/out/battleBroadcaster.port.ts
+++ b/backend/src/battles/application/ports/out/battleBroadcaster.port.ts
@@ -30,6 +30,5 @@ export interface BattleBroadcasterPort {
   emitAttackVoted(battleId: string, team: BattleTeam, voteRes: DiscussionVoteResponseDto): void
   emitDefenseVoted(battleId: string, team: BattleTeam, voteRes: DiscussionVoteResponseDto): void
   emitChatted(payload: BattleChatBroadcastPayload): void
-  emitUserSkipped(battleId: string, totalSkips: number): void
   on(event: string, listener: (...args: any[]) => void): void
 }

--- a/backend/src/battles/application/ports/out/battleBroadcaster.port.ts
+++ b/backend/src/battles/application/ports/out/battleBroadcaster.port.ts
@@ -2,6 +2,7 @@ import { BattlePhaseResponseDto, BattleRoundResponseDto } from '../../../dto/bat
 import { BattleUserUpdateResponseDto } from '../../../dto/battleUserUpdateResponse.dto'
 import { BattleTeamUpdateAllResponseDto } from '../../../dto/battleTeamUpdateAllResponse.dto'
 import { BattleClosedResponseDto } from '../../../dto/battleClosedResponse.dto'
+import { BattleLeaveResponseDto } from '../../../dto/battleLeaveResponse.dto'
 import { DiscussionVoteResultDto } from '../../../dto/discussionVoteResult.dto'
 import type { BattleDiscussion, BattleTeam } from '../../../domains/models/types/battle.types'
 import type { DiscussionVoteResponseDto } from '../../../dto/discussionVoteResponse.dto'
@@ -30,5 +31,6 @@ export interface BattleBroadcasterPort {
   emitAttackVoted(battleId: string, team: BattleTeam, voteRes: DiscussionVoteResponseDto): void
   emitDefenseVoted(battleId: string, team: BattleTeam, voteRes: DiscussionVoteResponseDto): void
   emitChatted(payload: BattleChatBroadcastPayload): void
+  emitLeaved(payload: BattleLeaveResponseDto): void
   on(event: string, listener: (...args: any[]) => void): void
 }

--- a/backend/src/battles/application/ports/out/battleBroadcaster.port.ts
+++ b/backend/src/battles/application/ports/out/battleBroadcaster.port.ts
@@ -30,5 +30,6 @@ export interface BattleBroadcasterPort {
   emitAttackVoted(battleId: string, team: BattleTeam, voteRes: DiscussionVoteResponseDto): void
   emitDefenseVoted(battleId: string, team: BattleTeam, voteRes: DiscussionVoteResponseDto): void
   emitChatted(payload: BattleChatBroadcastPayload): void
+  emitUserSkipped(battleId: string, totalSkips: number): void
   on(event: string, listener: (...args: any[]) => void): void
 }

--- a/backend/src/battles/application/ports/out/battleBroadcaster.port.ts
+++ b/backend/src/battles/application/ports/out/battleBroadcaster.port.ts
@@ -32,5 +32,6 @@ export interface BattleBroadcasterPort {
   emitDefenseVoted(battleId: string, team: BattleTeam, voteRes: DiscussionVoteResponseDto): void
   emitChatted(payload: BattleChatBroadcastPayload): void
   emitLeaved(payload: BattleLeaveResponseDto): void
+  emitStarted(battleId: string): void
   on(event: string, listener: (...args: any[]) => void): void
 }

--- a/backend/src/battles/application/ports/out/battleRepository.port.ts
+++ b/backend/src/battles/application/ports/out/battleRepository.port.ts
@@ -107,4 +107,7 @@ export interface BattleRepoPort {
 
   //배틀 참가자 업데이트
   updateManyBattleParticipants(args: { where: { battleId: string; userId?: { in?: string[] } }; data: { isMvp: boolean } }): Promise<void>
+
+  //배틀 삭제 (DEV ONLY) — BattleParticipant cascade 삭제
+  delete(battleId: string): Promise<void>
 }

--- a/backend/src/battles/dto/devForcePhase.dto.ts
+++ b/backend/src/battles/dto/devForcePhase.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsIn, IsInt, IsNotEmpty, IsOptional, IsString, MaxLength, Min, MinLength } from 'class-validator'
+import { IsBoolean, IsEnum, IsIn, IsInt, IsNotEmpty, IsOptional, IsString, MaxLength, Min, MinLength } from 'class-validator'
 import type { BattlePhaseName } from '@cmc/types'
 import { BATTLE_CHAT_SCOPE } from '../domains/models/const/battles.const'
 
@@ -98,4 +98,14 @@ export class DevLeaveDto {
   @IsString()
   @IsNotEmpty()
   userId: string
+}
+
+export class DevSkipDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: string
+
+  @IsOptional()
+  @IsBoolean()
+  skip?: boolean
 }

--- a/backend/src/battles/dto/devForcePhase.dto.ts
+++ b/backend/src/battles/dto/devForcePhase.dto.ts
@@ -84,3 +84,12 @@ export class DevChatDto {
   @MaxLength(500)
   text: string
 }
+
+export class DevSkipDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: string
+
+  @IsOptional()
+  skip?: boolean
+}

--- a/backend/src/battles/dto/devForcePhase.dto.ts
+++ b/backend/src/battles/dto/devForcePhase.dto.ts
@@ -93,3 +93,9 @@ export class DevTeamVoteDto {
   @IsEnum(['A', 'B', 'NONE'])
   team: 'A' | 'B' | 'NONE'
 }
+
+export class DevLeaveDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: string
+}

--- a/backend/src/battles/dto/devForcePhase.dto.ts
+++ b/backend/src/battles/dto/devForcePhase.dto.ts
@@ -85,11 +85,11 @@ export class DevChatDto {
   text: string
 }
 
-export class DevSkipDto {
+export class DevTeamVoteDto {
   @IsString()
   @IsNotEmpty()
   userId: string
 
-  @IsOptional()
-  skip?: boolean
+  @IsEnum(['A', 'B', 'NONE'])
+  team: 'A' | 'B' | 'NONE'
 }

--- a/backend/src/battles/dto/devForcePhase.dto.ts
+++ b/backend/src/battles/dto/devForcePhase.dto.ts
@@ -1,5 +1,6 @@
-import { IsEnum, IsInt, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator'
+import { IsEnum, IsIn, IsInt, IsNotEmpty, IsOptional, IsString, MaxLength, Min, MinLength } from 'class-validator'
 import type { BattlePhaseName } from '@cmc/types'
+import { BATTLE_CHAT_SCOPE } from '../domains/models/const/battles.const'
 
 const PHASE_VALUES: BattlePhaseName[] = ['PENDING', 'OPINION_SHARE', 'ATTACK', 'DEFENSE', 'TEAM_SWITCH']
 
@@ -67,4 +68,19 @@ export class DevInjectVoteDto {
   @IsOptional()
   @IsString()
   voterId?: string
+}
+
+export class DevChatDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: string
+
+  @IsString()
+  @IsIn([BATTLE_CHAT_SCOPE.ALL, BATTLE_CHAT_SCOPE.TEAM])
+  scope: typeof BATTLE_CHAT_SCOPE.ALL | typeof BATTLE_CHAT_SCOPE.TEAM
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(500)
+  text: string
 }

--- a/dev-mcp/src/clients/backend.ts
+++ b/dev-mcp/src/clients/backend.ts
@@ -19,3 +19,14 @@ export async function postBackend<TBody extends object, TResponse = unknown>(
   }
   return text ? (JSON.parse(text) as TResponse) : ({} as TResponse);
 }
+
+export async function deleteBackend<TResponse = unknown>(path: string): Promise<TResponse> {
+  const url = `${getBackendUrl()}${path}`;
+  const response = await fetch(url, { method: 'DELETE' });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`백엔드 응답 ${response.status}: ${text || response.statusText}`);
+  }
+  return text ? (JSON.parse(text) as TResponse) : ({} as TResponse);
+}

--- a/dev-mcp/src/index.ts
+++ b/dev-mcp/src/index.ts
@@ -13,6 +13,7 @@ import { injectVote, injectVoteSchema } from './tools/injectVote.js';
 import { injectChat, injectChatSchema } from './tools/injectChat.js';
 import { injectTeamVote, injectTeamVoteSchema } from './tools/injectTeamVote.js';
 import { injectLeave, injectLeaveSchema } from './tools/injectLeave.js';
+import { injectSkip, injectSkipSchema } from './tools/injectSkip.js';
 import { startBattle, startBattleSchema } from './tools/startBattle.js';
 import { resetBattle, resetBattleSchema } from './tools/resetBattle.js';
 import { inspectBattle, inspectBattleSchema } from './tools/inspectBattle.js';
@@ -146,6 +147,19 @@ server.tool(
   async (params) => {
     try {
       return { content: [{ type: 'text', text: await injectLeave(params) }] };
+    } catch (err) {
+      return { content: [{ type: 'text', text: `[오류] ${(err as Error).message}` }] };
+    }
+  },
+);
+
+server.tool(
+  'injectSkip',
+  '특정 유저의 페이즈 스킵 토글을 강제로 주입합니다. skip 기본 true(활성화), false면 해제. 참가자 전원 스킵 시 다음 페이즈로 자동 advance. USER_SKIPPED broadcast. (로컬 개발 전용)',
+  injectSkipSchema,
+  async (params) => {
+    try {
+      return { content: [{ type: 'text', text: await injectSkip(params) }] };
     } catch (err) {
       return { content: [{ type: 'text', text: `[오류] ${(err as Error).message}` }] };
     }

--- a/dev-mcp/src/index.ts
+++ b/dev-mcp/src/index.ts
@@ -14,6 +14,7 @@ import { injectChat, injectChatSchema } from './tools/injectChat.js';
 import { injectTeamVote, injectTeamVoteSchema } from './tools/injectTeamVote.js';
 import { injectLeave, injectLeaveSchema } from './tools/injectLeave.js';
 import { startBattle, startBattleSchema } from './tools/startBattle.js';
+import { resetBattle, resetBattleSchema } from './tools/resetBattle.js';
 import { inspectBattle, inspectBattleSchema } from './tools/inspectBattle.js';
 
 const server = new McpServer({
@@ -158,6 +159,19 @@ server.tool(
   async (params) => {
     try {
       return { content: [{ type: 'text', text: await startBattle(params) }] };
+    } catch (err) {
+      return { content: [{ type: 'text', text: `[오류] ${(err as Error).message}` }] };
+    }
+  },
+);
+
+server.tool(
+  'resetBattle',
+  '배틀을 완전히 정리합니다. timer ZSET → in-memory liveStates · Redis battle:* 키 → DB row(BattleParticipant cascade) 순서로 삭제. 장시간 테스트 메모리 누적 해소용. (로컬 개발 전용)',
+  resetBattleSchema,
+  async (params) => {
+    try {
+      return { content: [{ type: 'text', text: await resetBattle(params) }] };
     } catch (err) {
       return { content: [{ type: 'text', text: `[오류] ${(err as Error).message}` }] };
     }

--- a/dev-mcp/src/index.ts
+++ b/dev-mcp/src/index.ts
@@ -13,6 +13,7 @@ import { injectVote, injectVoteSchema } from './tools/injectVote.js';
 import { injectChat, injectChatSchema } from './tools/injectChat.js';
 import { injectTeamVote, injectTeamVoteSchema } from './tools/injectTeamVote.js';
 import { injectLeave, injectLeaveSchema } from './tools/injectLeave.js';
+import { startBattle, startBattleSchema } from './tools/startBattle.js';
 import { inspectBattle, inspectBattleSchema } from './tools/inspectBattle.js';
 
 const server = new McpServer({
@@ -144,6 +145,19 @@ server.tool(
   async (params) => {
     try {
       return { content: [{ type: 'text', text: await injectLeave(params) }] };
+    } catch (err) {
+      return { content: [{ type: 'text', text: `[오류] ${(err as Error).message}` }] };
+    }
+  },
+);
+
+server.tool(
+  'startBattle',
+  '배틀을 시작합니다. status를 OPEN으로 변경하고 PENDING→OPINION_SHARE로 자동 advance. PHASE_UPDATED/ROUND_UPDATED/STARTED broadcast. 가짜 참가자 양 팀 채운 후 호출하면 솔로 테스트에서도 진행 가능. (로컬 개발 전용)',
+  startBattleSchema,
+  async (params) => {
+    try {
+      return { content: [{ type: 'text', text: await startBattle(params) }] };
     } catch (err) {
       return { content: [{ type: 'text', text: `[오류] ${(err as Error).message}` }] };
     }

--- a/dev-mcp/src/index.ts
+++ b/dev-mcp/src/index.ts
@@ -11,6 +11,7 @@ import { addParticipant, addParticipantSchema } from './tools/addParticipant.js'
 import { injectDiscussion, injectDiscussionSchema } from './tools/injectDiscussion.js';
 import { injectVote, injectVoteSchema } from './tools/injectVote.js';
 import { injectChat, injectChatSchema } from './tools/injectChat.js';
+import { injectTeamVote, injectTeamVoteSchema } from './tools/injectTeamVote.js';
 import { inspectBattle, inspectBattleSchema } from './tools/inspectBattle.js';
 
 const server = new McpServer({
@@ -116,6 +117,19 @@ server.tool(
   async (params) => {
     try {
       return { content: [{ type: 'text', text: await injectChat(params) }] };
+    } catch (err) {
+      return { content: [{ type: 'text', text: `[오류] ${(err as Error).message}` }] };
+    }
+  },
+);
+
+server.tool(
+  'injectTeamVote',
+  '특정 유저의 진영 변경 투표를 강제로 주입합니다. 실제 흐름과 동일하게 broadcast 없이 state만 변경됩니다. TEAM_SWITCH 페이즈 진입 시 applyTeamSwitch가 ALL_UPDATED 한 번에 emit. (로컬 개발 전용)',
+  injectTeamVoteSchema,
+  async (params) => {
+    try {
+      return { content: [{ type: 'text', text: await injectTeamVote(params) }] };
     } catch (err) {
       return { content: [{ type: 'text', text: `[오류] ${(err as Error).message}` }] };
     }

--- a/dev-mcp/src/index.ts
+++ b/dev-mcp/src/index.ts
@@ -12,6 +12,7 @@ import { injectDiscussion, injectDiscussionSchema } from './tools/injectDiscussi
 import { injectVote, injectVoteSchema } from './tools/injectVote.js';
 import { injectChat, injectChatSchema } from './tools/injectChat.js';
 import { injectTeamVote, injectTeamVoteSchema } from './tools/injectTeamVote.js';
+import { injectLeave, injectLeaveSchema } from './tools/injectLeave.js';
 import { inspectBattle, inspectBattleSchema } from './tools/inspectBattle.js';
 
 const server = new McpServer({
@@ -130,6 +131,19 @@ server.tool(
   async (params) => {
     try {
       return { content: [{ type: 'text', text: await injectTeamVote(params) }] };
+    } catch (err) {
+      return { content: [{ type: 'text', text: `[오류] ${(err as Error).message}` }] };
+    }
+  },
+);
+
+server.tool(
+  'injectLeave',
+  '특정 유저를 배틀에서 강제로 나가게 합니다. 참가자/팀 목록/투표/스킵 상태에서 제거 후 LEAVED broadcast. 잔여 참가자 모두 skip 상태면 자동 페이즈 advance. (로컬 개발 전용)',
+  injectLeaveSchema,
+  async (params) => {
+    try {
+      return { content: [{ type: 'text', text: await injectLeave(params) }] };
     } catch (err) {
       return { content: [{ type: 'text', text: `[오류] ${(err as Error).message}` }] };
     }

--- a/dev-mcp/src/index.ts
+++ b/dev-mcp/src/index.ts
@@ -10,6 +10,7 @@ import { createTestBattle, createTestBattleSchema } from './tools/createTestBatt
 import { addParticipant, addParticipantSchema } from './tools/addParticipant.js';
 import { injectDiscussion, injectDiscussionSchema } from './tools/injectDiscussion.js';
 import { injectVote, injectVoteSchema } from './tools/injectVote.js';
+import { injectChat, injectChatSchema } from './tools/injectChat.js';
 import { inspectBattle, inspectBattleSchema } from './tools/inspectBattle.js';
 
 const server = new McpServer({
@@ -102,6 +103,19 @@ server.tool(
   async (params) => {
     try {
       return { content: [{ type: 'text', text: await injectVote(params) }] };
+    } catch (err) {
+      return { content: [{ type: 'text', text: `[오류] ${(err as Error).message}` }] };
+    }
+  },
+);
+
+server.tool(
+  'injectChat',
+  '특정 유저 명의로 채팅을 강제로 전송합니다. scope=ALL이면 전체 채팅 룸, scope=TEAM이면 해당 유저의 팀 룸으로 broadcast. team은 state.participants에서 자동 추출. NONE 진영 유저는 TEAM scope 불가. (로컬 개발 전용)',
+  injectChatSchema,
+  async (params) => {
+    try {
+      return { content: [{ type: 'text', text: await injectChat(params) }] };
     } catch (err) {
       return { content: [{ type: 'text', text: `[오류] ${(err as Error).message}` }] };
     }

--- a/dev-mcp/src/tools/injectChat.ts
+++ b/dev-mcp/src/tools/injectChat.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { postBackend } from '../clients/backend.js';
+
+export const injectChatSchema = {
+  battleId: z.string().min(1),
+  userId: z.string().min(1).describe('채팅 보낼 유저 ID. 배틀 참가자여야 함'),
+  scope: z.enum(['ALL', 'TEAM']).describe('ALL=전체 채팅, TEAM=팀 채팅 (NONE 진영 불가)'),
+  text: z.string().min(1).max(500),
+};
+
+interface InjectChatResponse {
+  battleId: string;
+  messageId: string;
+  scope: string;
+  team: string;
+  userId: string;
+  nickname: string;
+}
+
+export async function injectChat(params: {
+  battleId: string;
+  userId: string;
+  scope: 'ALL' | 'TEAM';
+  text: string;
+}): Promise<string> {
+  const result = await postBackend<
+    { userId: string; scope: 'ALL' | 'TEAM'; text: string },
+    InjectChatResponse
+  >(`/dev/battles/${params.battleId}/chat`, {
+    userId: params.userId,
+    scope: params.scope,
+    text: params.text,
+  });
+
+  return [
+    `[injectChat] 채팅 전송 완료`,
+    `battleId  : ${result.battleId}`,
+    `messageId : ${result.messageId}`,
+    `scope     : ${result.scope}`,
+    `team      : ${result.team}`,
+    `userId    : ${result.userId}`,
+    `nickname  : ${result.nickname}`,
+    `반영      : in-memory state · Redis · DB · 소켓 CHATTED emit (scope 룸)`,
+  ].join('\n');
+}

--- a/dev-mcp/src/tools/injectLeave.ts
+++ b/dev-mcp/src/tools/injectLeave.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { postBackend } from '../clients/backend.js';
+
+export const injectLeaveSchema = {
+  battleId: z.string().min(1),
+  userId: z.string().min(1).describe('나가게 할 유저 ID. 배틀 참가자여야 함'),
+};
+
+interface InjectLeaveResponse {
+  battleId: string;
+  userId: string;
+  counts: { teamA: number; teamB: number; teamNone: number };
+  totalSkips: number;
+}
+
+export async function injectLeave(params: { battleId: string; userId: string }): Promise<string> {
+  const result = await postBackend<{ userId: string }, InjectLeaveResponse>(
+    `/dev/battles/${params.battleId}/leave`,
+    { userId: params.userId },
+  );
+
+  return [
+    `[injectLeave] 배틀 나가기 완료`,
+    `battleId   : ${result.battleId}`,
+    `userId     : ${result.userId}`,
+    `counts     : A=${result.counts.teamA}, B=${result.counts.teamB}, NONE=${result.counts.teamNone}`,
+    `totalSkips : ${result.totalSkips}`,
+    `반영       : in-memory state · Redis · DB · 소켓 LEAVED emit. 잔여 참가자 모두 skip 시 자동 advance`,
+  ].join('\n');
+}

--- a/dev-mcp/src/tools/injectSkip.ts
+++ b/dev-mcp/src/tools/injectSkip.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import { postBackend } from '../clients/backend.js';
+
+export const injectSkipSchema = {
+  battleId: z.string().min(1),
+  userId: z.string().min(1).describe('스킵을 토글할 유저 ID. 배틀 참가자여야 함'),
+  skip: z
+    .boolean()
+    .optional()
+    .describe('true=스킵 활성화(기본), false=스킵 해제'),
+};
+
+interface InjectSkipResponse {
+  battleId: string;
+  userId: string;
+  skip: boolean;
+  totalSkips: number;
+}
+
+export async function injectSkip(params: {
+  battleId: string;
+  userId: string;
+  skip?: boolean;
+}): Promise<string> {
+  const result = await postBackend<{ userId: string; skip?: boolean }, InjectSkipResponse>(
+    `/dev/battles/${params.battleId}/skip`,
+    { userId: params.userId, skip: params.skip },
+  );
+
+  return [
+    `[injectSkip] 페이즈 스킵 토글 완료`,
+    `battleId   : ${result.battleId}`,
+    `userId     : ${result.userId}`,
+    `skip       : ${result.skip}`,
+    `totalSkips : ${result.totalSkips}`,
+    `반영       : in-memory state · Redis · 소켓 USER_SKIPPED emit. 전원 스킵 시 자동 advance`,
+  ].join('\n');
+}

--- a/dev-mcp/src/tools/injectTeamVote.ts
+++ b/dev-mcp/src/tools/injectTeamVote.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import { postBackend } from '../clients/backend.js';
+
+export const injectTeamVoteSchema = {
+  battleId: z.string().min(1),
+  userId: z.string().min(1).describe('진영 변경 투표할 유저 ID. 배틀 참가자여야 함'),
+  team: z.enum(['A', 'B', 'NONE']).describe('이동 희망 진영. NONE=중립'),
+};
+
+interface InjectTeamVoteResponse {
+  battleId: string;
+  userId: string;
+  team: string;
+  counts: { A: number; B: number; NONE: number };
+}
+
+export async function injectTeamVote(params: {
+  battleId: string;
+  userId: string;
+  team: 'A' | 'B' | 'NONE';
+}): Promise<string> {
+  const result = await postBackend<
+    { userId: string; team: 'A' | 'B' | 'NONE' },
+    InjectTeamVoteResponse
+  >(`/dev/battles/${params.battleId}/team-vote`, {
+    userId: params.userId,
+    team: params.team,
+  });
+
+  return [
+    `[injectTeamVote] 진영 투표 완료`,
+    `battleId : ${result.battleId}`,
+    `userId   : ${result.userId}`,
+    `team     : ${result.team}`,
+    `counts   : A=${result.counts.A}, B=${result.counts.B}, NONE=${result.counts.NONE}`,
+    `반영     : in-memory state · Redis · DB (broadcast 없음. TEAM_SWITCH 페이즈 진입 시 일괄 emit)`,
+  ].join('\n');
+}

--- a/dev-mcp/src/tools/resetBattle.ts
+++ b/dev-mcp/src/tools/resetBattle.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import { deleteBackend } from '../clients/backend.js';
+
+export const resetBattleSchema = {
+  battleId: z.string().min(1),
+};
+
+interface ResetBattleResponse {
+  battleId: string;
+  deleted: { timer: boolean; redis: boolean; memory: boolean; db: boolean };
+}
+
+export async function resetBattle(params: { battleId: string }): Promise<string> {
+  const result = await deleteBackend<ResetBattleResponse>(`/dev/battles/${params.battleId}`);
+
+  const mark = (ok: boolean) => (ok ? 'OK' : 'FAIL');
+  const { timer, redis, memory, db } = result.deleted;
+
+  return [
+    `[resetBattle] 배틀 정리 완료`,
+    `battleId : ${result.battleId}`,
+    `timer    : ${mark(timer)} (ZSET entry)`,
+    `redis    : ${mark(redis)} (battle:* keys)`,
+    `memory   : ${mark(memory)} (liveStates)`,
+    `db       : ${mark(db)} (battle row + cascade)`,
+  ].join('\n');
+}

--- a/dev-mcp/src/tools/startBattle.ts
+++ b/dev-mcp/src/tools/startBattle.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import { postBackend } from '../clients/backend.js';
+
+export const startBattleSchema = {
+  battleId: z.string().min(1),
+};
+
+interface StartBattleResponse {
+  battleId: string;
+}
+
+export async function startBattle(params: { battleId: string }): Promise<string> {
+  const result = await postBackend<Record<string, never>, StartBattleResponse>(
+    `/dev/battles/${params.battleId}/start`,
+    {},
+  );
+
+  return [
+    `[startBattle] 게임 시작 완료`,
+    `battleId : ${result.battleId}`,
+    `반영     : status=OPEN · PHASE_UPDATED/ROUND_UPDATED emit · PENDING→OPINION_SHARE 자동 advance · STARTED broadcast`,
+  ].join('\n');
+}


### PR DESCRIPTION
## 🔗 관련 이슈
#444 , Closes #443 

## ✅ 작업 내용

### 배경
이전 #441 에서 Dev-MCP를 만들게 된 이유는 이상한 버그가 리포트로 들어왔을때 그 상태를 손으로 재현하기가 너무 빡셌어서, 페이즈·타이머·참가자·토론 같은 걸 강제로 셋업할 수 있는 도구를 만들었습니다. 

만들고 나서 든 생각은 서버와 소켓 상태들이 MCP로 노출되어 있으니 AI 에이전트가 직접 호출 가능하니 기존 E2E 말고 `AI가 무작위 액션을 발사해서 상태 깨지는 케이스를 자동으로 찾는 fuzz QA`로 확장 가능 하겠다는 생각이 들어 이번 PR에서는 #441 에서 채우지 못했던 추가적인 유저 액션에 관한 모든 이벤트 제어 tool들을 추가 하려 합니다. 


<br/>

### 유저 액션 재현 dev API 6종 추가

 #441 에 추가한 dev 컨트롤러는  별도 우회 로직없이 운영 엔드포인트와 동일한 유스케이스(BattleInteractionUseCase 등)를 그대로 호 출하는식으로 구현했습니다.

| 엔드포인트 | 재현하는 유저 액션 |
|---|---|
| `POST /dev/battles/:id/chat` | 채팅 메시지 전송 (scope에 따라 전체/팀 룸 broadcast) |
| `POST /dev/battles/:id/skip` | 페이즈 스킵 토글|
| `POST /dev/battles/:id/team-vote` | 진영 변경 투표 (실제 흐름과 동일하게 state만 변경, TEAM_SWITCH 시 일괄 emit) |
| `POST /dev/battles/:id/leave` | 유저 강제 퇴장 + 잔여 참가자 전원 스킵 상태면 자동 전환|
| `POST /dev/battles/:id/start` | 배틀 시작 (PENDING → OPINION_SHARE 자동 전환) |
| `DELETE /dev/battles/:id` | 배틀 완전 정리 (timer ZSET → in-memory liveStates · Redis battle:* → DB row 순) |





<br/>

### 위 dev-api 6개를 래핑한 dev-mcp tool 추가

`dev-mcp/src/tools/` 아래에 위 엔드포인트와 1:1 매칭되는 tool 6개를 추가했습니다.

- `injectChat` → `POST /chat`
- `injectSkip` → `POST /skip`
- `injectTeamVote` → `POST /team-vote`
- `injectLeave` → `POST /leave`
- `startBattle` → `POST /start`
- `resetBattle` → `DELETE /:id`


<br/>


## 참고사항 
### `resetBattle`의 삭제 순서

참고로 `DELETE /:id`는 3단계 순으로 정리합니다.

```
1. timer.cancel(battleId)              <- timer ZSET에서 만료 스케줄 제거
2. stateRepo.clearBattleStateFromRedis <- Redis battle:* 키 + in-memory liveStates
3. repo.delete(battleId)               <- DB battle row (BattleParticipant cascade)
```

레이스 컨디션이 발생하지 않도록 timer -> 휘발성 state(Redis + 메모리) -> 영속성(DB) 순으로 정리했습니다.
DB row를 먼저 삭제하면 살아있는 timer가 이후 만료될 때 loadBattleState에서 row를 찾지 못해 throw하고, timer ZSET 스케줄이 좀비처럼 남는 문제가 생길 수 있기 때문에 외부 트리거(timer)부터 먼저 제거한 뒤 안쪽 상태를 순차적으로 정리하도록 구성했습니다.

<br/>

### 이번 devAPi/tool 추가로 할 수 있는것들

```
1. createTestBattle             -> battleId 발급            (#441)
2. addParticipant team:A,B 2번  -> 양 팀 1명씩 채우고       (#441)
3. startBattle                  -> 배틀 시작                 <- 이번 PR
4. injectSkip 2명 모두 true     -> 전원 스킵 -> 자동 ATTACK   <- 이번 PR
5. injectDiscussion 양 팀       -> 토론 주입                (#441)
6. injectVote                   -> 투표 주입                (#441)
7. setTimer durationMs:0        -> 페이즈 즉시 만료         (#441)
... 반복 ...
N. resetBattle                  ->  정리                     <- 이번 PR
```

기존에는 `start`, `skip`, `reset`이 빠져 있어서 배틀 시작은 직접 클라이언트에서 눌러야 했고, 테스트 종료 후 정리도 DB를 수동으로 지우거나 서버를 재시작해야 했습니다.
이번 PR로 시작 -> 진행 -> 액션 주입 -> 정리까지 전체 battle 사이클을 dev API/tool만으로 자동화할 수 있게 됐습니다