### PR TITLE
[Chore] Kafka 환경 설정

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -39,6 +39,7 @@
     "cookie-parser": "^1.4.7",
     "dotenv": "^17.2.3",
     "ioredis": "^5.9.2",
+    "kafkajs": "^2.2.4",
     "passport": "^0.7.0",
     "passport-github2": "^0.1.12",
     "passport-jwt": "^4.0.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { GeminiModule } from './gemini/gemini.module'
 import { RedisModule } from './redis/redis.module'
 import { PrismaModule } from './prisma/prisma.module'
 import { HealthModule } from './health/health.module'
+import { KafkaModule } from './kafka/kafka.module'
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { HealthModule } from './health/health.module'
     BattlesModule,
     OauthModule,
     MetricsModule,
+    KafkaModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/battles/adapters/out/state/battleStateRepository.adapter.spec.ts
+++ b/backend/src/battles/adapters/out/state/battleStateRepository.adapter.spec.ts
@@ -184,13 +184,6 @@ describe('BattleStateRepositoryAdapter', () => {
       adapter.saveBattleState('battle-1', state)
 
       expect(redis.mset).toHaveBeenCalled()
-      expect(prisma.battle.update).toHaveBeenCalledWith({
-        where: { id: 'battle-1' },
-        data: expect.objectContaining({
-          currentRound: 2,
-          currentPhase: 'ATTACK',
-        }),
-      })
     })
   })
 

--- a/backend/src/kafka/kafka.config.ts
+++ b/backend/src/kafka/kafka.config.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common'
+import { Kafka, logLevel } from 'kafkajs'
+import { ConfigService } from '@nestjs/config'
+
+@Injectable()
+export class KafkaConfigService {
+  private kafka: Kafka
+
+  constructor(private readonly configService: ConfigService) {
+    this.kafka = new Kafka({
+      clientId: 'web02-cmc-backend',
+      brokers: [configService.get<string>('KAFKA_BOOTSTRAP_SERVERS') || 'localhost:29092'],
+      logLevel: logLevel.INFO,
+    })
+  }
+
+  getClient(): Kafka {
+    return this.kafka
+  }
+}

--- a/backend/src/kafka/kafka.const.ts
+++ b/backend/src/kafka/kafka.const.ts
@@ -1,0 +1,4 @@
+export const KAFKA_TOPIC = {
+  BATTLE_EVENTS: 'battle-events',
+  BATTLE_CHAT_EVENTS: 'battle-chat-events',
+} as const

--- a/backend/src/kafka/kafka.module.ts
+++ b/backend/src/kafka/kafka.module.ts
@@ -1,0 +1,11 @@
+import { Module, Global } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
+import { KafkaConfigService } from './kafka.config'
+
+@Global()
+@Module({
+  imports: [ConfigModule],
+  providers: [KafkaConfigService],
+  exports: [KafkaConfigService],
+})
+export class KafkaModule {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,33 @@ services:
     volumes:
       - redis_data:/data
     restart: unless-stopped
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    ports:
+      - "29092:29092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: "broker,controller"
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@kafka:29093"
+      KAFKA_LISTENERS: "PLAINTEXT://kafka:9092,CONTROLLER://kafka:29093,PLAINTEXT_HOST://0.0.0.0:29092"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
+      KAFKA_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
+      KAFKA_INTER_BROKER_LISTENER_NAME: "PLAINTEXT"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      CLUSTER_ID: "Kn7DNxEzRGGT1ScZoyKMbw"
+      KAFKA_LOG_DIRS: "/tmp/kraft-combined-logs"
+    restart: unless-stopped
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    ports:
+      - "8085:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAP_SERVERS: "kafka:9092"
+    depends_on:
+      - kafka
 
   backend:
     build:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       ioredis:
         specifier: ^5.9.2
         version: 5.9.2
+      kafkajs:
+        specifier: ^2.2.4
+        version: 2.2.4
       passport:
         specifier: ^0.7.0
         version: 0.7.0
@@ -3892,6 +3895,10 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  kafkajs@2.2.4:
+    resolution: {integrity: sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==}
+    engines: {node: '>=14.0.0'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -9524,6 +9531,8 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
+
+  kafkajs@2.2.4: {}
 
   keyv@4.5.4:
     dependencies:


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

resolve #457 

## ✅ 작업 내용

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->
#### 1️⃣ Docker compose 파일 구성
> KRaft모드로 Kafka 구성

kafka구성
- `KAFKA_PROCESS_ROLES`: Kafka 서버 역할 지정 (kraft 특징)
- `CLUSTER_ID`: 주키퍼가 없기 때문에, 이 카프카 서버가 어떤 클러스터 소속인지 식별하기 위해 임의로 발급해 둔 고유 식별 번호
- `KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR`: 현재는 1대로 설정했지만, 추후 실제 운영 시에는 3대로 할 수 있다.

kafka-ui 구성
> localhost:8085
- 터미널 명령어 없이 웹 브라우저에서 카프카 클러스터, 브로커, 토픽, 컨슈머 그룹의 상태를 시각적으로 모니터링하고 관리할 수 있는 GUI 도구이다. 
- 토픽 내부의 파티션 구조와 유입되는 메시지 데이터를 실시간으로 열람할 수 있어 개발 및 디버깅 생산성을 극대화해 준다.

#### 2️⃣Kafka 토픽 생성
> [🔗 자세한 내용](https://lovely-sunstone-c80.notion.site/260630-Kafka-395d7ffb4ba48055a1e4e45a79d38d7b?source=copy_link)
<img width="70%"  alt="image" src="https://github.com/user-attachments/assets/267fe73f-0d28-4f3b-b8a6-193e9d16b0ba" />

- 토픽은 [앞서 설계](https://lovely-sunstone-c80.notion.site/260622-387d7ffb4ba480d18ac4d09925fd0401?source=copy_link)한 대로 `battle-events` 와 `battle-chat-events`로 구성한다. 
- 파티션의 개수는 Worst case 기반 이벤트 처리량과 브로커 장애 상황을 고려하여 6개로 구성한다. 

```bash
kafka-topics --create --topic battle-events --bootstrap-server kafka:9092 --partitions 6 --replication-factor 1
kafka-topics --create --topic battle-chat-events --bootstrap-server kafka:9092 --partitions 6 --replication-factor 1
```

#### 3️⃣NestJS Kafka 세팅
- kafkajs 설치
```bash
pnpm add kafkajs
```


## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->
| Kafka UI | cli | 
|-|-|
| <img width="955" height="337" alt="image" src="https://github.com/user-attachments/assets/0fb2e965-8062-4fbf-afca-b266ca51d7f3" /> | <img width="1142" height="242" alt="image" src="https://github.com/user-attachments/assets/dcbee4d8-e436-465f-b1e2-e563384ca576" /> |

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
