### PR TITLE
[Devops] GCP dev 배포 파이프라인 안정화

### DIFF
--- a/.github/scripts/deploy-gcp-backend.sh
+++ b/.github/scripts/deploy-gcp-backend.sh
@@ -1,13 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+mode="deploy"
+case "${1:-}" in
+  "")
+    ;;
+  --preflight)
+    mode="preflight"
+    ;;
+  *)
+    echo "usage: $0 [--preflight]" >&2
+    exit 2
+    ;;
+esac
+
 required_variables=(
   GCP_PROJECT_ID
   GCP_REGION
   GCP_BACKEND_MIG
-  BACKEND_IMAGE
-  VERSION_TAG
 )
+
+if [[ "$mode" == "deploy" ]]; then
+  required_variables+=(
+    BACKEND_IMAGE
+    VERSION_TAG
+  )
+fi
 
 for name in "${required_variables[@]}"; do
   if [[ -z "${!name:-}" ]]; then
@@ -26,14 +44,16 @@ if [[ ! "$GCP_REGION" =~ ^[a-z0-9-]+$ ]]; then
   exit 1
 fi
 
-if [[ ! "$BACKEND_IMAGE" =~ ^[a-z0-9][a-z0-9._/-]*$ ]]; then
-  echo "BACKEND_IMAGE contains unsupported characters" >&2
-  exit 1
-fi
+if [[ "$mode" == "deploy" ]]; then
+  if [[ ! "$BACKEND_IMAGE" =~ ^[a-z0-9][a-z0-9._/-]*$ ]]; then
+    echo "BACKEND_IMAGE contains unsupported characters" >&2
+    exit 1
+  fi
 
-if [[ ! "$VERSION_TAG" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
-  echo "VERSION_TAG must be a valid container image tag" >&2
-  exit 1
+  if [[ ! "$VERSION_TAG" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+    echo "VERSION_TAG must be a valid container image tag" >&2
+    exit 1
+  fi
 fi
 
 GCP_DEPLOY_PATH="${GCP_DEPLOY_PATH:-/opt/cmc}"
@@ -71,22 +91,137 @@ if [[ -z "${instance:-}" || -z "${zone:-}" || "$instance_status" != "RUNNING" ||
   exit 1
 fi
 
-echo "deploying $BACKEND_IMAGE:$VERSION_TAG to $instance ($zone)"
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to inspect effective OS Login metadata" >&2
+  exit 1
+fi
+
+instance_metadata="$(
+  gcloud compute instances describe "$instance" \
+    --project "$GCP_PROJECT_ID" \
+    --zone "$zone" \
+    --format='json(metadata.items)'
+)"
+instance_oslogin="$(
+  jq -r '[.metadata.items[]? | select(.key == "enable-oslogin") | .value][0] // empty' \
+    <<< "$instance_metadata"
+)"
+
+if [[ -n "$instance_oslogin" ]]; then
+  effective_oslogin="$instance_oslogin"
+  oslogin_source="instance metadata"
+else
+  project_metadata="$(
+    gcloud compute project-info describe \
+      --project "$GCP_PROJECT_ID" \
+      --format='json(commonInstanceMetadata.items)'
+  )"
+  effective_oslogin="$(
+    jq -r '[.commonInstanceMetadata.items[]? | select(.key == "enable-oslogin") | .value][0] // empty' \
+      <<< "$project_metadata"
+  )"
+  oslogin_source="project metadata"
+fi
+
+if [[ ! "$effective_oslogin" =~ ^[Tt][Rr][Uu][Ee]$ ]]; then
+  echo "OS Login is not enabled for $instance; effective value from $oslogin_source is '${effective_oslogin:-unset}'" >&2
+  echo "set enable-oslogin=TRUE on the current instance before rerunning deployment" >&2
+  exit 1
+fi
+
+echo "backend preflight passed: instance=$instance zone=$zone oslogin=$oslogin_source"
+
+required_runtime_variables=(
+  GF_SECURITY_ADMIN_PASSWORD
+  NODE_ENV
+  FRONTEND_URL
+  DATABASE_URL
+  REDIS_HOST
+  REDIS_PORT
+  JWT_ACCESS_SECRET
+  JWT_REFRESH_SECRET
+  JWT_ACCESS_EXPIRES_IN
+  JWT_REFRESH_EXPIRES_IN
+  GEMINI_API_KEYS
+  GITHUB_CLIENT_ID
+  GITHUB_CLIENT_SECRET
+  GITHUB_CALLBACK_URL
+  KAKAO_CLIENT_ID
+  KAKAO_CLIENT_SECRET
+  KAKAO_CALLBACK_URL
+)
+printf -v required_runtime_variables_q '%q ' "${required_runtime_variables[@]}"
 
 gcloud compute ssh "$instance" \
   --project "$GCP_PROJECT_ID" \
   --zone "$zone" \
   --tunnel-through-iap \
   --quiet \
-  --command="sudo install -d -o \"\$(id -un)\" -g \"\$(id -gn)\" '$GCP_DEPLOY_PATH'"
+  --command="set -euo pipefail
+env_file='$GCP_DEPLOY_PATH/.env'
+sudo test -f \"\$env_file\"
+for name in $required_runtime_variables_q; do
+  if ! sudo grep -Eq \"^\${name}=.+\" \"\$env_file\"; then
+    echo \"missing or empty runtime variable in \$env_file: \$name\" >&2
+    exit 1
+  fi
+done"
+echo "backend SSH preflight passed: required runtime variables exist in $GCP_DEPLOY_PATH/.env"
+
+if [[ "$mode" == "preflight" ]]; then
+  exit 0
+fi
+
+echo "deploying $BACKEND_IMAGE:$VERSION_TAG to $instance ($zone)"
+
+remote_stage_path="/tmp/cmc-deploy-${VERSION_TAG}"
+printf -v deploy_path_q '%q' "$GCP_DEPLOY_PATH"
+printf -v remote_stage_path_q '%q' "$remote_stage_path"
+printf -v backend_image_q '%q' "$BACKEND_IMAGE"
+printf -v version_tag_q '%q' "$VERSION_TAG"
+
+gcloud compute ssh "$instance" \
+  --project "$GCP_PROJECT_ID" \
+  --zone "$zone" \
+  --tunnel-through-iap \
+  --quiet \
+  --command="set -euo pipefail
+remote_stage_path=$remote_stage_path_q
+rm -rf \"\$remote_stage_path\"
+install -d -m 0700 \"\$remote_stage_path\""
 
 gcloud compute scp --recurse \
   docker-compose-prod.yml nginx monitoring \
-  "$instance:$GCP_DEPLOY_PATH/" \
+  "$instance:$remote_stage_path/" \
   --project "$GCP_PROJECT_ID" \
   --zone "$zone" \
   --tunnel-through-iap \
   --quiet
+
+gcloud compute ssh "$instance" \
+  --project "$GCP_PROJECT_ID" \
+  --zone "$zone" \
+  --tunnel-through-iap \
+  --quiet \
+  --command="set -euo pipefail
+deploy_path=$deploy_path_q
+remote_stage_path=$remote_stage_path_q
+
+sudo install -d -o \"\$(id -un)\" -g \"\$(id -gn)\" \"\$deploy_path\"
+sudo install \
+  -o \"\$(id -un)\" \
+  -g \"\$(id -gn)\" \
+  -m 0644 \
+  \"\$remote_stage_path/docker-compose-prod.yml\" \
+  \"\$deploy_path/docker-compose-prod.yml\"
+
+for directory in nginx monitoring; do
+  sudo install -d \"\$deploy_path/\$directory\"
+  sudo cp -a \"\$remote_stage_path/\$directory/.\" \"\$deploy_path/\$directory/\"
+  sudo chown -R \"\$(id -un):\$(id -gn)\" \"\$deploy_path/\$directory\"
+done
+
+rm -rf \"\$remote_stage_path\""
 
 gcloud auth print-access-token \
   | gcloud compute ssh "$instance" \
@@ -95,10 +230,6 @@ gcloud auth print-access-token \
       --tunnel-through-iap \
       --quiet \
       --command="sudo docker login -u oauth2accesstoken --password-stdin 'https://${GCP_REGION}-docker.pkg.dev'"
-
-printf -v deploy_path_q '%q' "$GCP_DEPLOY_PATH"
-printf -v backend_image_q '%q' "$BACKEND_IMAGE"
-printf -v version_tag_q '%q' "$VERSION_TAG"
 
 gcloud compute ssh "$instance" \
   --project "$GCP_PROJECT_ID" \

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -47,6 +47,9 @@ jobs:
         with:
           project_id: ${{ vars.GCP_PROJECT_ID }}
 
+      - name: Preflight backend instance
+        run: bash .github/scripts/deploy-gcp-backend.sh --preflight
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Configure Artifact Registry authentication

--- a/docs/gcp-dev-deployment-runbook.md
+++ b/docs/gcp-dev-deployment-runbook.md
@@ -883,6 +883,34 @@ health endpoint가 배포되기 전에 auto-healing을 연결하면 `/livez` 404
 8. dev VM recreate drill 후 `.env`, Redis session/AOF, OAuth, battle timer를 확인한다.
 9. 같은 snapshot/2단계 apply/recreate 검증을 prod에 반복한다.
 
+기존 VM은 `OPPORTUNISTIC` MIG 정책 때문에 새 instance template metadata를 자동으로 받지 않는다. 현재 instance에만 OS Login을 활성화하고, project 전체 metadata는 변경하지 않는다.
+
+```bash
+INSTANCE=$(gcloud compute instance-groups managed list-instances cmc-dev-backend \
+  --project cmctv-500213 \
+  --region asia-northeast3 \
+  --format='value(name)')
+
+ZONE=$(gcloud compute instance-groups managed list-instances cmc-dev-backend \
+  --project cmctv-500213 \
+  --region asia-northeast3 \
+  --format='value(instance.scope().segment(0))')
+
+gcloud compute instances add-metadata "$INSTANCE" \
+  --project cmctv-500213 \
+  --zone "$ZONE" \
+  --metadata=enable-oslogin=TRUE
+
+GCP_PROJECT_ID=cmctv-500213 \
+GCP_REGION=asia-northeast3 \
+GCP_BACKEND_MIG=cmc-dev-backend \
+bash .github/scripts/deploy-gcp-backend.sh --preflight
+```
+
+preflight는 image build/push 전에 실행되며 instance metadata가 project metadata보다 우선한다. instance에 `enable-oslogin=FALSE`가 명시돼 있으면 project 값이 `TRUE`여도 실패한다. effective OS Login 확인 후에는 IAP SSH로 `$GCP_DEPLOY_PATH/.env`와 필수 runtime key의 비어 있지 않은 설정을 검사하되 값은 출력하지 않는다. 이 경우 deployer에 `compute.instances.setMetadata`를 추가하지 말고 현재 instance metadata를 복구한다.
+
+OS Login service account의 POSIX 사용자는 기존 배포 사용자의 파일을 직접 덮어쓸 수 없다. 배포 script는 Compose/Nginx/monitoring을 `/tmp/cmc-deploy-<tag>`에 먼저 업로드한 뒤 `sudo`로 `$GCP_DEPLOY_PATH`에 승격한다. 이 과정은 기존 `.env`와 마지막 성공 배포의 `release.env`를 보존한다.
+
 상태 확인:
 
 ```bash

--- a/docs/gcp-platform.md
+++ b/docs/gcp-platform.md
@@ -104,14 +104,15 @@ flowchart TD
 ### Backend
 
 1. GitHub Actions authenticates with Workload Identity Federation.
-2. The workflow builds `linux/amd64` images.
-3. Images are pushed to Artifact Registry with an immutable version tag.
-4. The workflow resolves exactly one running instance from the configured MIG name.
-5. Compose, Nginx, and monitoring configuration are copied through IAP.
-6. The VM authenticates to Artifact Registry with a short-lived access token.
-7. Prisma migration runs as a separate Compose tool service.
-8. `docker compose up -d --remove-orphans` activates the new version.
-9. Nginx config, `/livez`, and `/healthz` must pass before `release.env` is updated.
+2. Before image build/push, the dev workflow resolves exactly one stable instance from the configured MIG, verifies effective OS Login, opens an IAP SSH session, and confirms that required runtime `.env` keys have non-empty values without printing them.
+3. The workflow builds `linux/amd64` images.
+4. Images are pushed to Artifact Registry with an immutable version tag.
+5. The deploy script repeats the MIG stability and effective OS Login checks immediately before SSH.
+6. Compose, Nginx, and monitoring configuration are copied through IAP to an OS Login user-owned staging directory, then promoted with `sudo` without replacing `.env`.
+7. The VM authenticates to Artifact Registry with a short-lived access token.
+8. Prisma migration runs as a separate Compose tool service.
+9. `docker compose up -d --remove-orphans` activates the new version.
+10. Nginx config, `/livez`, and `/healthz` must pass before `release.env` is updated.
 
 ### Frontend
 
@@ -148,7 +149,7 @@ Configure this build-time value as a repository-level Actions secret. An Environ
 
 Pull request CI does not authenticate to or push into a container registry. Its frontend image check uses repository variables `VITE_API_URL`, `VITE_SOCKET_URL`, and `VITE_ENABLE_SENTRY` with the dev public origins, plus the repository `VITE_SENTRY_DSN` secret. GCP deployment jobs use the environment-scoped values above.
 
-Terraform creates one repository-, environment-, and ref-restricted Workload Identity Provider and deployer service account per environment. The deployer uses Artifact Registry writer and frontend bucket object admin at resource scope, plus Compute read/OS Login, IAP tunnel, service usage, and target backend service-account-user permissions. Service account JSON keys are forbidden.
+Terraform creates one repository-, environment-, and ref-restricted Workload Identity Provider and deployer service account per environment. The deployer uses Artifact Registry writer plus frontend bucket object admin and bucket metadata reader at resource scope, as well as Compute read/OS Login, IAP tunnel, service usage, and target backend service-account-user permissions. Service account JSON keys are forbidden.
 
 GitHub deployment branch policies allow only `dev` for the dev Environment and `release` for prod. The repository ruleset requires pull requests for `release`, and the tag ruleset prevents moving or deleting existing `v*` release tags.
 

--- a/terraform/modules/gcp_frontend_storage/main.tf
+++ b/terraform/modules/gcp_frontend_storage/main.tf
@@ -40,3 +40,11 @@ resource "google_storage_bucket_iam_member" "upload" {
   role   = "roles/storage.objectAdmin"
   member = each.value
 }
+
+resource "google_storage_bucket_iam_member" "upload_bucket_reader" {
+  for_each = toset(var.upload_members)
+
+  bucket = google_storage_bucket.this.name
+  role   = "roles/storage.legacyBucketReader"
+  member = each.value
+}

--- a/terraform/modules/gcp_frontend_storage/variables.tf
+++ b/terraform/modules/gcp_frontend_storage/variables.tf
@@ -44,7 +44,7 @@ variable "public_read" {
 }
 
 variable "upload_members" {
-  description = "IAM members allowed to upload and replace frontend objects."
+  description = "IAM members allowed to inspect the bucket and upload, replace, or delete frontend objects."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 예: Closes #123, Relates to #456 -->

Relates to #455
Follow-up to #463

## ✅ 작업 내용

### 💡개선 사항

- GCP dev backend 배포 전에 fail-fast preflight를 실행하도록 변경했습니다.
  - configured MIG에서 정확히 1개의 `RUNNING/NONE` instance만 허용
  - instance metadata를 우선해 effective OS Login 확인
  - IAP SSH로 `/opt/cmc/.env`의 필수 runtime key 존재 여부를 값 노출 없이 확인
  - image build/push 전에 실패시켜 불필요한 Artifact Registry 업로드 방지
- OS Login service account의 POSIX 사용자와 기존 배포 파일 소유권이 달라도 배포할 수 있도록 변경했습니다.
  - Compose/Nginx/monitoring 설정을 `/tmp/cmc-deploy-<tag>`에 먼저 업로드
  - `sudo`로 `/opt/cmc`에 승격
  - 기존 `.env`와 마지막 성공 배포의 `release.env` 보존
- frontend 배포 권한을 보완했습니다.
  - `roles/storage.objectAdmin`에 없는 `storage.buckets.get` 권한을 bucket scope의 `roles/storage.legacyBucketReader`로 추가
  - `gcloud storage rsync`가 bucket metadata 조회 단계에서 실패하던 문제 해결
- OS Login 복구, preflight, stateful MIG 2단계 적용 절차를 GCP platform 문서와 dev runbook에 반영했습니다.

<br />

## 📸 참고 사항

- UI 변경사항은 없습니다.
- 기존 GCP 마이그레이션 PR 이후 dev 배포에서 확인된 원인은 다음과 같습니다.
  1. `OPPORTUNISTIC` MIG의 기존 VM에는 새 instance template의 OS Login metadata가 자동 적용되지 않았습니다.
  2. OS Login service account가 이전 배포 사용자가 소유한 Nginx/monitoring 경로를 직접 덮어쓸 수 없었습니다.
  3. dev runtime `.env`에 `GF_SECURITY_ADMIN_PASSWORD`가 없어 Compose 검증이 실패했습니다.
  4. frontend deployer의 object admin 권한만으로는 `gcloud storage rsync`가 요구하는 bucket metadata를 조회할 수 없었습니다.
- 실제 dev 환경 복구 및 검증 결과:
  - GitHub Actions run `30249544162` backend/frontend 성공
  - backend immutable image tag와 container `healthy` 확인
  - frontend 신규 fingerprint asset 및 cache metadata 확인
  - `/healthz`, `/livez`, Socket.IO handshake, 실제 화면/API 응답 확인
  - dev auto-healing plan `0 add / 1 change / 0 destroy` 확인 후 적용
- 로컬 검증:
  - `bash -n .github/scripts/deploy-gcp-backend.sh`
  - deploy script 인자 검증
  - `terraform fmt -check -recursive terraform`
  - dev Terraform bucket IAM plan/apply 성공
  - workflow YAML parse
  - `bash .codex/scripts/check-harness.sh`
  - `git diff --check`
- 공유 배포 script와 frontend storage module을 수정하므로 prod도 다음 Terraform/deploy 시 같은 사전점검과 bucket metadata reader 권한을 사용합니다. prod 외부 환경에는 아직 적용하지 않았습니다.
- merge 후 dev 자동 배포에서 새 staging 경로까지 end-to-end로 확인하고, stateful boot disk 보존을 검증하는 VM recreate drill을 진행해야 합니다.

<br />

## 💬 질문사항 (고민했던 부분)

- `roles/storage.objectAdmin`에 bucket metadata 조회 권한이 없어, custom role 대신 bucket 범위의 `roles/storage.legacyBucketReader`를 최소 추가 권한으로 사용했습니다. 이 권한 구성을 중점적으로 확인 부탁드립니다.
