### PR TITLE
[Fix] 채팅 및 이의제기 & 반박 이벤트 내 DB 요청 로직 제거

### DIFF
--- a/backend/src/battles/adapters/in/dev.controller.ts
+++ b/backend/src/battles/adapters/in/dev.controller.ts
@@ -37,6 +37,12 @@ import { BattleCreationUseCase } from '../../application/usecases/battleCreation
 import { BattleUserUpdateResponseDto } from '../../dto/battleUserUpdateResponse.dto'
 import { BATTLE_CHAT_SCOPE, BATTLE_TEAM } from '../../domains/models/const/battles.const'
 import type { BattleChatDto } from '../../dto/battleChat.dto'
+import type { BattleUserInfo } from '../../domains/models/types/battle.types'
+
+const getNicknameFromUserInfo = (info: BattleUserInfo | undefined): string | null => {
+  if (!info) return null
+  return typeof info === 'string' ? info : info.nickname
+}
 
 @Controller('dev/battles')
 export class DevController implements OnModuleInit {
@@ -322,15 +328,15 @@ export class DevController implements OnModuleInit {
 
     const teamAUsers = state.teamA.users.map(userId => ({
       userId,
-      nickname: state.userInfoMap.get(userId) ?? null,
+      nickname: getNicknameFromUserInfo(state.userInfoMap.get(userId)),
     }))
     const teamBUsers = state.teamB.users.map(userId => ({
       userId,
-      nickname: state.userInfoMap.get(userId) ?? null,
+      nickname: getNicknameFromUserInfo(state.userInfoMap.get(userId)),
     }))
     const noneUsers = Array.from(state.participants.entries())
       .filter(([, team]) => team === 'NONE')
-      .map(([userId]) => ({ userId, nickname: state.userInfoMap.get(userId) ?? null }))
+      .map(([userId]) => ({ userId, nickname: getNicknameFromUserInfo(state.userInfoMap.get(userId)) }))
 
     const teamVoteCounts = { A: 0, B: 0, NONE: 0 }
     state.teamVotes.forEach(team => {

--- a/backend/src/battles/adapters/out/state/battleStateRepository.adapter.spec.ts
+++ b/backend/src/battles/adapters/out/state/battleStateRepository.adapter.spec.ts
@@ -118,6 +118,18 @@ describe('BattleStateRepositoryAdapter', () => {
       expect(result.state.userInfoMap.get('user-1')).toBe('테스터')
     })
 
+    it('tier가 포함된 userInfoMap을 파싱한다', async () => {
+      const mockBattle = createMockBattle({
+        userInfoState: [['user-1', { nickname: '테스터', tier: 'GOLD' }]],
+      })
+      ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(mockBattle)
+
+      const result = await adapter.loadBattleState('battle-1')
+
+      expect(adapter.getNicknameByUserId(result.state, 'user-1')).toBe('테스터')
+      expect(adapter.getTierByUserId(result.state, 'user-1')).toBe('GOLD')
+    })
+
     it('채팅 상태를 파싱한다', async () => {
       const mockBattle = createMockBattle({
         chatsAllState: [
@@ -184,13 +196,6 @@ describe('BattleStateRepositoryAdapter', () => {
       adapter.saveBattleState('battle-1', state)
 
       expect(redis.mset).toHaveBeenCalled()
-      expect(prisma.battle.update).toHaveBeenCalledWith({
-        where: { id: 'battle-1' },
-        data: expect.objectContaining({
-          currentRound: 2,
-          currentPhase: 'ATTACK',
-        }),
-      })
     })
   })
 
@@ -289,6 +294,28 @@ describe('BattleStateRepositoryAdapter', () => {
       } as Parameters<typeof adapter.getNicknameByUserId>[0]
 
       const result = adapter.getNicknameByUserId(state, 'nonexistent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getTierByUserId', () => {
+    it('userId로 티어를 찾는다', () => {
+      const state = {
+        userInfoMap: new Map([['user-1', { nickname: '테스터', tier: 'GOLD' }]]),
+      } as Parameters<typeof adapter.getTierByUserId>[0]
+
+      const result = adapter.getTierByUserId(state, 'user-1')
+
+      expect(result).toBe('GOLD')
+    })
+
+    it('문자열 userInfo이면 null을 반환한다', () => {
+      const state = {
+        userInfoMap: new Map([['user-1', '테스터']]),
+      } as Parameters<typeof adapter.getTierByUserId>[0]
+
+      const result = adapter.getTierByUserId(state, 'user-1')
 
       expect(result).toBeNull()
     })

--- a/backend/src/battles/adapters/out/state/battleStateRepository.adapter.spec.ts
+++ b/backend/src/battles/adapters/out/state/battleStateRepository.adapter.spec.ts
@@ -77,6 +77,47 @@ describe('BattleStateRepositoryAdapter', () => {
       expect(result.state.phase).toBe('PENDING')
     })
 
+    it('Redis에 상태가 있으면 DB를 조회하지 않는다', async () => {
+      const core = {
+        battleId: 'battle-1',
+        status: 'OPEN',
+        round: 2,
+        topics: ['topic1', 'topic2'],
+        totalRounds: 2,
+        phase: 'ATTACK',
+        phaseCount: 1,
+        startedAt: 1700000000000,
+        expiredAt: 1700000060000,
+        skipState: [],
+        participants: [['user-1', BATTLE_TEAM.A]],
+        teamVotes: [],
+        userInfoMap: [['user-1', '테스터']],
+        teamAUsers: ['user-1'],
+        teamBUsers: [],
+        allRoomId: 'battle:battle-1:room:all',
+        teamARoomId: 'battle:battle-1:room:A',
+        teamBRoomId: 'battle:battle-1:room:B',
+      }
+      const redisValues: Record<string, string> = {
+        'battle:core:battle-1': JSON.stringify(core),
+        'battle:attacks:battle-1': JSON.stringify({ all: [], opinionHistory: [] }),
+        'battle:defenses:battle-1': JSON.stringify({ all: [] }),
+        'battle:chats:all:battle-1': JSON.stringify([]),
+        'battle:chats:a:battle-1': JSON.stringify([]),
+        'battle:chats:b:battle-1': JSON.stringify([]),
+      }
+      ;(redis.get as jest.Mock).mockImplementation((key: string) => Promise.resolve(redisValues[key] ?? null))
+
+      const result = await adapter.loadBattleState('battle-1')
+
+      expect(prisma.battle.findUnique).not.toHaveBeenCalled()
+      expect(result.battle.status).toBe('OPEN')
+      expect(result.state.battleId).toBe('battle-1')
+      expect(result.state.round).toBe(2)
+      expect(result.state.phase).toBe('ATTACK')
+      expect(result.state.participants.get('user-1')).toBe(BATTLE_TEAM.A)
+    })
+
     it('배틀이 없으면 NotFoundException을 던진다', async () => {
       ;(prisma.battle.findUnique as jest.Mock).mockResolvedValue(null)
 

--- a/backend/src/battles/adapters/out/state/battleStateRepository.adapter.ts
+++ b/backend/src/battles/adapters/out/state/battleStateRepository.adapter.ts
@@ -5,6 +5,7 @@ import { PrismaService } from '../../../../prisma/prisma.service'
 import { RedisRepository } from '../../../../redis/redis.repository'
 import {
   ActiveBattleState,
+  BattleUserInfo,
   BattleTeam,
   BattleDiscussion,
   BattleDefense,
@@ -30,7 +31,7 @@ interface SerializedCore {
   skipState: string[]
   participants: [string, BattleTeam][]
   teamVotes: [string, BattleTeam][]
-  userInfoMap: [string, string][]
+  userInfoMap: [string, BattleUserInfo][]
   teamAUsers: string[]
   teamBUsers: string[]
   allRoomId: string
@@ -293,12 +294,16 @@ return {1, prev}
   }
 
   getNicknameByUserId(state: ActiveBattleState, userId: string): string | null {
-    return state.userInfoMap.get(userId) ?? null
+    return this.getNicknameFromUserInfo(state.userInfoMap.get(userId))
+  }
+
+  getTierByUserId(state: ActiveBattleState, userId: string): string | null {
+    return this.getTierFromUserInfo(state.userInfoMap.get(userId))
   }
 
   async isNicknameDuplicate(battleId: string, nickname: string): Promise<boolean> {
     const { state } = await this.loadBattleState(battleId)
-    return Array.from(state.userInfoMap.values()).includes(nickname)
+    return Array.from(state.userInfoMap.values()).some(info => this.getNicknameFromUserInfo(info) === nickname)
   }
 
   // ─── 비동기 flush 헬퍼 ──────────────────────────────────────────────────────
@@ -523,7 +528,7 @@ return {1, prev}
     return [...teamVotes.entries()]
   }
 
-  private serializeUserInfoState(userInfoMap: Map<string, string>): [string, string][] {
+  private serializeUserInfoState(userInfoMap: Map<string, BattleUserInfo>): [string, BattleUserInfo][] {
     return [...userInfoMap.entries()]
   }
 
@@ -542,7 +547,7 @@ return {1, prev}
   ): ActiveBattleState {
     const participants = new Map<string, BattleTeam>(core.participants ?? [])
     const teamVotes = new Map<string, BattleTeam>(core.teamVotes ?? [])
-    const userInfoMap = new Map<string, string>(core.userInfoMap ?? [])
+    const userInfoMap = new Map<string, BattleUserInfo>(core.userInfoMap ?? [])
 
     return {
       battleId: core.battleId,
@@ -586,7 +591,7 @@ return {1, prev}
     //참가자, 투표, 유저 정보 복원
     const participants = this.restoreMap<string, BattleTeam>(battle.participantsState)
     const teamVotes = this.restoreMap<string, BattleTeam>(battle.teamVotesState)
-    const userInfoMap = this.restoreMap<string, string>(battle.userInfoState)
+    const userInfoMap = this.restoreMap<string, BattleUserInfo>(battle.userInfoState)
 
     const attackStateRaw = this.normalizeTeamState(battle.attacksState)
     const defenseStateRaw = this.normalizeTeamState(battle.defensesState)
@@ -682,5 +687,15 @@ return {1, prev}
   // Redis에 배열 형태로 저장된 Map snapshot을 Map으로 복원
   private restoreMap<K, V>(value: unknown): Map<K, V> {
     return new Map((value as [K, V][]) ?? [])
+  }
+
+  private getNicknameFromUserInfo(info: BattleUserInfo | undefined): string | null {
+    if (!info) return null
+    return typeof info === 'string' ? info : info.nickname
+  }
+
+  private getTierFromUserInfo(info: BattleUserInfo | undefined): string | null {
+    if (!info || typeof info === 'string') return null
+    return info.tier ?? null
   }
 }

--- a/backend/src/battles/adapters/out/state/battleStateRepository.adapter.ts
+++ b/backend/src/battles/adapters/out/state/battleStateRepository.adapter.ts
@@ -120,6 +120,13 @@ export class BattleStateRepositoryAdapter implements BattleStatePort {
       return { battle: { id: battleId, status: live.status } as PrismaBattle, state: live }
     }
 
+    //캐시에서 상태 로드
+    const cached = await this.loadBattleStateFromRedis(battleId)
+    if (cached) {
+      this.liveStates.set(battleId, cached)
+      return { battle: { id: battleId, status: cached.status } as PrismaBattle, state: cached }
+    }
+
     const statusRow = await this.prisma.battle.findUnique({ where: { id: battleId }, select: { status: true } })
     if (!statusRow) throw new NotFoundException('배틀이 존재하지 않습니다.')
 
@@ -135,13 +142,6 @@ export class BattleStateRepositoryAdapter implements BattleStatePort {
         this.logger.error(`[loadBattleState] Redis 삭제 실패 ${battleId}: ${(err as Error).message}`),
       )
       return { battle, state }
-    }
-
-    //캐시에서 상태 로드
-    const cached = await this.loadBattleStateFromRedis(battleId)
-    if (cached) {
-      this.liveStates.set(battleId, cached)
-      return { battle: { id: battleId, status: cached.status } as PrismaBattle, state: cached }
     }
 
     //캐시에서 상태 로드 실패 시 데이터베이스에서 상태 로드

--- a/backend/src/battles/application/ports/out/battleState.port.ts
+++ b/backend/src/battles/application/ports/out/battleState.port.ts
@@ -15,6 +15,8 @@ export interface BattleStatePort {
   parseMvpsState(value: unknown): Mvp[]
   //사용자 ID로 닉네임 조회
   getNicknameByUserId(state: ActiveBattleState, userId: string): string | null
+  //사용자 ID로 티어 조회
+  getTierByUserId(state: ActiveBattleState, userId: string): string | null
   //닉네임 중복 체크
   isNicknameDuplicate(battleId: string, nickname: string): Promise<boolean>
   //discussion 메타데이터를 Redis HASH에 저장장.

--- a/backend/src/battles/application/usecases/battleInteraction.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/battleInteraction.usecase.spec.ts
@@ -98,6 +98,7 @@ describe('BattleInteractionUseCase', () => {
       const result = await useCase.submitDiscussion('battle-1', 'user-1', '의견 내용', BATTLE_TEAM.A, 'attack')
 
       expect(discussionService.applyAttack).toHaveBeenCalled()
+      expect(stateRepo.saveBattleState).toHaveBeenCalledWith('battle-1', mockState)
       expect(stateRepo.saveDiscussionToRedis).toHaveBeenCalled()
       expect(result.type).toBe('ATTACK')
     })
@@ -115,6 +116,7 @@ describe('BattleInteractionUseCase', () => {
       const result = await useCase.submitDiscussion('battle-1', 'user-1', '반론 내용', BATTLE_TEAM.A, 'defense')
 
       expect(discussionService.applyDefense).toHaveBeenCalled()
+      expect(stateRepo.saveBattleState).toHaveBeenCalledWith('battle-1', mockState)
       expect(stateRepo.saveDiscussionToRedis).toHaveBeenCalled()
       expect(result.type).toBe('DEFENSE')
     })
@@ -123,6 +125,7 @@ describe('BattleInteractionUseCase', () => {
   describe('submitVote', () => {
     it('공격에 투표한다', async () => {
       const mockState = createMockState()
+      mockState.opinionHistory = [{ ...mockState.teamA.attacks[0] }] as BattleDiscussion[]
       stateRepo.loadBattleState.mockResolvedValue({
         battle: {},
         state: mockState,
@@ -131,6 +134,9 @@ describe('BattleInteractionUseCase', () => {
       const result = await useCase.submitVote('battle-1', 'discussion-1', 'user-1', BATTLE_TEAM.A, 'attack')
 
       expect(stateRepo.castVoteInRedis).toHaveBeenCalledWith('battle-1', 'discussion-1', 'user-1')
+      expect(stateRepo.saveBattleState).toHaveBeenCalledWith('battle-1', mockState)
+      expect(mockState.opinionHistory[0].votes).toEqual(['user-1'])
+      expect(mockState.opinionHistory[0].upvotes).toBe(1)
       expect(result).toHaveLength(1)
       expect(result[0].discussionId).toBe('discussion-1')
     })
@@ -153,6 +159,7 @@ describe('BattleInteractionUseCase', () => {
       const result = await useCase.submitVote('battle-1', 'discussion-1', 'user-1', BATTLE_TEAM.A, 'defense')
 
       expect(stateRepo.castVoteInRedis).toHaveBeenCalledWith('battle-1', 'discussion-1', 'user-1')
+      expect(stateRepo.saveBattleState).toHaveBeenCalledWith('battle-1', mockState)
       expect(result).toHaveLength(1)
     })
 

--- a/backend/src/battles/application/usecases/battleInteraction.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/battleInteraction.usecase.spec.ts
@@ -47,6 +47,7 @@ describe('BattleInteractionUseCase', () => {
       loadBattleState: jest.fn(),
       saveBattleState: jest.fn(),
       getNicknameByUserId: jest.fn().mockReturnValue('테스터'),
+      getTierByUserId: jest.fn().mockReturnValue(null),
       saveDiscussionToRedis: jest.fn().mockResolvedValue(undefined),
       castVoteInRedis: jest.fn().mockResolvedValue({ added: true, prevDiscussionId: null }),
     } as unknown as jest.Mocked<BattleStatePort>
@@ -218,6 +219,48 @@ describe('BattleInteractionUseCase', () => {
       expect(stateRepo.saveBattleState).toHaveBeenCalled()
       expect(result.battleId).toBe('battle-1')
       expect(result.scope).toBe('all')
+    })
+
+    it('상태에 tier가 있으면 채팅 메시지에 포함한다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+      stateRepo.getTierByUserId.mockReturnValue('GOLD')
+
+      const dto = {
+        battleId: 'battle-1',
+        scope: 'all',
+        team: BATTLE_TEAM.A,
+        text: '안녕하세요',
+      } as unknown as BattleChatDto
+
+      await useCase.sendChat(dto, 'user-1')
+
+      expect(repo.findUniqueUser).not.toHaveBeenCalled()
+      expect(chatService.buildChatMessage).toHaveBeenCalledWith('new-id-123', 'user-1', '테스터', 'GOLD', BATTLE_TEAM.A, '안녕하세요')
+    })
+
+    it('상태에 tier가 없어도 사용자 tier 조회를 위해 DB를 호출하지 않는다', async () => {
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: {},
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+      stateRepo.getTierByUserId.mockReturnValue(null)
+
+      const dto = {
+        battleId: 'battle-1',
+        scope: 'all',
+        team: BATTLE_TEAM.A,
+        text: '안녕하세요',
+      } as unknown as BattleChatDto
+
+      await useCase.sendChat(dto, 'guest-1')
+
+      expect(repo.findUniqueUser).not.toHaveBeenCalled()
+      expect(chatService.buildChatMessage).toHaveBeenCalledWith('new-id-123', 'guest-1', '테스터', undefined, BATTLE_TEAM.A, '안녕하세요')
     })
 
     it('battleId가 없으면 BadRequestException을 던진다', async () => {

--- a/backend/src/battles/application/usecases/battleInteraction.usecase.ts
+++ b/backend/src/battles/application/usecases/battleInteraction.usecase.ts
@@ -136,9 +136,9 @@ export class BattleInteractionUseCase {
 
     const { state } = await this.stateRepo.loadBattleState(battleId)
     const nickname = this.stateRepo.getNicknameByUserId(state, userId) || ''
-    const userTier = await this.repo.findUniqueUser(userId, { tier: true })
+    const tier = this.stateRepo.getTierByUserId(state, userId) ?? undefined
 
-    const chat = this.chatService.buildChatMessage(this.identifierPort.generateId(), userId, nickname, userTier?.tier ?? undefined, team, text)
+    const chat = this.chatService.buildChatMessage(this.identifierPort.generateId(), userId, nickname, tier, team, text)
 
     this.chatService.applyChatMessage(state, chat, scope, team)
     this.stateRepo.saveBattleState(battleId, state)

--- a/backend/src/battles/application/usecases/battleInteraction.usecase.ts
+++ b/backend/src/battles/application/usecases/battleInteraction.usecase.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject, BadRequestException, ForbiddenException, Logger, NotFoundException } from '@nestjs/common'
 
 import { BATTLE_TEAM } from '../../domains/models/const/battles.const'
-import { BattleDiscussion, BattleTeam } from '../../domains/models/types/battle.types'
+import { ActiveBattleState, BattleDiscussion, BattleTeam } from '../../domains/models/types/battle.types'
 import { DiscussionVoteResponseDto } from '../../dto/discussionVoteResponse.dto'
 import type { BattleChatDto } from '../../dto/battleChat.dto'
 
@@ -53,6 +53,7 @@ export class BattleInteractionUseCase {
       )
     }
 
+    this.stateRepo.saveBattleState(battleId, state)
     void this.stateRepo
       .saveDiscussionToRedis(battleId, result, discussionType, team)
       .catch(err => this.logger.error(`[submitDiscussion] Redis write failed: ${(err as Error).message}`))
@@ -98,6 +99,7 @@ export class BattleInteractionUseCase {
     const target = discussions[targetIdx]
     target.votes = [...target.votes.filter(v => v !== userId), userId]
     target.upvotes = target.votes.length
+    this.replaceDiscussionInOpinionHistory(state, target)
 
     const updatedDiscussions: DiscussionVoteResponseDto[] = [DiscussionVoteResponseDto.of(battleId, target)]
 
@@ -105,13 +107,26 @@ export class BattleInteractionUseCase {
       const prevIdx = discussions.findIndex(d => d?.discussionId === prevDiscussionId)
       if (prevIdx >= 0 && discussions[prevIdx]) {
         const prev = discussions[prevIdx]
+
         prev.votes = prev.votes.filter(v => v !== userId)
         prev.upvotes = prev.votes.length
+        this.replaceDiscussionInOpinionHistory(state, prev)
+
         updatedDiscussions.push(DiscussionVoteResponseDto.of(battleId, prev))
       }
     }
 
+    this.stateRepo.saveBattleState(battleId, state)
     return updatedDiscussions
+  }
+
+  private replaceDiscussionInOpinionHistory(state: ActiveBattleState, discussion: BattleDiscussion): void {
+    if (!Array.isArray(state.opinionHistory)) return
+
+    const idx = state.opinionHistory.findIndex(item => item.discussionId === discussion.discussionId)
+    if (idx >= 0) {
+      state.opinionHistory[idx] = discussion
+    }
   }
 
   //채팅 전송

--- a/backend/src/battles/application/usecases/battleParticipation.usecase.spec.ts
+++ b/backend/src/battles/application/usecases/battleParticipation.usecase.spec.ts
@@ -94,6 +94,25 @@ describe('BattleParticipationUseCase', () => {
       expect(mockState.userInfoMap.get('user-1')).toBe('테스터')
     })
 
+    it('등록된 사용자의 tier를 userInfoMap에 함께 저장한다', async () => {
+      repo.findUniqueUser.mockResolvedValue({ id: 'user-1', tier: 'GOLD' })
+      const mockState = createMockState()
+      stateRepo.loadBattleState.mockResolvedValue({
+        battle: { status: BATTLE_STATUS.OPEN },
+        state: mockState,
+      } as unknown as Awaited<ReturnType<BattleStatePort['loadBattleState']>>)
+
+      const dto: BattleJoinRequestDto = {
+        battleId: 'battle-1',
+        team: BATTLE_TEAM.A,
+        nickname: '테스터',
+      } as unknown as BattleJoinRequestDto
+
+      await useCase.join(dto, 'user-1')
+
+      expect(mockState.userInfoMap.get('user-1')).toEqual({ nickname: '테스터', tier: 'GOLD' })
+    })
+
     it('battleId가 없으면 BadRequestException을 던진다', async () => {
       const dto: BattleJoinRequestDto = {
         battleId: '',

--- a/backend/src/battles/application/usecases/battleParticipation.usecase.ts
+++ b/backend/src/battles/application/usecases/battleParticipation.usecase.ts
@@ -34,8 +34,9 @@ export class BattleParticipationUseCase {
     if (state.status === BATTLE_STATUS.CLOSED) throw new BadRequestException('이미 종료된 배틀입니다.')
 
     const existingTeam = state.participants.get(userId)
+    const userExists = await this.repo.findUniqueUser(userId, { id: true, tier: true })
     if (!state.userInfoMap.has(userId)) {
-      state.userInfoMap.set(userId, nickname)
+      state.userInfoMap.set(userId, userExists?.tier ? { nickname, tier: userExists.tier } : nickname)
     }
 
     if (!existingTeam || existingTeam !== team) {
@@ -44,7 +45,6 @@ export class BattleParticipationUseCase {
       })
     }
 
-    const userExists = await this.repo.findUniqueUser(userId, { id: true })
     if (userExists) {
       await this.repo.upsertBattleParticipant({ userId, battleId, team: String(team), isMvp: false })
     }

--- a/backend/src/battles/domains/models/types/battle.types.ts
+++ b/backend/src/battles/domains/models/types/battle.types.ts
@@ -54,6 +54,7 @@ export interface BattleChat {
 export type ParticipantEntry = { userId: string; team: BattleTeam }
 export type TeamVoteEntry = { userId: string; team: BattleTeam }
 export type UserInfoEntry = { userId: string; nickname: string }
+export type BattleUserInfo = string | { nickname: string; tier?: string | null }
 export type BattleChatSnapshot = Omit<BattleChat, 'createdAt'> & { createdAt: string }
 
 export interface BattleDiscussion {
@@ -102,7 +103,7 @@ export interface ActiveBattleState {
   participants: Map<string, BattleTeam>
   teamVotes: Map<string, BattleTeam>
 
-  userInfoMap: Map<string, string>
+  userInfoMap: Map<string, BattleUserInfo>
 
   opinionHistory: BattleDiscussion[]
   skipState: Set<string>


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

## ✅ 작업 내용

작업 내용은 [노션](https://lovely-sunstone-c80.notion.site/Rate-Limiter-NestJS-356d7ffb4ba480d2a7c3fde11b50d972#3a9d7ffb4ba480589d97f998d01bedf2)에 계속해서 업데이트하고 있습니다. 자세한 테스트 과정과 내용은 노션을 참고해주세요 :)

### 💡개선 사항
<!-- 이 PR에서 변경된 주요 내용 개선 사항 -->

1. 채팅 과정 중 발생하는 DB 요청 제거
    - 채팅 저장 시, `flushToDB()` 메서드를 통해 DB Write 기능 제거
        - 배틀 진행 과정은 Redis에 저장하고 배틀 종료 후 결과를 DB에 저장하도록 수정
    - 채팅 전송마다 `findUniqueUser()` 메서드를 통해 유저 티어 조회 기능 제거
        -  배틀 접속 시, 사용자 정보 캐싱 과정에서 티어 정보도 함께 저장하여 메모리 내에서 관리하도록 수정
2. 배틀 진행 정보를 DB에서 먼저 조회
    - 기본 배틀 정보를 DB에서 먼저 조회 후 실패 시 Redis에서 조회하는 순서로 진행되고 있었음
        - Redis에서 배틀 진행 정보를 먼저 조회 후 실패 시 DB에서 조회하도록 변경
    - 배틀 진행 중 서버 재시작 시, 이의제기 & 반박 투표에 대한 집계가 실제 내용과 일치하지 않던 문제가 존재하였음
        - 투표 시, sync 작업을 진행하여 일관된 내용을 보존하도록 개선
<br />

## 📸 참고 사항
<!-- 코드 리뷰에서 참고할 사항, 새로 주의 깊게 봐야 하는 파일/코드, 주요 고민과 해결 과정-->

<br />

## 💬 질문사항 (고민했던 부분)
<!-- 리뷰어에게 묻고 싶은 것, 트레이드오프 등 -->
