### PR TITLE
[Refactor] 프론트 배포 구조 변경

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -18,7 +18,6 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_BACKEND: ${{ github.repository }}-backend-prod
-  IMAGE_FRONTEND: ${{ github.repository }}-frontend-prod
 
 jobs:
   ci:
@@ -61,7 +60,6 @@ jobs:
         id: image_names
         run: |
           echo "backend_image=${IMAGE_BACKEND,,}" >> "$GITHUB_OUTPUT"
-          echo "frontend_image=${IMAGE_FRONTEND,,}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v3
 
@@ -81,20 +79,6 @@ jobs:
             ${{ env.REGISTRY }}/${{ steps.image_names.outputs.backend_image }}:latest
             ${{ env.REGISTRY }}/${{ steps.image_names.outputs.backend_image }}:${{ steps.set_version.outputs.version_tag }}
 
-      - name: Build and push frontend
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: frontend/Dockerfile
-          push: true
-          build-args: |
-            VITE_API_URL=${{ secrets.VITE_API_URL }}
-            VITE_SOCKET_URL=${{ secrets.VITE_SOCKET_URL }}
-            VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
-            VITE_ENABLE_SENTRY=${{ secrets.VITE_ENABLE_SENTRY }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ steps.image_names.outputs.frontend_image }}:latest
-            ${{ env.REGISTRY }}/${{ steps.image_names.outputs.frontend_image }}:${{ steps.set_version.outputs.version_tag }}
 
   cd-backend:
     needs: ci
@@ -102,13 +86,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Sync monitoring configs to server
+      - name: Sync compose, nginx, and monitoring configs to server
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.NCP_HOST_PROD }}
           username: ${{ secrets.NCP_USER_PROD }}
           password: ${{ secrets.NCP_PASSWORD_PROD }}
-          source: "monitoring/**"
+          source: "docker-compose-prod.yml,nginx/**,monitoring/**"
           target: ${{ secrets.NCP_DEPLOY_PATH }}
 
       - name: Deploy on NCP via SSH
@@ -129,19 +113,19 @@ jobs:
             echo "Deploying version: ${VERSION_TAG}"
 
             # === 기존 컨테이너 종료 ===
-            docker compose -f docker-compose.yml down || true
+            docker compose -f docker-compose-prod.yml down --remove-orphans || true
 
             # === 이미지 pull ===
-            docker compose -f docker-compose.yml pull
+            docker compose -f docker-compose-prod.yml pull
 
             # === Prisma Migration용 컨테이너 실행 ===
-            docker compose -f docker-compose.yml run --rm migrate
+            docker compose -f docker-compose-prod.yml run --rm migrate
 
             # === 오래된 이미지 정리 ===
             docker image prune -f
 
             # === 새 버전 실행 ===
-            docker compose -f docker-compose.yml up -d
+            docker compose -f docker-compose-prod.yml up -d
 
             echo "[SUCCESS] Deployment completed successfully ✅"
 

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   migrate:
     image: ghcr.io/boostcampwm2025/web02-cmc-backend-prod:${VERSION_TAG:-latest}
@@ -69,16 +67,9 @@ services:
       - letsencrypt:/etc/letsencrypt:ro
       - certbot-webroot:/var/www/certbot:ro
     depends_on:
-      - frontend
       - backend
     restart: unless-stopped
     command: "/bin/sh -c 'while :; do sleep 12h; nginx -s reload; done & nginx -g \"daemon off;\"'"
-
-  frontend:
-    image: ghcr.io/boostcampwm2025/web02-cmc-frontend-prod:${VERSION_TAG:-latest}
-    depends_on:
-      - backend
-    restart: unless-stopped
 
   certbot:
     image: certbot/certbot:latest

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,7 +1,7 @@
 # HTTP → HTTPS 리다이렉트
 server {
     listen 80;
-    server_name cmctv.kro.kr;
+    server_name api.coedbattle.kro.kr;
 
     # certbot 인증서 발급/갱신용
     location /.well-known/acme-challenge/ {
@@ -13,25 +13,16 @@ server {
     }
 }
 
-# HTTPS 서버
+# HTTPS 서버: backend API / WebSocket 전용
 server {
     listen 443 ssl;
-    server_name cmctv.kro.kr;
+    server_name api.coedbattle.kro.kr;
 
-    ssl_certificate /etc/letsencrypt/live/cmctv.kro.kr/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/cmctv.kro.kr/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/api.coedbattle.kro.kr/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.coedbattle.kro.kr/privkey.pem;
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers on;
-
-    # 프론트엔드 정적 파일
-    location / {
-        proxy_pass http://frontend:80;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
 
     # 백엔드 API
     location /api/ {
@@ -49,7 +40,18 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 600s;
         proxy_send_timeout 600s;
+    }
+
+    # frontend는 NCP Object Storage/CDN에서 서빙한다.
+    location / {
+        proxy_pass http://backend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -47,11 +47,8 @@ server {
     }
 
     # frontend는 NCP Object Storage/CDN에서 서빙한다.
+    # API 도메인은 명시된 API/WebSocket 경로만 백엔드로 전달한다.
     location / {
-        proxy_pass http://backend:3000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        return 404;
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

#449

## ✅ 작업 내용

### 💡개선 사항

- prod 배포 구조에서 frontend 컨테이너를 제거
  - frontend는 NCP Object Storage/CDN에서 정적 파일로 서빙
  - prod Docker Compose는 backend, nginx, redis, monitoring 중심으로 동작
- prod nginx는 backend API/WebSocket 전용 reverse proxy
  - `/api/` 요청을 backend container로 proxy
  - `/socket.io/` WebSocket 요청을 backend container로 proxy
- prod GitHub Actions workflow 갱신
  - frontend Docker image build/push 제거
  - backend image만 GHCR에 build/push
  - 서버에는 `docker-compose-prod.yml`, `nginx/**`, `monitoring/**`만 sync
  - 배포 시 `docker-compose-prod.yml` 기준으로 pull/migrate/up 실행
- frontend build 산출물은 GitHub Actions에서 NCP Object Storage로 업로드
  - 정적 asset은 long cache
  - `index.html`은 no-cache

<br />

## 📸 참고 사항

