### PR TITLE
fix: 배틀 진행 중 DB 저장 로직  제거

### DIFF
--- a/backend/src/battles/adapters/out/state/battleStateRepository.adapter.ts
+++ b/backend/src/battles/adapters/out/state/battleStateRepository.adapter.ts
@@ -162,7 +162,6 @@ export class BattleStateRepositoryAdapter implements BattleStatePort {
     if (state.status !== BATTLE_STATUS.CLOSED) {
       this.flushAllToRedis(state)
     }
-    this.flushToDB(battleId, state)
   }
 
   async updateSkipState(battleId: string, skipList: Set<string>, expectedPhase?: string): Promise<void> {


### PR DESCRIPTION
배틀 진행 중 Redis, DB 중복 저장 발생, DB 네트워크 비용 발생으로 이벤트 응답 시간 저하

## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

## ✅ 작업 내용

- 배틀 진행 중 요청받은 이벤트에 대한 상태값이 redis와 DB에 중복적으로 저장되고 있었습니다.
- 하지만 배틀이 종료되고 난 후, 배틀 진행 상태 값은 모두 `null`로 저장되고 있어 배틀 진행 과정에서의 DB 저장 로직은 의미가 없었습니다. 
- 이에 따라 배틀 진행 중 상태값은 redis에서 보관하며 배틀이 종료된 직후 배틀 결과 내용을 계산하여 DB에 상태를 기록하도록 합니다. 

### 💡개선 사항
- 배틀 진행 중 상태 저장 흐름에서 DB snapshot 저장 로직을 제거했습니다.
- 기존에는 배틀 상태 변경 시 Redis에 상태를 저장하면서, DB에도 동일한 진행 중 상태를 저장할 수 있는 구조가 남아 있었습니다.
- 하지만 배틀 종료 시 진행 중 상태 필드(`participantsState`, `teamVotesState`, `userInfoState`, `attacksState`, `defensesState`, `chatsAllState` 등)는 최종 결과 저장 이후 `null`로 정리되고 있습니다.
- 따라서 진행 중 상태 값의 저장 위치는 Redis로 두고, DB는 배틀 생성 정보와 종료 후 최종 결과 저장 용도로만 사용하도록 역할을 분리했습니다.
- 이를 통해 `battle:chat` 등 socket 이벤트 처리 과정에서 불필요한 DB 네트워크 비용이 발생하지 않도록 정리했습니다.

<br />

## 📸 참고 사항
- 배틀 진행 중 상태는 Redis에 저장되고, 종료 시점에만 DB에 최종 결과(`timeline`, `mvpsState`, 참가자 수, 승리 팀 등)를 저장합니다.
- 이번 변경은 socket rate limit 부하테스트에서 DB 저장 비용이 이벤트 응답 시간 측정에 섞이지 않도록 하기 위한 목적도 있습니다.
- DB snapshot 저장을 제거하면서 진행 중 상태 복구는 Redis에 더 강하게 의존하게 됩니다.

<br />

## 💬 질문사항 (고민했던 부분)
- 배틀의 진행 상태를 DB에 계속 기록하면 redis의 fallback 상황에서도 DB를 통해 배틀 진행 상황을 가져올 수 있다는 장점이 존재합니다.
- 역동적인 배틀 진행 상황 속에서 DB Writes를 최대한 줄이기 위해 실시간 배틀 진행 상황을 DB에 저장하지 않기로 했기 때문에, Redis fallback 상황에 대한 대처는 다른 PR에서 작업이 필요할 것 같습니다.