### PR TITLE
[Devops] IaC - terraform 전환

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,17 @@ Thumbs.db
 
 # prisma
 /backend/generated/*
+
+# Terraform
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+.terraform.tfstate.lock.info
+*.tfplan
+*.tfplan.*
+tfplan
+crash.log
+crash.*.log
+terraform/envs/*/ncloud.env

--- a/terraform/envs/dev/.terraform.lock.hcl
+++ b/terraform/envs/dev/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/navercloudplatform/ncloud" {
+  version     = "4.0.5"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:xv5ojc1tqHadCnYfO5Y4O8Jghhtg9uFNZilO7SyMut0=",
+    "zh:170060ba35c70f1764122bb4343f25b327ce945f536bf3d2de97ebfdf4ea8357",
+    "zh:1706a4691903aaeddb8d03b3e5cb92c7075cd97a2bd4db1ac8ba069eabff4050",
+    "zh:2af369d9ea5d829bb18a8c3c147f6bf5a37ef70b6562617c408066f3d2398e13",
+    "zh:2f7578f7a15b4473e329d1bf00bae0004903ef80bbe8a01f4764bafee7067a95",
+    "zh:45fc015c4cc84847a4bbc591544f1dfe5b29e7c237a35c9b2e3c2c724cc59e65",
+    "zh:576de8c1e6b6c66fbcd3e409b3b0b2892f4c91132f49bd19d4965546c12b3c38",
+    "zh:5b243d009d9dc4766adbe33ebbba632d2eb02097f670f7da098d7c253365db3c",
+    "zh:5cbd9b359708792e0226e3f1c63908666bc4001c158cbe2e49aaf7e056504e7e",
+    "zh:5f5d0c7c43fc4812c0c127cd950ca266fdcb21ad82814265b691b5ccd8eb60f4",
+    "zh:8a9e4b408f8199a45788c3014eb4d348357cf07b25db92a7aeaa35d2ae2b13a9",
+    "zh:c11ce67481848cea6ff1a7ef13265a67eafb3358ba51adc472edae9521a06198",
+    "zh:c8a167677f5043d1ba06c4a2291f17f5517b98e38842b249d9bc1480b89bd780",
+    "zh:e46d3d13d314fb28a901c2f479c72cb68a33ed7d7d4d61274b1aad65b328ad45",
+    "zh:e96f9b39c3a3a2f7ce814c89d3efe4ef241f937e378adcc8fa15dc7466dd6f9a",
+  ]
+}

--- a/terraform/envs/dev/locals.tf
+++ b/terraform/envs/dev/locals.tf
@@ -1,0 +1,37 @@
+locals {
+  environment = "dev"
+
+  common_tags = {
+    owner       = var.owner
+    cost_center = var.cost_center
+    service     = var.project
+  }
+
+  default_server_init_script = <<-EOT
+    #!/bin/bash
+    set -euxo pipefail
+
+    export DEBIAN_FRONTEND=noninteractive
+
+    apt-get update
+    apt-get install -y ca-certificates curl git gnupg
+
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    chmod a+r /etc/apt/keyrings/docker.asc
+
+    . /etc/os-release
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list
+
+    apt-get update
+    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+    systemctl enable --now docker
+    usermod -aG docker ubuntu || true
+
+    mkdir -p /opt/cmc
+    chown ubuntu:ubuntu /opt/cmc || true
+  EOT
+
+  effective_server_init_script = var.server_init_script == null ? local.default_server_init_script : var.server_init_script
+}

--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -1,0 +1,59 @@
+module "backend_labels" {
+  source = "../../modules/labels"
+
+  project     = var.project
+  environment = local.environment
+  component   = "backend"
+  extra_tags  = local.common_tags
+}
+
+module "network" {
+  source = "../../modules/network"
+
+  project                  = var.project
+  environment              = local.environment
+  vpc_name                 = var.vpc_name
+  vpc_cidr                 = var.vpc_cidr
+  zone                     = var.zone
+  public_subnet_name       = var.public_subnet_name
+  private_subnet_name      = null
+  public_subnet_cidr       = var.public_subnet_cidr
+  private_subnet_cidr      = "10.255.255.0/24"
+  create_private_subnet    = false
+  ssh_access_cidrs         = var.ssh_access_cidrs
+  public_access_cidrs      = var.public_access_cidrs
+  extra_inbound_rules      = var.extra_public_inbound_rules
+  manage_default_acg_rules = true
+  tags                     = local.common_tags
+}
+
+module "backend_server" {
+  source = "../../modules/backend_server"
+
+  project                       = var.project
+  environment                   = local.environment
+  name                          = var.server_name
+  description                   = var.server_description
+  public_ip_description         = var.public_ip_description
+  server_image_name             = var.server_image_name
+  server_hypervisor_type        = var.server_hypervisor_type
+  server_spec_code              = var.server_spec_code
+  subnet_no                     = module.network.public_subnet_no
+  login_key_name                = var.login_key_name
+  associate_public_ip           = true
+  init_script                   = local.effective_server_init_script
+  is_protect_server_termination = var.is_protect_server_termination
+  tags                          = module.backend_labels.tags
+}
+
+module "observability" {
+  source = "../../modules/observability"
+
+  project     = var.project
+  environment = local.environment
+  name        = "${var.project}-${local.environment}-observability"
+  mode        = var.observability_mode
+  subnet_name = module.network.public_subnet_name
+  components  = ["prometheus", "grafana", "cadvisor"]
+  tags        = local.common_tags
+}

--- a/terraform/envs/dev/outputs.tf
+++ b/terraform/envs/dev/outputs.tf
@@ -1,0 +1,39 @@
+output "vpc_name" {
+  value = module.network.vpc_name
+}
+
+output "vpc_no" {
+  value = module.network.vpc_no
+}
+
+output "public_subnet_name" {
+  value = module.network.public_subnet_name
+}
+
+output "public_subnet_no" {
+  value = module.network.public_subnet_no
+}
+
+output "backend_server_name" {
+  value = module.backend_server.name
+}
+
+output "backend_server_id" {
+  value = module.backend_server.server_id
+}
+
+output "backend_public_ip" {
+  value = module.backend_server.public_ip
+}
+
+output "backend_public_ip_instance_no" {
+  value = module.backend_server.public_ip_instance_no
+}
+
+output "backend_private_ip" {
+  value = module.backend_server.private_ip
+}
+
+output "observability_name" {
+  value = module.observability.name
+}

--- a/terraform/envs/dev/providers.tf
+++ b/terraform/envs/dev/providers.tf
@@ -1,0 +1,8 @@
+provider "ncloud" {
+  region      = "KR"
+  site        = "public"
+  support_vpc = true
+
+  # Credentials are expected from environment variables or a local override file
+  # excluded from version control.
+}

--- a/terraform/envs/dev/terraform.tfvars.example
+++ b/terraform/envs/dev/terraform.tfvars.example
@@ -1,0 +1,31 @@
+owner              = "team-cmc"
+cost_center        = "bootcamp"
+
+zone               = "KR-1"
+vpc_name           = "os-emul"
+vpc_cidr           = "10.0.0.0/20"
+public_subnet_name = "os-emul-public-subnet"
+public_subnet_cidr = "10.0.0.0/24"
+
+ssh_access_cidrs   = ["YOUR_IP/32"]
+public_access_cidrs = ["0.0.0.0/0"]
+
+extra_public_inbound_rules = [
+  {
+    protocol    = "TCP"
+    ip_block    = "YOUR_IP/32"
+    port_range  = "3001"
+    description = "grafana-admin"
+  }
+]
+
+server_name                    = "cmc-dev"
+server_description             = ""
+server_image_name              = "ubuntu-24.04-base"
+server_hypervisor_type         = "KVM"
+server_spec_code               = "c2-g3a"
+login_key_name                 = "web02"
+server_init_script             = null
+is_protect_server_termination  = false
+
+observability_mode = "docker-compose"

--- a/terraform/envs/dev/variables.tf
+++ b/terraform/envs/dev/variables.tf
@@ -1,0 +1,103 @@
+variable "project" {
+  type    = string
+  default = "cmc"
+}
+
+variable "owner" {
+  type = string
+}
+
+variable "cost_center" {
+  type    = string
+  default = "cmc"
+}
+
+variable "zone" {
+  type    = string
+  default = "KR-1"
+}
+
+variable "vpc_name" {
+  type = string
+}
+
+variable "vpc_cidr" {
+  type = string
+}
+
+variable "public_subnet_name" {
+  type = string
+}
+
+variable "public_subnet_cidr" {
+  type = string
+}
+
+variable "ssh_access_cidrs" {
+  type    = list(string)
+  default = []
+}
+
+variable "public_access_cidrs" {
+  type    = list(string)
+  default = ["0.0.0.0/0"]
+}
+
+variable "extra_public_inbound_rules" {
+  type = list(object({
+    protocol    = string
+    ip_block    = string
+    port_range  = string
+    description = string
+  }))
+  default = []
+}
+
+variable "server_name" {
+  type = string
+}
+
+variable "server_description" {
+  type    = string
+  default = ""
+}
+
+variable "public_ip_description" {
+  type     = string
+  default  = null
+  nullable = true
+}
+
+variable "server_image_name" {
+  type = string
+}
+
+variable "server_hypervisor_type" {
+  type    = string
+  default = "KVM"
+}
+
+variable "server_spec_code" {
+  type = string
+}
+
+variable "login_key_name" {
+  type = string
+}
+
+variable "server_init_script" {
+  description = "Optional override for the backend server bootstrap script. Set null to use the default Docker Compose bootstrap."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "is_protect_server_termination" {
+  type    = bool
+  default = false
+}
+
+variable "observability_mode" {
+  type    = string
+  default = "docker-compose"
+}

--- a/terraform/envs/dev/versions.tf
+++ b/terraform/envs/dev/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    ncloud = {
+      source  = "navercloudplatform/ncloud"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/terraform/envs/prod/.terraform.lock.hcl
+++ b/terraform/envs/prod/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/navercloudplatform/ncloud" {
+  version     = "4.0.5"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:xv5ojc1tqHadCnYfO5Y4O8Jghhtg9uFNZilO7SyMut0=",
+    "zh:170060ba35c70f1764122bb4343f25b327ce945f536bf3d2de97ebfdf4ea8357",
+    "zh:1706a4691903aaeddb8d03b3e5cb92c7075cd97a2bd4db1ac8ba069eabff4050",
+    "zh:2af369d9ea5d829bb18a8c3c147f6bf5a37ef70b6562617c408066f3d2398e13",
+    "zh:2f7578f7a15b4473e329d1bf00bae0004903ef80bbe8a01f4764bafee7067a95",
+    "zh:45fc015c4cc84847a4bbc591544f1dfe5b29e7c237a35c9b2e3c2c724cc59e65",
+    "zh:576de8c1e6b6c66fbcd3e409b3b0b2892f4c91132f49bd19d4965546c12b3c38",
+    "zh:5b243d009d9dc4766adbe33ebbba632d2eb02097f670f7da098d7c253365db3c",
+    "zh:5cbd9b359708792e0226e3f1c63908666bc4001c158cbe2e49aaf7e056504e7e",
+    "zh:5f5d0c7c43fc4812c0c127cd950ca266fdcb21ad82814265b691b5ccd8eb60f4",
+    "zh:8a9e4b408f8199a45788c3014eb4d348357cf07b25db92a7aeaa35d2ae2b13a9",
+    "zh:c11ce67481848cea6ff1a7ef13265a67eafb3358ba51adc472edae9521a06198",
+    "zh:c8a167677f5043d1ba06c4a2291f17f5517b98e38842b249d9bc1480b89bd780",
+    "zh:e46d3d13d314fb28a901c2f479c72cb68a33ed7d7d4d61274b1aad65b328ad45",
+    "zh:e96f9b39c3a3a2f7ce814c89d3efe4ef241f937e378adcc8fa15dc7466dd6f9a",
+  ]
+}

--- a/terraform/envs/prod/locals.tf
+++ b/terraform/envs/prod/locals.tf
@@ -1,0 +1,24 @@
+locals {
+  environment = "prod"
+
+  common_tags = {
+    owner       = var.owner
+    cost_center = var.cost_center
+    service     = var.project
+  }
+
+  postgresql_private_inbound_rules = [
+    {
+      protocol    = "TCP"
+      ip_block    = var.public_subnet_cidr
+      port_range  = "5432"
+      description = "postgresql-from-backend-subnet"
+    },
+    {
+      protocol    = "TCP"
+      ip_block    = var.public_subnet_cidr
+      port_range  = "22"
+      description = "ssh-from-backend-subnet"
+    }
+  ]
+}

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -1,0 +1,130 @@
+module "frontend_labels" {
+  source = "../../modules/labels"
+
+  project     = var.project
+  environment = local.environment
+  component   = "frontend"
+  extra_tags  = local.common_tags
+}
+
+module "frontend_storage" {
+  source = "../../modules/object_storage_frontend"
+
+  project              = var.project
+  environment          = local.environment
+  bucket_name          = var.frontend_bucket_name
+  service_domain       = "${var.frontend_subdomain}.${var.root_domain}"
+  asset_prefix         = var.frontend_asset_prefix
+  enable_versioning    = true
+  cors_allowed_origins = ["https://${var.frontend_subdomain}.${var.root_domain}"]
+  tags                 = module.frontend_labels.tags
+}
+
+module "network" {
+  source = "../../modules/network"
+
+  project                 = var.project
+  environment             = local.environment
+  vpc_name                = "${var.project}-${local.environment}-vpc"
+  vpc_cidr                = var.vpc_cidr
+  zone                    = var.zone
+  public_subnet_name      = "${var.project}-${local.environment}-public-subnet"
+  private_subnet_name     = "${var.project}-${local.environment}-private-subnet"
+  public_subnet_cidr      = var.public_subnet_cidr
+  private_subnet_cidr     = var.private_subnet_cidr
+  create_nat_gateway      = true
+  nat_subnet_name         = var.nat_subnet_name
+  nat_subnet_cidr         = var.nat_subnet_cidr
+  nat_gateway_name        = var.nat_gateway_name
+  nat_gateway_description = "Outbound internet access for ${var.project}-${local.environment} private subnet"
+  ssh_access_cidrs        = var.ssh_access_cidrs
+  public_access_cidrs     = var.public_access_cidrs
+  extra_inbound_rules     = concat(var.extra_public_inbound_rules, local.postgresql_private_inbound_rules)
+  tags                    = local.common_tags
+}
+
+module "backend_labels" {
+  source = "../../modules/labels"
+
+  project     = var.project
+  environment = local.environment
+  component   = "backend"
+  extra_tags  = local.common_tags
+}
+
+module "backend_server" {
+  source = "../../modules/backend_server"
+
+  project                = var.project
+  environment            = local.environment
+  name                   = "${var.project}-${local.environment}-api"
+  server_image_name      = var.server_image_name
+  server_hypervisor_type = var.server_hypervisor_type
+  server_spec_code       = var.server_spec_code
+  subnet_no              = module.network.public_subnet_no
+  login_key_name         = var.login_key_name
+  associate_public_ip    = true
+  init_script            = var.server_init_script
+  description            = "CMC prod nginx + backend node"
+  tags                   = module.backend_labels.tags
+}
+
+module "postgresql_labels" {
+  source = "../../modules/labels"
+
+  project     = var.project
+  environment = local.environment
+  component   = "postgresql"
+  extra_tags  = local.common_tags
+}
+
+module "postgresql_server" {
+  source = "../../modules/backend_server"
+
+  project                       = var.project
+  environment                   = local.environment
+  name                          = var.postgres_server_name
+  description                   = "CMC prod PostgreSQL node"
+  public_ip_description         = null
+  server_image_name             = var.postgres_server_image_name
+  server_hypervisor_type        = var.postgres_server_hypervisor_type
+  server_spec_code              = var.postgres_server_spec_code
+  fee_system_type_code          = var.postgres_fee_system_type_code
+  subnet_no                     = module.network.private_subnet_no
+  login_key_name                = var.login_key_name
+  associate_public_ip           = false
+  init_script                   = var.postgres_server_init_script
+  is_protect_server_termination = var.postgres_protect_server_termination
+  tags                          = module.postgresql_labels.tags
+}
+
+module "redis_cache" {
+  source = "../../modules/redis_cache"
+
+  project             = var.project
+  environment         = local.environment
+  name                = "${var.project}-${local.environment}-redis"
+  mode                = var.redis_mode
+  vpc_no              = module.network.vpc_no
+  subnet_no           = module.network.private_subnet_no
+  subnet_name         = module.network.private_subnet_name
+  product_code        = var.redis_product_code
+  engine_version_code = var.redis_engine_version_code
+  redis_version       = var.redis_version
+  is_ha               = var.redis_ha
+  is_backup           = var.redis_backup
+  tags                = local.common_tags
+}
+
+module "observability" {
+  source = "../../modules/observability"
+
+  project     = var.project
+  environment = local.environment
+  name        = "${var.project}-${local.environment}-observability"
+  mode        = var.observability_mode
+  subnet_name = module.network.public_subnet_name
+  components  = ["prometheus", "grafana", "cadvisor"]
+  tags        = local.common_tags
+}
+

--- a/terraform/envs/prod/outputs.tf
+++ b/terraform/envs/prod/outputs.tf
@@ -1,0 +1,52 @@
+output "frontend_bucket_name" {
+  value = module.frontend_storage.bucket_name
+}
+
+output "frontend_domain" {
+  value = "${var.frontend_subdomain}.${var.root_domain}"
+}
+
+output "api_domain" {
+  value = "${var.api_subdomain}.${var.root_domain}"
+}
+
+
+output "nat_gateway_public_ip" {
+  value = module.network.nat_gateway_public_ip
+}
+
+output "nat_gateway_no" {
+  value = module.network.nat_gateway_no
+}
+
+output "backend_server_name" {
+  value = module.backend_server.name
+}
+
+output "backend_public_ip" {
+  value = module.backend_server.public_ip
+}
+
+output "backend_private_ip" {
+  value = module.backend_server.private_ip
+}
+
+output "postgres_server_name" {
+  value = module.postgresql_server.name
+}
+
+output "postgres_server_id" {
+  value = module.postgresql_server.server_id
+}
+
+output "postgres_private_ip" {
+  value = module.postgresql_server.private_ip
+}
+
+output "redis_name" {
+  value = module.redis_cache.name
+}
+
+output "observability_name" {
+  value = module.observability.name
+}

--- a/terraform/envs/prod/providers.tf
+++ b/terraform/envs/prod/providers.tf
@@ -1,0 +1,8 @@
+provider "ncloud" {
+  region      = "KR"
+  site        = "public"
+  support_vpc = true
+
+  # Credentials are expected from environment variables or a local override file
+  # excluded from version control.
+}

--- a/terraform/envs/prod/terraform.tfvars.example
+++ b/terraform/envs/prod/terraform.tfvars.example
@@ -1,0 +1,50 @@
+owner                  = "team-cmc"
+cost_center            = "bootcamp"
+root_domain            = "example.com"
+frontend_subdomain     = "www"
+api_subdomain          = "api"
+frontend_bucket_name   = "cmc-prod-frontend"
+frontend_asset_prefix  = ""
+frontend_certificate_name = "cmc-frontend-cert"
+
+zone                   = "KR-2"
+ssh_access_cidrs       = ["0.0.0.0/0"]
+public_access_cidrs    = ["0.0.0.0/0"]
+nat_subnet_cidr     = "10.10.30.0/24"
+nat_subnet_name     = "cmc-prod-nat-subnet"
+nat_gateway_name    = "cmc-prod-nat"
+extra_public_inbound_rules = [
+  {
+    protocol    = "TCP"
+    ip_block    = "0.0.0.0/0"
+    port_range  = "3001"
+    description = "grafana-admin"
+  }
+]
+
+server_image_name      = "ubuntu-22.04"
+server_hypervisor_type = "KVM"
+server_spec_code       = "c2-g3a"
+login_key_name         = "web02"
+
+postgres_server_name           = "cmc-prod-postgres"
+postgres_server_spec_code      = "mi1-g3"
+postgres_fee_system_type_code  = "FXSUM"
+# Keep PostgreSQL database/user/password in the server .env or DB bootstrap process, not in Terraform state.
+
+redis_mode             = "container"
+redis_version          = "7.0.13-simple"
+observability_mode     = "docker-compose"
+
+server_init_script = <<-EOT
+#!/bin/bash
+set -e
+# TODO: install docker, docker compose plugin, nginx, certbot, node exporter, deploy user bootstrap
+EOT
+
+postgres_server_init_script = <<-EOT
+#!/bin/bash
+set -e
+# TODO: install and configure PostgreSQL on the private DB VM.
+# Do not put DB passwords in this Terraform script; Terraform stores init script content in state.
+EOT

--- a/terraform/envs/prod/variables.tf
+++ b/terraform/envs/prod/variables.tf
@@ -1,0 +1,192 @@
+variable "project" {
+  type    = string
+  default = "cmc"
+}
+
+variable "owner" {
+  type = string
+}
+
+variable "cost_center" {
+  type    = string
+  default = "cmc"
+}
+
+variable "root_domain" {
+  type = string
+}
+
+variable "frontend_subdomain" {
+  type    = string
+  default = "www"
+}
+
+variable "api_subdomain" {
+  type    = string
+  default = "api"
+}
+
+variable "frontend_bucket_name" {
+  type = string
+}
+
+variable "frontend_asset_prefix" {
+  type    = string
+  default = ""
+}
+
+variable "frontend_certificate_name" {
+  type = string
+}
+
+variable "zone" {
+  type    = string
+  default = "KR-2"
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.10.0.0/16"
+}
+
+variable "public_subnet_cidr" {
+  type    = string
+  default = "10.10.10.0/24"
+}
+
+variable "private_subnet_cidr" {
+  type    = string
+  default = "10.10.20.0/24"
+}
+
+
+variable "nat_subnet_cidr" {
+  type    = string
+  default = "10.10.30.0/24"
+}
+
+variable "nat_subnet_name" {
+  type    = string
+  default = "cmc-prod-nat-subnet"
+}
+
+variable "nat_gateway_name" {
+  type    = string
+  default = "cmc-prod-nat"
+}
+
+variable "ssh_access_cidrs" {
+  type    = list(string)
+  default = []
+}
+
+variable "public_access_cidrs" {
+  type    = list(string)
+  default = ["0.0.0.0/0"]
+}
+
+variable "extra_public_inbound_rules" {
+  type = list(object({
+    protocol    = string
+    ip_block    = string
+    port_range  = string
+    description = string
+  }))
+  default = []
+}
+
+variable "server_image_name" {
+  type = string
+}
+
+variable "server_hypervisor_type" {
+  type    = string
+  default = "KVM"
+}
+
+variable "server_spec_code" {
+  type = string
+}
+
+variable "login_key_name" {
+  type = string
+}
+
+variable "server_init_script" {
+  type    = string
+  default = ""
+}
+
+variable "postgres_server_name" {
+  type    = string
+  default = "cmc-prod-postgres"
+}
+
+variable "postgres_server_image_name" {
+  type    = string
+  default = "ubuntu-24.04-base"
+}
+
+variable "postgres_server_hypervisor_type" {
+  type    = string
+  default = "KVM"
+}
+
+variable "postgres_server_spec_code" {
+  description = "PostgreSQL VM spec code. Set this to the NCP micro/basic spec code for prod."
+  type        = string
+}
+
+variable "postgres_fee_system_type_code" {
+  description = "NCP fee system type code for the PostgreSQL VM. mi1-g3 micro servers require FXSUM."
+  type        = string
+  default     = "FXSUM"
+}
+
+variable "postgres_server_init_script" {
+  description = "Optional bootstrap script for the private PostgreSQL VM. Avoid placing DB passwords here because init script content is stored in Terraform state."
+  type        = string
+  default     = ""
+}
+
+variable "postgres_protect_server_termination" {
+  type    = bool
+  default = true
+}
+
+variable "redis_mode" {
+  type    = string
+  default = "container"
+}
+
+variable "redis_product_code" {
+  type     = string
+  default  = null
+  nullable = true
+}
+
+variable "redis_engine_version_code" {
+  type     = string
+  default  = null
+  nullable = true
+}
+
+variable "redis_version" {
+  type    = string
+  default = "7.0.13-simple"
+}
+
+variable "redis_ha" {
+  type    = bool
+  default = false
+}
+
+variable "redis_backup" {
+  type    = bool
+  default = false
+}
+
+variable "observability_mode" {
+  type    = string
+  default = "docker-compose"
+}

--- a/terraform/envs/prod/versions.tf
+++ b/terraform/envs/prod/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    ncloud = {
+      source  = "navercloudplatform/ncloud"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/terraform/modules/backend_server/main.tf
+++ b/terraform/modules/backend_server/main.tf
@@ -1,0 +1,47 @@
+locals {
+  server_tags = merge(var.tags, {
+    runtime = "docker-compose"
+  })
+}
+
+data "ncloud_server_image_numbers" "this" {
+  server_image_name = var.server_image_name
+
+  filter {
+    name   = "hypervisor_type"
+    values = [var.server_hypervisor_type]
+  }
+}
+
+data "ncloud_server_specs" "this" {
+  filter {
+    name   = "server_spec_code"
+    values = [var.server_spec_code]
+  }
+}
+
+resource "ncloud_init_script" "this" {
+  count = trimspace(var.init_script) == "" ? 0 : 1
+
+  name    = "${var.name}-init"
+  content = var.init_script
+}
+
+resource "ncloud_server" "this" {
+  subnet_no                     = var.subnet_no
+  name                          = var.name
+  description                   = var.description
+  server_image_number           = data.ncloud_server_image_numbers.this.image_number_list[0].server_image_number
+  server_spec_code              = data.ncloud_server_specs.this.server_spec_list[0].server_spec_code
+  login_key_name                = var.login_key_name
+  fee_system_type_code          = var.fee_system_type_code
+  is_protect_server_termination = var.is_protect_server_termination
+  init_script_no                = try(ncloud_init_script.this[0].id, null)
+}
+
+resource "ncloud_public_ip" "this" {
+  count = var.associate_public_ip ? 1 : 0
+
+  server_instance_no = ncloud_server.this.id
+  description        = var.public_ip_description
+}

--- a/terraform/modules/backend_server/outputs.tf
+++ b/terraform/modules/backend_server/outputs.tf
@@ -1,0 +1,31 @@
+output "name" {
+  value = var.name
+}
+
+output "server_image_name" {
+  value = var.server_image_name
+}
+
+output "server_spec_code" {
+  value = ncloud_server.this.server_spec_code
+}
+
+output "server_id" {
+  value = ncloud_server.this.id
+}
+
+output "private_ip" {
+  value = ncloud_server.this.private_ip
+}
+
+output "public_ip" {
+  value = try(ncloud_public_ip.this[0].public_ip, ncloud_server.this.public_ip)
+}
+
+output "public_ip_instance_no" {
+  value = try(ncloud_public_ip.this[0].id, null)
+}
+
+output "tags" {
+  value = local.server_tags
+}

--- a/terraform/modules/backend_server/variables.tf
+++ b/terraform/modules/backend_server/variables.tf
@@ -1,0 +1,80 @@
+variable "project" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "server_image_name" {
+  description = "Base image name to use for the instance."
+  type        = string
+}
+
+variable "server_spec_code" {
+  description = "Server spec code such as c2-g3 or c2-g2-s50."
+  type        = string
+}
+
+variable "server_hypervisor_type" {
+  description = "Server hypervisor type."
+  type        = string
+  default     = "KVM"
+}
+
+variable "fee_system_type_code" {
+  description = "Optional NCP server fee system type code. Micro servers require FXSUM."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "subnet_no" {
+  description = "Subnet number where the server should live."
+  type        = string
+}
+
+variable "login_key_name" {
+  description = "SSH login key configured in NCP."
+  type        = string
+}
+
+variable "associate_public_ip" {
+  description = "Whether to attach a public IP to the server."
+  type        = bool
+  default     = true
+}
+
+variable "public_ip_description" {
+  description = "Optional description for the managed public IP."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "init_script" {
+  description = "Cloud-init or user data script for server bootstrap."
+  type        = string
+  default     = ""
+}
+
+variable "description" {
+  description = "Optional instance description."
+  type        = string
+  default     = ""
+}
+
+variable "is_protect_server_termination" {
+  description = "Whether to protect the instance from accidental termination."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/terraform/modules/backend_server/versions.tf
+++ b/terraform/modules/backend_server/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    ncloud = {
+      source = "navercloudplatform/ncloud"
+    }
+  }
+}

--- a/terraform/modules/labels/main.tf
+++ b/terraform/modules/labels/main.tf
@@ -1,0 +1,13 @@
+locals {
+  name_prefix = "${var.project}-${var.environment}-${var.component}"
+
+  default_tags = {
+    project     = var.project
+    environment = var.environment
+    component   = var.component
+    managed_by  = "terraform"
+  }
+
+  merged_tags = merge(local.default_tags, var.extra_tags)
+}
+

--- a/terraform/modules/labels/outputs.tf
+++ b/terraform/modules/labels/outputs.tf
@@ -1,0 +1,10 @@
+output "name_prefix" {
+  description = "Standardized name prefix."
+  value       = local.name_prefix
+}
+
+output "tags" {
+  description = "Merged tags to reuse across resources."
+  value       = local.merged_tags
+}
+

--- a/terraform/modules/labels/variables.tf
+++ b/terraform/modules/labels/variables.tf
@@ -1,0 +1,21 @@
+variable "project" {
+  description = "Service or project identifier."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name such as dev or prod."
+  type        = string
+}
+
+variable "component" {
+  description = "Infra component name."
+  type        = string
+}
+
+variable "extra_tags" {
+  description = "Additional free-form tags or labels."
+  type        = map(string)
+  default     = {}
+}
+

--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -1,0 +1,134 @@
+locals {
+  network_tags = merge(var.tags, {
+    network_scope = "application"
+  })
+
+  base_inbound_rules = concat(
+    [
+      for cidr in var.ssh_access_cidrs : {
+        protocol    = "TCP"
+        ip_block    = cidr
+        port_range  = "22"
+        description = "ssh"
+      }
+    ],
+    flatten([
+      for cidr in var.public_access_cidrs : [
+        for port in ["80", "443"] : {
+          protocol    = "TCP"
+          ip_block    = cidr
+          port_range  = port
+          description = "public-web"
+        }
+      ]
+    ])
+  )
+
+  inbound_rules = concat(local.base_inbound_rules, var.extra_inbound_rules)
+}
+
+resource "ncloud_vpc" "this" {
+  name            = var.vpc_name
+  ipv4_cidr_block = var.vpc_cidr
+}
+
+resource "ncloud_subnet" "public" {
+  vpc_no         = ncloud_vpc.this.id
+  subnet         = var.public_subnet_cidr
+  zone           = var.zone
+  network_acl_no = ncloud_vpc.this.default_network_acl_no
+  subnet_type    = "PUBLIC"
+  usage_type     = "GEN"
+  name           = var.public_subnet_name
+}
+
+resource "ncloud_subnet" "private" {
+  count = var.create_private_subnet ? 1 : 0
+
+  vpc_no         = ncloud_vpc.this.id
+  subnet         = var.private_subnet_cidr
+  zone           = var.zone
+  network_acl_no = ncloud_vpc.this.default_network_acl_no
+  subnet_type    = "PRIVATE"
+  usage_type     = "GEN"
+  name           = var.private_subnet_name
+}
+
+resource "ncloud_access_control_group_rule" "default" {
+  count = var.manage_default_acg_rules ? 1 : 0
+
+  access_control_group_no = ncloud_vpc.this.default_access_control_group_no
+
+  dynamic "inbound" {
+    for_each = local.inbound_rules
+    content {
+      protocol    = inbound.value.protocol
+      ip_block    = inbound.value.ip_block
+      port_range  = inbound.value.port_range
+      description = inbound.value.description
+    }
+  }
+
+  outbound {
+    protocol    = "TCP"
+    ip_block    = "0.0.0.0/0"
+    port_range  = "1-65535"
+    description = "allow-all-tcp-egress"
+  }
+
+  outbound {
+    protocol    = "UDP"
+    ip_block    = "0.0.0.0/0"
+    port_range  = "1-65535"
+    description = "allow-all-udp-egress"
+  }
+}
+
+resource "ncloud_subnet" "nat" {
+  count = var.create_nat_gateway ? 1 : 0
+
+  vpc_no         = ncloud_vpc.this.id
+  subnet         = var.nat_subnet_cidr
+  zone           = var.zone
+  network_acl_no = ncloud_vpc.this.default_network_acl_no
+  subnet_type    = "PUBLIC"
+  usage_type     = "NATGW"
+  name           = var.nat_subnet_name
+}
+
+resource "ncloud_nat_gateway" "this" {
+  count = var.create_nat_gateway ? 1 : 0
+
+  vpc_no      = ncloud_vpc.this.id
+  subnet_no   = ncloud_subnet.nat[0].id
+  zone        = var.zone
+  name        = var.nat_gateway_name
+  description = var.nat_gateway_description
+}
+
+resource "ncloud_route_table" "private_nat" {
+  count = var.create_nat_gateway && var.create_private_subnet ? 1 : 0
+
+  vpc_no                = ncloud_vpc.this.id
+  supported_subnet_type = "PRIVATE"
+  name                  = "${var.vpc_name}-private-nat-rt"
+  description           = "Private subnet route table for NAT Gateway outbound access."
+}
+
+resource "ncloud_route" "private_nat_default" {
+  count = var.create_nat_gateway && var.create_private_subnet ? 1 : 0
+
+  route_table_no         = ncloud_route_table.private_nat[0].id
+  destination_cidr_block = "0.0.0.0/0"
+  target_type            = "NATGW"
+  target_name            = ncloud_nat_gateway.this[0].name
+  target_no              = ncloud_nat_gateway.this[0].id
+}
+
+resource "ncloud_route_table_association" "private_nat" {
+  count = var.create_nat_gateway && var.create_private_subnet ? 1 : 0
+
+  route_table_no = ncloud_route_table.private_nat[0].id
+  subnet_no      = ncloud_subnet.private[0].id
+}
+

--- a/terraform/modules/network/outputs.tf
+++ b/terraform/modules/network/outputs.tf
@@ -1,0 +1,56 @@
+output "vpc_name" {
+  value = var.vpc_name
+}
+
+output "vpc_no" {
+  value = ncloud_vpc.this.id
+}
+
+output "public_subnet_cidr" {
+  value = var.public_subnet_cidr
+}
+
+output "private_subnet_cidr" {
+  value = var.private_subnet_cidr
+}
+
+output "public_subnet_no" {
+  value = ncloud_subnet.public.id
+}
+
+output "private_subnet_no" {
+  value = try(ncloud_subnet.private[0].id, null)
+}
+
+output "public_subnet_name" {
+  value = ncloud_subnet.public.name
+}
+
+output "private_subnet_name" {
+  value = try(ncloud_subnet.private[0].name, null)
+}
+
+output "default_access_control_group_no" {
+  value = ncloud_vpc.this.default_access_control_group_no
+}
+
+output "tags" {
+  value = local.network_tags
+}
+
+output "nat_subnet_no" {
+  value = try(ncloud_subnet.nat[0].id, null)
+}
+
+output "nat_gateway_no" {
+  value = try(ncloud_nat_gateway.this[0].id, null)
+}
+
+output "nat_gateway_public_ip" {
+  value = try(ncloud_nat_gateway.this[0].public_ip, null)
+}
+
+output "private_route_table_no" {
+  value = try(ncloud_route_table.private_nat[0].id, null)
+}
+

--- a/terraform/modules/network/variables.tf
+++ b/terraform/modules/network/variables.tf
@@ -1,0 +1,108 @@
+variable "project" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "vpc_name" {
+  type = string
+}
+
+variable "vpc_cidr" {
+  type = string
+}
+
+variable "zone" {
+  description = "Zone code such as KR-1 or KR-2."
+  type        = string
+}
+
+variable "public_subnet_cidr" {
+  type = string
+}
+
+variable "private_subnet_cidr" {
+  type = string
+}
+
+variable "public_subnet_name" {
+  type = string
+}
+
+variable "private_subnet_name" {
+  type    = string
+  default = null
+}
+
+variable "ssh_access_cidrs" {
+  description = "CIDRs allowed to access SSH."
+  type        = list(string)
+  default     = []
+}
+
+variable "public_access_cidrs" {
+  description = "CIDRs allowed to access public web ports."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "extra_inbound_rules" {
+  description = "Additional inbound rules for the default ACG."
+  type = list(object({
+    protocol    = string
+    ip_block    = string
+    port_range  = string
+    description = string
+  }))
+  default = []
+}
+
+variable "create_private_subnet" {
+  description = "Whether to create and manage a private subnet."
+  type        = bool
+  default     = true
+}
+
+variable "manage_default_acg_rules" {
+  description = "Whether to manage default ACG rules for the VPC."
+  type        = bool
+  default     = true
+}
+
+
+variable "create_nat_gateway" {
+  description = "Whether to create a public NAT Gateway for private subnet outbound internet access."
+  type        = bool
+  default     = false
+}
+
+variable "nat_subnet_name" {
+  description = "Name of the dedicated NAT Gateway subnet."
+  type        = string
+  default     = null
+}
+
+variable "nat_subnet_cidr" {
+  description = "CIDR block for the dedicated NAT Gateway subnet."
+  type        = string
+  default     = null
+}
+
+variable "nat_gateway_name" {
+  description = "Name of the NAT Gateway."
+  type        = string
+  default     = null
+}
+
+variable "nat_gateway_description" {
+  description = "Optional NAT Gateway description."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/terraform/modules/network/versions.tf
+++ b/terraform/modules/network/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    ncloud = {
+      source = "navercloudplatform/ncloud"
+    }
+  }
+}

--- a/terraform/modules/object_storage_frontend/main.tf
+++ b/terraform/modules/object_storage_frontend/main.tf
@@ -1,0 +1,9 @@
+locals {
+  bucket_labels = merge(var.tags, {
+    bucket_role = "frontend-static"
+  })
+}
+
+resource "ncloud_objectstorage_bucket" "this" {
+  bucket_name = var.bucket_name
+}

--- a/terraform/modules/object_storage_frontend/outputs.tf
+++ b/terraform/modules/object_storage_frontend/outputs.tf
@@ -1,0 +1,24 @@
+output "bucket_name" {
+  description = "Bucket that stores frontend artifacts."
+  value       = ncloud_objectstorage_bucket.this.bucket_name
+}
+
+output "bucket_id" {
+  description = "Bucket identifier."
+  value       = ncloud_objectstorage_bucket.this.id
+}
+
+output "asset_prefix" {
+  description = "Upload prefix used by CI."
+  value       = var.asset_prefix
+}
+
+output "service_domain" {
+  description = "Frontend service domain."
+  value       = var.service_domain
+}
+
+output "tags" {
+  description = "Normalized labels for storage resources."
+  value       = local.bucket_labels
+}

--- a/terraform/modules/object_storage_frontend/variables.tf
+++ b/terraform/modules/object_storage_frontend/variables.tf
@@ -1,0 +1,41 @@
+variable "project" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "bucket_name" {
+  description = "Frontend artifact bucket name."
+  type        = string
+}
+
+variable "service_domain" {
+  description = "User-facing frontend domain."
+  type        = string
+}
+
+variable "asset_prefix" {
+  description = "Object prefix for uploaded frontend assets."
+  type        = string
+  default     = ""
+}
+
+variable "enable_versioning" {
+  description = "Whether to keep object versions in the bucket."
+  type        = bool
+  default     = true
+}
+
+variable "cors_allowed_origins" {
+  description = "Origins allowed to access assets directly if needed."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+

--- a/terraform/modules/object_storage_frontend/versions.tf
+++ b/terraform/modules/object_storage_frontend/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    ncloud = {
+      source = "navercloudplatform/ncloud"
+    }
+  }
+}

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -1,0 +1,9 @@
+locals {
+  observability_tags = merge(var.tags, {
+    observability_mode = var.mode
+  })
+}
+
+# TODO:
+# - If observability stays on the nginx/backend host, treat this module as documentation and outputs only
+# - If the team separates monitoring later, replace this with a dedicated node or managed monitoring resources

--- a/terraform/modules/observability/outputs.tf
+++ b/terraform/modules/observability/outputs.tf
@@ -1,0 +1,15 @@
+output "name" {
+  value = var.name
+}
+
+output "mode" {
+  value = var.mode
+}
+
+output "components" {
+  value = var.components
+}
+
+output "tags" {
+  value = local.observability_tags
+}

--- a/terraform/modules/observability/variables.tf
+++ b/terraform/modules/observability/variables.tf
@@ -1,0 +1,33 @@
+variable "project" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "mode" {
+  description = "docker-compose, dedicated-node, or managed."
+  type        = string
+  default     = "docker-compose"
+}
+
+variable "subnet_name" {
+  description = "Subnet where observability resources or hosts live."
+  type        = string
+}
+
+variable "components" {
+  description = "Observability components to enable."
+  type        = list(string)
+  default     = ["prometheus", "grafana", "cadvisor"]
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/terraform/modules/observability/versions.tf
+++ b/terraform/modules/observability/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    ncloud = {
+      source = "navercloudplatform/ncloud"
+    }
+  }
+}

--- a/terraform/modules/redis_cache/main.tf
+++ b/terraform/modules/redis_cache/main.tf
@@ -1,0 +1,31 @@
+locals {
+  redis_tags = merge(var.tags, {
+    cache_engine = "redis"
+    cache_mode   = var.mode
+  })
+
+  managed = var.mode == "managed"
+}
+
+resource "ncloud_redis_config_group" "this" {
+  count = local.managed ? 1 : 0
+
+  name          = substr(var.name, 0, 15)
+  redis_version = var.redis_version
+  description   = "Managed by Terraform for ${var.project}-${var.environment}"
+}
+
+resource "ncloud_redis" "this" {
+  count = local.managed ? 1 : 0
+
+  service_name        = substr(var.name, 0, 15)
+  server_name_prefix  = substr(var.name, 0, 15)
+  vpc_no              = var.vpc_no
+  subnet_no           = var.subnet_no
+  config_group_no     = ncloud_redis_config_group.this[0].id
+  mode                = "SIMPLE"
+  engine_version_code = var.engine_version_code
+  product_code        = var.product_code
+  is_ha               = var.is_ha
+  is_backup           = var.is_backup
+}

--- a/terraform/modules/redis_cache/outputs.tf
+++ b/terraform/modules/redis_cache/outputs.tf
@@ -1,0 +1,23 @@
+output "name" {
+  value = var.name
+}
+
+output "mode" {
+  value = var.mode
+}
+
+output "subnet_name" {
+  value = var.subnet_name
+}
+
+output "redis_id" {
+  value = try(ncloud_redis.this[0].id, null)
+}
+
+output "private_domain" {
+  value = null
+}
+
+output "tags" {
+  value = local.redis_tags
+}

--- a/terraform/modules/redis_cache/variables.tf
+++ b/terraform/modules/redis_cache/variables.tf
@@ -1,0 +1,77 @@
+variable "project" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "mode" {
+  description = "container, managed, or reserved."
+  type        = string
+  default     = "container"
+}
+
+variable "vpc_no" {
+  description = "VPC number for managed Redis."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "subnet_no" {
+  description = "Subnet number for managed Redis."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "subnet_name" {
+  description = "Subnet name if Redis remains conceptual or container-based."
+  type        = string
+}
+
+variable "product_code" {
+  description = "Optional product code for managed Redis."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "engine_version_code" {
+  description = "Optional engine version code for managed Redis."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "redis_version" {
+  description = "Redis config group version string."
+  type        = string
+  default     = "7.0.13-simple"
+}
+
+variable "product_name" {
+  description = "Optional flavor if Redis runs on a dedicated host."
+  type        = string
+  default     = ""
+}
+
+variable "is_ha" {
+  type    = bool
+  default = false
+}
+
+variable "is_backup" {
+  type    = bool
+  default = false
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/terraform/modules/redis_cache/versions.tf
+++ b/terraform/modules/redis_cache/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    ncloud = {
+      source = "navercloudplatform/ncloud"
+    }
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->
#447 

Relates to NCP 인프라 구성 작업

## ✅ 작업 내용

### 💡개선 사항

- NCP Terraform 환경 추가
  - `dev`: 단일 public VM 기반 개발 환경
  - `prod`: public backend VM + private PostgreSQL VM 기반 운영 환경
- Terraform 공통 모듈을 추가했습니다.
  - `network`: VPC, subnet, ACG, NAT Gateway, private route table 구성
  - `backend_server`: NCP Server, init script, public IP 구성
  - `object_storage_frontend`: frontend 정적 파일 배포용 Object Storage bucket 구성
  - `redis_cache`: 현재는 container mode 기준 output 관리
  - `observability`: Docker Compose 기반 monitoring 구성 정보 관리
  - `labels`: 공통 tag/label 구성
- prod private subnet의 outbound 인터넷 접근을 위해 NAT Gateway를 추가했습니다.
- prod PostgreSQL은 private subnet의 micro VM으로 구성했습니다.
  - NCP micro 서버 제약에 맞춰 `fee_system_type_code = "FXSUM"` 적용
  - DB 계정/비밀번호는 Terraform state에 저장하지 않고 서버 bootstrap 이후 수동 생성하도록 분리
- Terraform 로컬 파일과 리소스 환경변수가 커밋되지 않도록 ignore 규칙을 추가했습니다.
  - `.terraform/`
  - `terraform.tfvars`
  - `tfstate`
  - `tfplan`
  - `ncloud.env`

<br />

## 📸 참고 사항

- CDN/DNS/인증서는 이번 Terraform 관리 범위에서 제외했습니다.
  - NCP 서비스 자체는 존재하지만, 현재 NCP Terraform provider에서 해당 리소스를 안정적으로 관리할 수 없어 수동 관리로 결정했습니다.
  - Terraform에서는 Object Storage bucket까지만 관리합니다.
- prod apply 기준 생성 리소스:
  - Object Storage bucket
  - VPC
  - public/private/NAT subnet
  - NAT Gateway
  - private route table / route / association
  - default ACG rules
  - backend VM + public IP
  - PostgreSQL private VM
  - init scripts
- 검증 결과:
  - `terraform fmt -check`: dev/prod 통과
  - `terraform validate`: dev/prod 통과
  - `terraform plan`
    - dev: `6 to add, 0 to change, 0 to destroy`
    - prod: `15 to add, 0 to change, 0 to destroy`


### DEV
```mermaid
flowchart TD
  DevUser[Developer] --> DevPublicIP[Public IP]
  DevPublicIP --> DevVM[cmc-dev VM<br/>Docker Compose Host]

  subgraph DevVPC["Dev VPC: os-emul<br/>10.0.0.0/20"]
    subgraph DevPublicSubnet["Public Subnet<br/>10.0.0.0/24"]
      DevVM
    end

    DevACG["Default ACG<br/>22, 80, 443, 3001 open"]
  end

  DevVM --> DevDocker[Docker / Docker Compose]
  DevDocker --> DevApp["App containers<br/>frontend / backend / postgres / redis / monitoring"]
```

### PROD
```mermaid
flowchart TD
  User[User] --> ManualDNS["DNS / CDN / Certificate<br/>Manual management"]
  ManualDNS --> FrontendBucket["Object Storage Bucket<br/>frontend static files"]

  User --> ApiDomain["api.coedbattle.kro.kr<br/>Manual DNS A record"]
  ApiDomain --> BackendPublicIP[Backend Public IP]
  BackendPublicIP --> BackendVM["cmc-prod-api VM<br/>Public Subnet<br/>Docker Compose Host"]

  BackendVM --> Nginx["Nginx Container<br/>80 / 443"]
  Nginx --> Backend["Backend Container<br/>3000"]
  Backend --> Redis["Redis Container<br/>6379"]
  Backend --> Postgres["cmc-prod-postgres VM<br/>Private IP :5432"]

  BackendVM --> Monitoring["Prometheus / Grafana / cAdvisor<br/>Docker Compose"]

  Postgres --> NatGateway["NAT Gateway<br/>Outbound internet"]
  NatGateway --> Internet[Internet]

  subgraph ProdVPC["Prod VPC<br/>10.10.0.0/16"]
    subgraph PublicSubnet["Public Subnet<br/>10.10.10.0/24"]
      BackendVM
    end

    subgraph PrivateSubnet["Private Subnet<br/>10.10.20.0/24"]
      Postgres
    end

    subgraph NatSubnet["NAT Subnet<br/>10.10.30.0/24"]
      NatGateway
    end

    ACG["Default ACG<br/>22, 80, 443, 3001 open<br/>5432 only from public subnet"]
  end
```

<br />

## 💬 질문사항 (고민했던 부분)

- 현재 초기 세팅 편의를 위해 ACG에서 SSH `22`, web `80/443`, Grafana `3001`을 `0.0.0.0/0`으로 열어두었습니다.
  - 운영 안정화 후 SSH/Grafana는 관리자 IP로 제한하는게 좋습니다
- Terraform state는 현재 local backend 기준입니다.
  - 협업을 위해 추후 remote backend 도입으로 공유하면 될 것 같습니다